### PR TITLE
Add CI check for updating translations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,7 @@ jobs:
       - run: npm install --prefix assets
       - run: npm --prefix assets run webpack:build
       - run: mix compile --all-warnings
+      - run: mix gettext.extract --check-up-to-date --verbose
 
   elixir_unit:
     name: Unit tests / Elixir / mix coveralls.html

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule DotCom.Mixfile do
         flags: [:unmatched_returns]
       ],
       deps: deps(),
+      gettext: [write_reference_line_numbers: false],
       listeners: [Phoenix.CodeReloader],
       # docs
       name: "MBTA Website",

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -62,7 +62,7 @@ msgstr ""
 msgid " at "
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr ""
@@ -128,7 +128,7 @@ msgstr ""
 msgid " on track "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr ""
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr ""
@@ -350,8 +351,8 @@ msgstr ""
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr ""
@@ -362,12 +363,12 @@ msgstr ""
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr ""
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr ""
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr ""
@@ -447,7 +448,7 @@ msgstr ""
 msgid "Admins Only"
 msgstr ""
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr ""
@@ -531,7 +532,7 @@ msgstr ""
 msgid "All Updates"
 msgstr ""
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr ""
@@ -945,7 +946,7 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr ""
@@ -961,7 +962,7 @@ msgid "Charlie Service Center"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr ""
@@ -978,8 +979,8 @@ msgstr ""
 msgid "CharlieCards & Tickets"
 msgstr ""
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr ""
@@ -994,12 +995,12 @@ msgstr ""
 msgid "Check-In at South Station"
 msgstr ""
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr ""
@@ -1055,7 +1056,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr ""
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Commuter Rail"
 msgstr ""
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr ""
@@ -1190,7 +1191,7 @@ msgstr ""
 msgid "Credit/debit cards"
 msgstr ""
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr ""
@@ -1261,7 +1262,7 @@ msgstr ""
 msgid "Date and Time"
 msgstr ""
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr ""
@@ -1402,7 +1403,7 @@ msgstr ""
 msgid "Early Departure Stop"
 msgstr ""
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr ""
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Explore stations by mode"
 msgstr ""
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr ""
@@ -1674,7 +1675,7 @@ msgstr ""
 msgid "Facility Issue"
 msgstr ""
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr ""
@@ -1772,7 +1773,7 @@ msgstr ""
 msgid "Ferry"
 msgstr ""
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr ""
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr ""
@@ -1938,7 +1939,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr ""
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr ""
@@ -1958,7 +1959,7 @@ msgstr ""
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr ""
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr ""
@@ -2039,7 +2040,7 @@ msgstr ""
 msgid "Group Name"
 msgstr ""
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr ""
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Hide Details"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr ""
@@ -2166,17 +2167,17 @@ msgstr ""
 msgid "Intended Audience"
 msgstr ""
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr ""
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr ""
@@ -2414,7 +2415,7 @@ msgstr ""
 msgid "Lobby inside Back Bay station"
 msgstr ""
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr ""
@@ -2442,7 +2443,7 @@ msgstr ""
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr ""
@@ -2463,7 +2464,7 @@ msgstr ""
 msgid "Lost and Found"
 msgstr ""
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr ""
@@ -2681,8 +2682,8 @@ msgstr ""
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr ""
@@ -2782,7 +2783,7 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr ""
@@ -2845,23 +2846,23 @@ msgstr ""
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr ""
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr ""
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr ""
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr ""
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Notice"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3107,12 +3108,12 @@ msgstr ""
 msgid "Onboard ramps at the front door of each bus"
 msgstr ""
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr ""
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr ""
@@ -3466,12 +3467,12 @@ msgstr ""
 msgid "Prefer accessible routes"
 msgstr ""
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr ""
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr ""
@@ -3677,7 +3678,7 @@ msgstr ""
 msgid "Right"
 msgstr ""
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr ""
@@ -3915,7 +3916,7 @@ msgstr ""
 msgid "Send Us Feedback"
 msgstr ""
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr ""
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Senior ID Cards"
 msgstr ""
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr ""
@@ -4025,8 +4026,8 @@ msgid "Showing major stops."
 msgstr ""
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr ""
@@ -4163,7 +4164,7 @@ msgstr ""
 msgid "Southbound"
 msgstr ""
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr ""
@@ -4198,13 +4199,13 @@ msgstr ""
 msgid "Station Issue"
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4266,12 +4267,12 @@ msgstr ""
 msgid "Stops Skipped"
 msgstr ""
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr ""
@@ -4294,7 +4295,7 @@ msgstr ""
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr ""
@@ -5119,8 +5120,8 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr ""
@@ -5145,11 +5146,6 @@ msgstr ""
 #: lib/dotcom_web/components/trip_planner/input_form.ex:69
 #, elixir-autogen, elixir-format
 msgid "When"
-msgstr ""
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
 msgstr ""
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
@@ -5229,12 +5225,12 @@ msgid "Zone"
 msgstr ""
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr ""
@@ -5299,7 +5295,7 @@ msgstr ""
 msgid "bus stop"
 msgstr ""
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr ""
@@ -5314,7 +5310,7 @@ msgstr ""
 msgid "changes"
 msgstr ""
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr ""
@@ -5386,7 +5382,7 @@ msgid "location"
 msgstr ""
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr ""
@@ -5426,7 +5422,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr ""
@@ -5446,7 +5442,7 @@ msgstr ""
 msgid "outbound"
 msgstr ""
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr ""
@@ -5636,8 +5632,8 @@ msgstr ""
 msgid "west"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5646,4 +5642,14 @@ msgstr ""
 #: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "with your request."
+msgstr ""
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -11,5645 +11,5523 @@
 msgid ""
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr ""
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr ""
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr ""
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr ""
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr ""
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr ""
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr ""
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr ""
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr ""
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr ""
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr ""
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr ""
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr ""
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr ""
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr ""
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr ""
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr ""
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr ""
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr ""
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr ""
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr ""
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr ""
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr ""
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr ""
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr ""
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr ""
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr ""
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr ""
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr ""
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr ""
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr ""
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr ""
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr ""
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr ""
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr ""
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr ""
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr ""
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr ""
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr ""
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr ""
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr ""
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr ""
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr ""
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr ""
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr ""
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr ""
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr ""
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr ""
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr ""
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr ""
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr ""
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr ""
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr ""
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr ""
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr ""
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr ""
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr ""
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr ""
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr ""
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr ""
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr ""
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr ""
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr ""
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr ""
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr ""
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr ""
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr ""
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr ""
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr ""
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr ""
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr ""
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr ""
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr ""
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr ""
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr ""
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr ""
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr ""
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr ""
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr ""
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr ""
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr ""
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr ""
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr ""
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr ""
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr ""
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr ""
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr ""
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr ""
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr ""
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr ""
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr ""
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr ""
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr ""
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr ""
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr ""
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr ""
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr ""
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr ""
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr ""
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr ""
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr ""
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr ""
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr ""
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr ""
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr ""
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr ""
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr ""
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr ""
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr ""
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr ""
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr ""
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr ""
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr ""
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr ""
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr ""
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr ""
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr ""
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr ""
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr ""
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr ""
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr ""
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr ""
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr ""
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr ""
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr ""
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr ""
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr ""
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr ""
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr ""
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr ""
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr ""
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr ""
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr ""
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr ""
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr ""
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr ""
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr ""
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr ""
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr ""
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr ""
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr ""
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr ""
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr ""
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr ""
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr ""
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr ""
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr ""
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr ""
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr ""
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr ""
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr ""
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr ""
 msgid " at "
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr ""
@@ -128,7 +128,7 @@ msgstr ""
 msgid " on track "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr ""
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr ""
@@ -350,8 +351,8 @@ msgstr ""
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr ""
@@ -362,12 +363,12 @@ msgstr ""
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr ""
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr ""
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr ""
@@ -447,7 +448,7 @@ msgstr ""
 msgid "Admins Only"
 msgstr ""
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr ""
@@ -531,7 +532,7 @@ msgstr ""
 msgid "All Updates"
 msgstr ""
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr ""
@@ -945,7 +946,7 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr ""
@@ -961,7 +962,7 @@ msgid "Charlie Service Center"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr ""
@@ -978,8 +979,8 @@ msgstr ""
 msgid "CharlieCards & Tickets"
 msgstr ""
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr ""
@@ -994,12 +995,12 @@ msgstr ""
 msgid "Check-In at South Station"
 msgstr ""
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr ""
@@ -1055,7 +1056,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr ""
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Commuter Rail"
 msgstr ""
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr ""
@@ -1190,7 +1191,7 @@ msgstr ""
 msgid "Credit/debit cards"
 msgstr ""
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr ""
@@ -1261,7 +1262,7 @@ msgstr ""
 msgid "Date and Time"
 msgstr ""
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr ""
@@ -1402,7 +1403,7 @@ msgstr ""
 msgid "Early Departure Stop"
 msgstr ""
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr ""
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Explore stations by mode"
 msgstr ""
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr ""
@@ -1674,7 +1675,7 @@ msgstr ""
 msgid "Facility Issue"
 msgstr ""
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr ""
@@ -1772,7 +1773,7 @@ msgstr ""
 msgid "Ferry"
 msgstr ""
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr ""
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr ""
@@ -1938,7 +1939,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr ""
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr ""
@@ -1958,7 +1959,7 @@ msgstr ""
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr ""
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr ""
@@ -2039,7 +2040,7 @@ msgstr ""
 msgid "Group Name"
 msgstr ""
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr ""
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Hide Details"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr ""
@@ -2166,17 +2167,17 @@ msgstr ""
 msgid "Intended Audience"
 msgstr ""
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr ""
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr ""
@@ -2414,7 +2415,7 @@ msgstr ""
 msgid "Lobby inside Back Bay station"
 msgstr ""
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr ""
@@ -2442,7 +2443,7 @@ msgstr ""
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr ""
@@ -2463,7 +2464,7 @@ msgstr ""
 msgid "Lost and Found"
 msgstr ""
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr ""
@@ -2681,8 +2682,8 @@ msgstr ""
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr ""
@@ -2782,7 +2783,7 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr ""
@@ -2845,23 +2846,23 @@ msgstr ""
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr ""
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr ""
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr ""
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr ""
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Notice"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3107,12 +3108,12 @@ msgstr ""
 msgid "Onboard ramps at the front door of each bus"
 msgstr ""
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr ""
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr ""
@@ -3466,12 +3467,12 @@ msgstr ""
 msgid "Prefer accessible routes"
 msgstr ""
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr ""
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr ""
@@ -3677,7 +3678,7 @@ msgstr ""
 msgid "Right"
 msgstr ""
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr ""
@@ -3915,7 +3916,7 @@ msgstr ""
 msgid "Send Us Feedback"
 msgstr ""
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr ""
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Senior ID Cards"
 msgstr ""
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr ""
@@ -4025,8 +4026,8 @@ msgid "Showing major stops."
 msgstr ""
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr ""
@@ -4163,7 +4164,7 @@ msgstr ""
 msgid "Southbound"
 msgstr ""
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr ""
@@ -4198,13 +4199,13 @@ msgstr ""
 msgid "Station Issue"
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4266,12 +4267,12 @@ msgstr ""
 msgid "Stops Skipped"
 msgstr ""
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr ""
@@ -4294,7 +4295,7 @@ msgstr ""
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr ""
@@ -5119,8 +5120,8 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr ""
@@ -5145,11 +5146,6 @@ msgstr ""
 #: lib/dotcom_web/components/trip_planner/input_form.ex:69
 #, elixir-autogen, elixir-format
 msgid "When"
-msgstr ""
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
 msgstr ""
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
@@ -5229,12 +5225,12 @@ msgid "Zone"
 msgstr ""
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr ""
@@ -5299,7 +5295,7 @@ msgstr ""
 msgid "bus stop"
 msgstr ""
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr ""
@@ -5314,7 +5310,7 @@ msgstr ""
 msgid "changes"
 msgstr ""
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr ""
@@ -5386,7 +5382,7 @@ msgid "location"
 msgstr ""
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr ""
@@ -5426,7 +5422,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr ""
@@ -5446,7 +5442,7 @@ msgstr ""
 msgid "outbound"
 msgstr ""
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr ""
@@ -5636,8 +5632,8 @@ msgstr ""
 msgid "west"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5646,4 +5642,14 @@ msgstr ""
 #: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "with your request."
+msgstr ""
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -11,5645 +11,5523 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr ""
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr ""
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr ""
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr ""
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr ""
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr ""
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr ""
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr ""
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr ""
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr ""
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr ""
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr ""
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr ""
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr ""
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr ""
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr ""
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr ""
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr ""
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr ""
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr ""
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr ""
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr ""
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr ""
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr ""
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr ""
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr ""
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr ""
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr ""
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr ""
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr ""
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr ""
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr ""
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr ""
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr ""
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr ""
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr ""
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr ""
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr ""
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr ""
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr ""
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr ""
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr ""
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr ""
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr ""
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr ""
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr ""
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr ""
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr ""
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr ""
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr ""
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr ""
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr ""
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr ""
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr ""
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr ""
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr ""
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr ""
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr ""
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr ""
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr ""
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr ""
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr ""
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr ""
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr ""
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr ""
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr ""
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr ""
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr ""
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr ""
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr ""
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr ""
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr ""
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr ""
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr ""
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr ""
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr ""
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr ""
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr ""
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr ""
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr ""
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr ""
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr ""
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr ""
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr ""
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr ""
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr ""
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr ""
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr ""
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr ""
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr ""
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr ""
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr ""
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr ""
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr ""
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr ""
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr ""
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr ""
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr ""
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr ""
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr ""
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr ""
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr ""
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr ""
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr ""
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr ""
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr ""
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr ""
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr ""
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr ""
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr ""
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr ""
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr ""
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr ""
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr ""
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr ""
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr ""
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr ""
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr ""
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr ""
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr ""
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr ""
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr ""
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr ""
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr ""
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr ""
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr ""
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr ""
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr ""
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr ""
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr ""
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr ""
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr ""
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr ""
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr ""
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr ""
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr ""
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr ""
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr ""
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr ""
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr ""
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr ""
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr ""
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr ""
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr ""
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr ""
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr ""
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr ""
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr ""
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr ""
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr ""
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr ""
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr ""
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr ""
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr ""
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr ""
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr ""
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr ""
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr ""
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr ""
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr ""
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr ""
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr ""
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr ""
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr ""
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr ""
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr ""
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr ""
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr ""
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr ""
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr ""
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr ""
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr ""
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr ""
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr ""
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr ""
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr ""
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr ""
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr ""
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr ""
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr ""
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr ""
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr ""
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr ""
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr ""
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr ""
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr ""
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr ""
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr ""
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr ""
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr ""
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr ""
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr ""
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr ""
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr ""
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr ""
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr ""
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr ""
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr ""
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr ""
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr ""
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr ""
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr ""
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr ""
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr ""
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr ""
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -11,5667 +11,5545 @@ msgstr ""
 "Language: es_LA\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " & Stops"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " Hay servicio adicional entre Boston, Hingham y Hull disponible a través de la %{link}"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " Circula por atajada limitadas entre Foxboro y Providence o Downtown Boston (South Station)"
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " Líneas"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " Rutas"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " El servicio continúa más tarde en dirección contraria. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " El servicio está disponible más temprano en la dirección contraria. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Los trenes salen de Foxboro 30 minutos luego de la conclusión de los eventos"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " alerta"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " en "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " en %{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " En este momento."
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " Dependen de la distancia recorrida (zonas). Consulte la información a continuación:"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " para cambios de seguimiento en tiempo real."
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " para la "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " llegó a "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " está llegando a "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " está de camino a "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " Puede salir antes de horario en estas atajada."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " Un minuto andando"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " en "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " en el "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " En pista "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " o "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " horario"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " Horario y mapa"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " símbolo. Comprobado "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " que desean marchar. El pasajero esperando para abordar debe ser visible en el Andén para el "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " parar."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "\"A distancia andando\""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg} minutos"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count} Paroas"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count} alerta"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count} más adelante %{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date} a %{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date} a %{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date} está fuera de nuestro horario actual."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date} hasta nuevo aviso"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max} minutos"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1} y %{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label} Solo"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name} Tren de cercanías"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "%{place} Información"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating} trabajo planeado"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating} horario, termina %{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating} horario, empieza %{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name} %{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time} en %{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y} de %{x} funcionando"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ", "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ", efectivo, o "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "1 Ruta accesible"
 msgstr[1] "%{count} rutas accesibles"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "1 Ruta inaccesible"
 msgstr[1] "%{count} Rutas inaccesibles"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "1 Ruta no disponible"
 msgstr[1] "%{count} sin rutas disponibles"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 alerta"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "1 resultado"
 msgstr[1] "%{count} resultados"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "1 atajada"
 msgstr[1] "%{count} atajada"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "1 viaje más tarde hoy"
 msgstr[1] "%{count} viajes más tarde hoy"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Pase de 1 día"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 zonas donde se puede cerciorar un dispositivo de movilidad con ruedas"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "24 horas, 7 días a la semana"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Pase de 7 días"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 para los oyentes de Relé telefónico de texto (TTY);  VRS para llamadores ASL"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Atracción ADA"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarifa de viaje ADA"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/accesibilidad Quejas"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Acerca de"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "Acceso"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "Problema de acceso"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "Problemas de acceso"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "accesibilidad"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "Recursos de accesibilidad"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "accesibilidad en %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "accesible"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Agregar"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "Agregar %{title} al calendario"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "Agregar evento al calendario"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "Agregar al calendario"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "Solo para administradores"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulto"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "Agenda"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "alerta"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "alerta"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "alerta para la MBTA %{description}"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "Todos alerta"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "Todos Boston Stadium Train Boleto incluyen un viaje de regreso tras el combate. Los trenes comenzarán a salir de la estación Foxboro 30 minutos luego del"
 " pitido final. Los trenes de regreso saldrán del estadio aproximadamente cada 15 minutos hasta que todos los trenes salieron."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "All entrada a la ciudad Trenes"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "Todos los tipos de ubicación"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "Todos los proyectos de mejora de la MBTA"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "Todos los trenes de salida de la ciudad"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "Todo el horario y mapas"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "Todos los trenes"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "Todos los trenes cancelados"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "Todas las actualizaciones"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Todas las rutas de ferry"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "Todos los campos con asterisco* son obligatorios."
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "Todos los modos"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "Todas las ubicaciones propuestas están sujetas a la idoneidad del sitio, licencias y disponibilidad de tiendas."
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "Alerta Amber"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Una toma exterior de la Downtown Crossing estación entrada. Banderas estadounidenses bordean la calle y rascacielos son visibles al fondo. Muchos peatones"
 " pasan por allí."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "próximo a llegar"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "Llega por"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "Llegando"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "Llegando por %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "En máquina expendedora de boletos, puedes"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "En la estación con múltiples vías fuera de Norte, Sur, Back Bayy Ruggles estación, los trenes entrada a la ciudad abordan desde la vía 2, y salida de la"
 " ciudad abordan desde la vía 1, salvo que se indique lo contrario. Los cambios programados de vía se indicarán con el "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Asistentes"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "Datos malos agrupados de tarjetas de tarifa"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "Política de bolsas y artículos prohibidos"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "Estate en South Station a la hora que se muestra para tu grupo de abordaje. Tu grupo de embarque está en tu Boston Stadium Tren Boleto."
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "Antes de hoy"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "Proyecto Better Colectivo"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "¿Se permiten bicicletas?"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "Bicicletas permitidas"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "Se permiten bicicletas en trenes con el símbolo de bicicleta debajo del número del tren, sujeto a restricciones."
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "No se permiten bicicletas"
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "bicicleta"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "Problema con la bicicleta"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "Bicicleta Storage"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "Bicicleta Storage en %{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "bicicleta"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "Bicicleta permitida"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "Las bicicletas están permitidas en todos ferry barcos"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line Subterráneo andén dentro de State Street"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line tren que sale de Airport estación"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "Internado"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "Grupo de Abordaje A"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "Grupo de Abordaje B"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "Grupo de Abordaje C"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "Grupo de Abordaje D"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "Grupo de Embarque E"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "Grupos de internado"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Boston Stadium Boleto de tren necesario"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "Boston Stadium Boleto de Tren debe comprar con antelación en la app mTicket . Para más información, lee nuestro %{world_cup_link}"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Trenes"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "Guía del Visitante de Boston sobre Subterráneo"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "Ambas direcciones"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "Llevar tu auto o bicicleta"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "autobús"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "Colectivo %{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "Guía para principiantes de colectivos"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "tarifas de colectivo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "Características del colectivo"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "Mapa de colectivos"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "colectivo Otros"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "Ruta de colectivos"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "parada de autobús"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "Atajada de Colectivo Cambios"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "Colectivos que se pueden bajar para facilitar el embarque y la bajada"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Negocios"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "Oportunidades de negocio"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "Vista del calendario"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "Llamada"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "Llámanos"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "cancelación"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "cancelación"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "Transformación de Capital"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "Carreras"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "Efectivo"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Cambio"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "Fecha de cambio"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "Cambia de dirección del viaje."
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "Cambios"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "Charlie Retailer"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCards"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & Boleto"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "Comprobado"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "Registro en South Station"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Niño"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Menores de 3 años"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "Elige tu idioma"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "Elige un tipo de horario entre las opciones disponibles"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "Día de Navidad"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "Derechos civiles"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "Gráfico clicable para las Guías de Usuario"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Cierre"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "Diálogo cerrado"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "Moneda"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "Día de Colón"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Comentario"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Ferry de cercanías a Logan Airport"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "Tren de cercanías"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Tren de cercanías "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "Tren de cercanías Fares"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "Tren de cercanías Map"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "Tren de cercanías mensual pase"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "Tren de cercanías solo ida"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "Tren de cercanías Positive Train Control"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "Tren de cercanías Status"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "Mapa de zonas del Tren de cercanías"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "La disponibilidad de asientos en el Tren de cercanías se actualiza de manera regular para reflejar la afluencia típica de pasajeros de un viaje según datos"
 " automatizados y de conductores de los últimos 14-30 días."
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "Quejas"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "Cumplido"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contacto"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Contáctanos"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "Números de contacto"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "Contacta con el equipo de Atención al cliente de la MBTA y consulta números de contacto adicionales de la Policía de Tránsito, Objetos extraviados y accesibilidad."
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "Contacta con la Policía de Tránsito"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continúa"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "Costo"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "Portabicicletas cubiertas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "Hay racks cubiertos para bicicletas disponibles"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "Crear una cuenta"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "Tarjeta de crédito/débito"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "Tarjetas de crédito/débito"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Ferry de Cross Harbor"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "Crosstown"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "Abarrotado"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "Actualidad"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "Alerta actual"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "Cambios actuales"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "Estado actual"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "Los umbrales actuales de disponibilidad de asientos son:"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "Atención al cliente"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Diario"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "Horario diario"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Fecha"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "Fecha y hora"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Día de día"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "demora"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "Retrasado %{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "demora"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "Salida"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "Salida en"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "Salidas"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "La ubicación del destino no está lo suficientemente cerca de ninguna atajada de tránsito"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "La ubicación de destino está fuera de nuestra área de servicio"
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "Destinos"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "Detalles"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "Desvío"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Desarrolladores"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "Pantallas digitales y anuncios automáticos que comparten información de claves y atajada de Rutas"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "Dirección de tu viaje"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "Tarjetas de identificación de discapacidad"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "Muelle cierre"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "Problema en el muelle"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "Documentos"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "No se detiene en"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "Debido al seguimiento único"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "Tarjeta EBT"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ pase"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "Antes"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "Llegada más temprana"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "Salida anticipada"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "Atajada de salida temprana"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "Dirección este"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "Elevador"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "Ascensor y escalera mecánica"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "Cierre del ascensor"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "Cierre del ascensor"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "Línea directa de ascensores/escaleras mecánicas"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "Ascensores"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "Ascensores en %{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "situación de emergencia"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "situación de emergencia Contactos"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "Empleado"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "Quejas de empleados"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "Terminado"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "Normas de Diseño de Ingeniería"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "Introducir una ubicación de destino"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "Entra una ubicación"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "Introduce una ubicación de origen"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "Introduzca palabra(s) clave(s)"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "Introduce las palabras clave del proyecto"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "Entrada en la estación"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "Entra en el círculo de tránsito"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "Introduce tu dirección registrada"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "Entrada a Blue y Green Lines fuera de Government Center"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "Entrada a Green y Red Lines fuera de Park Street"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "Entrada a Orange y Red Lines fuera de Downtown Crossing"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "Entrada a Ruggles estación"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "entrada a Red Line y Tren de cercanías a las afueras South Station"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Error"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "Escalera mecánica"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "Escalera mecánica (solo para bajar)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "Escalera mecánica (subiendo y bajando)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "Escalera mecánica (solo para subir)"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "Escalera mecánica cerrada"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "Escalera mecánica cerrada"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "Escaleras mecánicas"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "Escaleras mecánicas en %{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "Llegada estimada a la estación de Foxboro"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "Descripción del evento"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "Resumen del evento para "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "Eventos"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "Salida de la estación"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "se esperan demoras"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "Explora estación por modo"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Autobús exprés"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "Colectivo exprés solo ida"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Exterior de la estación Wonderland"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "Servicio extra"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "Información sobre la instalación"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "Problema de la instalación"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Paquete familiar de 4 (2 adultos, 2 niños)"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "Evasión de tarifas"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "Opciones tarifarias"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "Opciones de tarifas en %{name}"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "Política tarifaria"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "Ubicaciones de venta de tarifas"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "Transformación tarifaria"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "Tipos de tarifas"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "máquina expendedora de boletos"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "máquina expendedora de boletos"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "Tarifas"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "Información de tarifas"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "Resumen de tarifas"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "Tarifas por modo"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Las tarifas varían entre ferris Hingham/Hull y Charlestown ferris. Consulte la información a continuación:"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "Actualizaciones y proyectos destacados de la MBTA"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "ferry"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "ferry "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "Tarifas de ferry"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "Mapa del ferry"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "Ferry Mensual Pase"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "Pocos asientos disponibles"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "Presenta una queja por discriminación"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "Rellena el formulario"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "Filtrar por tipo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "Finanzas"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "Encuentra ubicaciones propuestas cerca de ti"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "Encuentra tu colegio electoral"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "Encontrar una ubicación"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "Encuentra una tienda cerca de ti"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "Descubre cómo involucrarte"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "Terminando otro viaje"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "Primera %{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "Atajada de bandera"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "Marca el colectivo en cualquier lugar seguro a lo largo de la ruta"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "Sígue@MBTA en Twitter"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "Sígue@MBTA_CR en Twitter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "Sigue las señales"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "Sigue el enlace de abajo para encontrar el número asociado al modo o ruta donde perdiste tu artículo."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "Para las tarifas de Colectivo exprés, lee la página completa de %{link} ."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "Para toda la información sobre el servicio de trenes en la Copa del Mundo, lee nuestro %{world_cup_link}"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "Para más información"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "Para preguntas o comentarios sobre este comunicado de prensa, por favor contacte"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Para el servicio regular del Día de semana a Foxboro por favor visite: "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evento Especial de Foxboro"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Línea Franklin"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratis"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "Parqueadero seguro gratis para pedales y parqueadero"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Servicio gratis"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "Viernes"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Andén de nivel alto completo para proporcionar un abordaje nivelado a cada vagón de un tren"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "Obtén indicaciones"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "Involúcrate"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "Recibe actualizaciones del servicio"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "¡Haz T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "Consigue una CharlieCard"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "Recibe una factura por correo por una tarifa de 1 dólar"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "Obtén indicaciones para este parqueadero"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "Conócenos"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "Obtén sugerencias de viajes"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "Ve"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "¿Vas a un partido de la Copa del Mundo en el Boston Stadium?"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Green Line %{branch} Rama"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "Nombre del grupo"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Ferry Harbor Loop"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "Viraje a la izquierda"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "Voltea a la derecha"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Escóndete"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "Ocultar detalles"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Hingham/Hull ferry"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Historia"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "Horario festivo"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "Fiestas"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Inicio"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Dirección de casa"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "Clave de iconos"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "Si procede, por favor cerciórate de incluir la hora y la fecha del incidente, la ruta y el número del vehículo."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "Si proporcionaste tu información de contacto, revisa tu email para ver si hay una confirmación con un número de incidente. Si no recibes confirmación en"
 " 10 minutos, intenta enviar tu feedback de nuevo o llámanos a"
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "Si desea que le llamemos, por favor díganos el mejor número donde podamos localizarle."
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "Si se violaron tus derechos civiles, puedes presentar una quejas ante la Oficina de Diversidad y Derechos Civiles de la MBTA."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "Información importante"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "Enlaces importantes"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "entrada a la ciudad Trenes cancelados"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "Día de la Independencia"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "Información y soporte"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "Ventas institucionales"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "Público objetivo"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "%{zone}Interzona"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Duración inválida"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarifa inválida"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "Factura"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "¿Esto es útil? Envíanos tus comentarios"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "Saltar a"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "Día de la Independencia del Juneteenth"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "Conoce tu grupo de abordaje"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "¿Conoces a algún dueño de tienda local que pueda estar interesado en unir a nuestra red de tiendas minoristas? Sugiere un minorista y nosotros nos pondremos"
 " en contacto con ellos en tu nombre."
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "Día del Trabajo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "Servicios de Idiomas"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Idiomas"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "Último"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "Último %{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Más tarde"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "Liderazgo"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "Más información sobre CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "Obtenga más información sobre las tarifas de la MBTA"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "Más información sobre accesibilidad en Subterráneo"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "Más información sobre el parqueadero de bicicletas en Subterráneo"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "Descubre más sobre el almacenamiento de bicicletas en esta estación."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "Infórmate más sobre la bicicleta en el Tren de cercanías"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "Más información sobre la accesibilidad del colectivo"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "Infórmate más sobre los precios de las tarifas, los tipos de pase y cómo pagar tu tarifa en Subterráneo."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "Infórmate sobre tarifas"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "Infómate más sobre ferry accesibilidad"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "Más información sobre cómo presentar una quejas"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "Más información sobre el parqueadero en Subterráneo"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "Infórmate más sobre Tarifa reducida y su elegibilidad"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "Infezca más sobre las tendencias de disponibilidad de asientos"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "Infórmate más sobre las funciones de accesibilidad en este %{place}."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "Descubre más sobre este proyecto"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "Descubre qué ocurre luego de presentar una quejas"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "Caminar menos"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "Dejar en"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "Marchar a %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "Izquierda"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "Cuéntanoslo"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "Líneas y rutas"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "Vista de lista"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "Alertas de servicio en directo para todos los modos de transporte de la MBTA, incluyendo Subterráneo, colectivo, Tren de cercanías y ferry. Actualizaciones"
 " sobre demora, construcción, caídas en ascensores y más."
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Carga más"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "Cargando llegadas..."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "Horario de carga para servicios seleccionados"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "Detalles del viaje de carga"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "Cargando salidas de Próximo"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Vestíbulo dentro de la estación Back Bay"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Colectivo local"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "Colectivo local solo ida"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ubicación"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "La ubicación no está lo suficientemente cerca de ninguna estación de transporte"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "Ubicación no disponible"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "Rampa larga"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "Objetos Perdidos y Objetos"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "Objetos extraviados"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type} estación y horario, incluyendo mapas, actualizaciones en tiempo real, información sobre parqueadero y accesibilidad, y conexiones."
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{route_name} %{station_name} y horario, incluyendo horarios, mapas, tarifas, actualizaciones en tiempo real, información de parqueadero y accesibilidad,"
 " y conexiones."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "Atajada y horarios de %{text} MBTA, incluyendo mapas, información sobre parqueadero y accesibilidad, y tarifas."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{type} ruta %{name} atajada y horarios, incluyendo mapas, actualizaciones en tiempo real, información de parqueadero y accesibilidad, y conexiones."
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - Autoridad de Transporte de la Bahía de Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "MBTA Facebook"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "Tarifas MBTA"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "Tienda de Regalos de la MBTA"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "La estación de tranvías y horaria de la MBTA Green Line incluyendo mapas, actualizaciones en tiempo real, información sobre parqueadero y accesibilidad,"
 " y conexiones."
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "Página principal de la MBTA"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "Página principal de la MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "MBTA Instagram"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "Programa Paratránsito MBTA"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "Proyectos/Programas MBTA"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "Estación MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "Hilos MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "Policía de Tránsito de la MBTA"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "Planificador de viajes MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "MBTA Twitter"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "Guías de Usuario de MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "MBTA YouTube"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA máquina expendedora de boletos"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "El pasajero de la MBTA puede comprar CharlieTickets y recargar y adquirir %{charlie_card} para el colectivo, Subterráneo, Tren de cercanías y ferry en"
 " comercios de toda la zona metropolitana de Boston y Providence ."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "MBTA.com Últimas noticias"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "MBTA.com Menú"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Principales"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "Línea directa principal"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "mantenimiento"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "mantenimiento Quejas"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "Haz un giro de U"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "Gestionado por"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "Muchos asientos disponibles"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Mapas"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "Día de Martin Luther King, Jr."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "Autoridad de Transporte de la Bahía de Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "Autoridad de Transporte de la Bahía de Massachusetts, todos los derechos reservados."
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport enlace"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport enlace %{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "Partido 18"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "Partido 30"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "Partido 45"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "Partido 5"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "Partido 61"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "Partido 74"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "Partido 97"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "Match Boleto Required "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Puede que no sea accesible"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "Información de contacto de medios"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "Relaciones con los medios"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "Información de la reunión"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "Los afiliados a la prensa pueden aplicar unir a nuestra lista de medios enviando un email "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "Los miembros del público tienen derecho a aplicar copias de documentos de la MBTA, con ciertas excepciones. Las tasas se aplican y pueden variar según"
 " la solicitud."
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "Día de los caídos"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "Menú"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militar"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "Mini Andén de nivel alto para proporcionar un abordaje nivelado a ciertos vagones de un tren"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "Actas"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "Aplicación móvil"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "Boleto móvil"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "Modos"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "Modos de transporte"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "Lunes"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "Lunes - viernes"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "De lunes a viernes"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "De lunes a viernes"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "mensual"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensual"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "Mensual Colectivo Pase local"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "mensual pase"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mensual pase en mTicket App"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "Más guías"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "Más información"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "Más de "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "Más directo"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "Tarifas más populares"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "La mayoría, pero no todas, las muelles de la MBTA son accesibles para pasajeros con discapacidad. Según el nivel de la marea y el tipo de embarcación empleada"
 " para viajar, puedes encontrar pendientes significativas y corredores estrechos, incluso en muellers accesibles. En absoluto, mulas, espera a que un afiliado"
 " a la tripulación te diga que es seguro continuar."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menú de navegación"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Nuevo"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "Día de Año Nuevo"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "Noticias"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Siguiente"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "La semana que viene"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "Próxima atajada"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "No %{group} alerta"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "Sin servicio programado"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "Sin servicio"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "Aquí no hay alerta."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "No se publicaron cambios durante los próximos 7 días"
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "Sin eventos"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Prohibido parquear"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "Hoy no hay servicio"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "No se encontraron conexiones de tránsito entre el origen y el destino en esa fecha y hora"
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "No se seleccionaron modos de transporte"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "No se encontraron rutas de transporte en menos de 2 horas desde %{time_on_date}. Las rutas pueden estar disponibles en otros horarios."
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "No se encontraron salidas"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "No hay festividades en Próximo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "servicio normal"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "Dirección norte"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "No accesible"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "No disponible"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "No está lleno"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Nota"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Nota:"
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notas"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "Aviso"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Ahora"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "Ahora en"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "Observado"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "Sitio web oficial de la MBTA — horario, mapas e información tarifaria del sistema de transporte gubernamental del Gran Boston, incluyendo Subterráneo,"
 " Tren de cercanías, rutas de colectivo y líneas de barcos."
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "Sitio web oficial de la MBTA — Planea un viaje en transporte gubernamental por la región del Gran Boston"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "¡Oh, no! Estamos experimentando desmoralización."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "A tiempo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampas a bordo en la puerta principal de cada colectivo"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Pase de un día"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "solo ida"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "en curso"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "Solo se permiten carteras o bolsas transparentes pequeñas. Los objetos prohibidos deben descartar antes de embarcar."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "O,"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "O, ve a "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "Orden mensual pase"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "La ubicación de origen no está lo suficientemente cerca de ninguna atajada de tránsito"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "La ubicación de origen está fuera de nuestra área de servicio"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "El origen o destino está fuera de nuestra área de servicio"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Otros"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "Otros horarios"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "Nuestro trabajo"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "Nuestras guías de Usuario pueden ayudarte a aprender a navegar por el sistema, acudir a eventos locales, emplear funciones de accesibilidad y mucho más."
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "Fuera de servicio"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "Salida de la ciudad Trenes cancelados"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "Parrillas exteriores para bicicletas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "Hay aparcajadores para bicicletas al aire libre"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "Durante la noche"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Resumen"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF horario"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF Próximo"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Página no encontrada | MBTA - Autoridad de Transporte de la Bahía de Massachusetts"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "Página no encontrada"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Páginas"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "Paratránsito (The RIDE)"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "Parqueadero"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "Parking cierre"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "Problema de parqueadero"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "Tarifas de parqueadero"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "Parqueadero en %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Parqueadero disponible"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "pasajero debe contar "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "Cambios pasados"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "Día de los Patriotas"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "Paga tu billete"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Métodos de pago"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personas"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "Gente esperando mientras llega el tren de la línea naranja dentro de North Station"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "Las personas que viajan en tren saliendo de la North Station"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "Gente caminando hacia Green Line tren dentro de North Station"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "Rendimiento"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "Planea tu viaje"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "Planea un viaje"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "Planea un viaje accesible"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "Planea tu viaje"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "Planned alertas de servicio"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "trabajo planificado"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "Por favor, introduce un comentario para continuar."
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "Por favor, introduce un email válido."
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "Por favor, introduzca un número de vehículo válido solo con caracteres numéricos."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "Por favor, introduzca una dirección que esté a menos de 100 millas de un área de servicio de la MBTA."
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "Por favor, introduce tu nombre de pila para continuar."
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "Por favor, introduzca su nombre Último para continuar."
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "Por favor, selecciona un destino en una ubicación diferente a la de origen."
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "Por favor, seleccione un destino de destino."
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "Por favor, selecciona una ubicación de origen."
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "Por favor, seleccione al menos un modo de transporte."
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "Por favor, seleccione el tipo de preocupación."
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "Por favor, especifica una fecha y hora en el futuro o selecciona 'Ahora'."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "Por favor, inténtalo de nuevo o envíenos su opinión en mbta.com/customer-support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "Políticas y Derechos Civiles"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "Cambio de política"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "Ascensor portátil de subida"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "Publicado en"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "Los horarios previstos de salida aún no están disponibles, pero aparecerán aquí antes del primer viaje programado."
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "Prefiere rutas accesibles"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Atracción Premium"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarifa Premium Ride"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "Notas de prensa"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "Versión previa"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Política de privacidad"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "Proyectos"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "Ubicaciones de venta propuestas"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "Reuniones públicas"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "Transporte gubernamental en la región del Gran Boston. Rutas, horarios, Planificador de viajes, tarifas, alertas de servicio, actualizaciones en tiempo"
 " real e información general."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "Compra entradas para Charlie"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "Compra una CharlieCard o recarga una existente"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "Compra tarifas en máquina expendedora de boletos."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "Compra tarifas en los puntos de venta cercanos."
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "Calidad, Cumplimiento y Supervisión"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "Cuartos de final"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "Pregunta"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "ferrocarril"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "Lee nuestro %{world_cup_link}"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "Recibe notificaciones de alertas de servicio MBTA por email o mensaje de texto."
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "Noticias recientes sobre Subterráneo"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "Recientemente visitado"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "Tarifa reducida"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "Regístrate tu CharlieCard para el parqueadero de bicicletas"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "Archivos relacionados"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "Alertas de servicio relacionadas"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "Denuncia fraude, desperdicio o abuso"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Reportar un problema en la puerta de un paso a nivel"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "Reporta un problema de accesibilidad"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "Reporta un problema con el ascensor"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "Reporta un problema con la escalera mecánica"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "Denuncia sospechas de fraude, desperdicio o abuso"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "Aplicar Registros Públicos"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "Ubicaciones de venta minorista"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "Viaje de ida y vuelta incluido"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "Súbete a la %{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "Viaja en el tren %{route} %{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "no se permitirá el pasajero sin boleto de coincidencia para abordar Boston Stadium trenes."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "Derecha"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ida y vuelta"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "Octavos de final"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "Ruta %{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "Ruta %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Rutas"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "Rutas con alerta de alta prioridad"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Seguridad"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "Sábado"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "horario & Mapas"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "Cambio de horario"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "horario para"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "información del horario para las líneas MBTA Tren de cercanías en la región del Gran Boston, incluyendo actualizaciones en tiempo real y predicciones de"
 " llegadas."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "información del horario para rutas de colectivo MBTA en la región del Gran Boston, incluyendo actualizaciones en tiempo real y predicciones de llegada."
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "Información del horario para rutas de la MBTA ferry que operan en la Bahía de Massachusetts, incluyendo PDFs descargables."
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "información del horario para las líneas MBTA Subterráneo en el área metropolitana de Boston, incluyendo actualizaciones en tiempo real y predicciones de"
 " llegadas."
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "información del horario para MBTA Subterráneo, colectivo, Tren de cercanías y ferry en la región del Gran Boston, incluyendo actualizaciones en tiempo"
 " real y predicciones de llegadas."
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "horario estará disponible pronto en el sitio web de la MBTA."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Programados"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "El servicio regular continúa hasta %{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "Previsto para partir"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "horario"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "horario & Mapas"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "horario y mapas"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "Solo en días escolares"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Búsqueda"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "Buscar MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "Busca una atajada o estación"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "Busca rutas, lugares, información y mucho más"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "Resultados de búsqueda para"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "Buscar en el MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "Estacional"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "Servicio estacional"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "Disponibilidad de asientos"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "Sitio oficial del Secretario de State"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "Hay parqueadero cerciorado, pero se requiere registro previo de la Charlie Card."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "Ver alerta"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "Ves algo, di algo"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "Ver todas las notas de prensa"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "Ver todas las reuniones y eventos públicos"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "Ver todas las alertas de servicio"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "Consulta todas las guías de Usuario"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "Descubre qué puedes traer en Boston Stadium Trains"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Seleccionar"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "Envíanos tus comentarios"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "adultos mayores CharlieCard o TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "Tarjetas de identificación de adultos mayores"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "adultos mayores"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "Problema con el servidor"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "Servicio"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "alertas de servicio"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "cambio de servicio"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "Quejas de servicio"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "Consulta de servicio"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "alertas de servicio o demora"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "El cambio de servicio está en vigor del 6 de junio al 12 de julio. Consulta cada día de tu %{timetable_link} de línea para encontrar el horario más actualizado."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "Finalización del servicio"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "El servicio funciona según lo esperado"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "Servicio en la Copa del Mundo"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "Viaje más corto"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Programa"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "Detalles del programa"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "Mostrar menos atajada"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "Mostrar más atajada"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "Mostrando todo"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "Mostrando atajada importantes."
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "enlace"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "servicios de enlace"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "Regístrate para recibir alertas de servicio"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "Apúntate a pago automático"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "Apúntate a T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "Regístrate para recibir notificaciones de alerta"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "Un viaje similar llega a %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "Un viaje similar sale a %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "Viajes similares llegan a %{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "Viajes similares salen en %{times}"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "Seguimiento único"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "desvío al contenido principal"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "desvío"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "Ligeramente a la izquierda"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "Un poco a la derecha"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "Tarjeta inteligente"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "Ruta de la nieve"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "Palear la nieve"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "Algunos asientos disponibles"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "Algo de hacinamiento"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "Algo salió mal por nuestra parte."
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "¡Perdón! Nos perdimos tu atajada."
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "Perdona. Algo salió mal. Por favor, inténtalo de nuevo."
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "Perdona. Tuvimos problemas para cargar tu imagen. Por favor, inténtalo de nuevo."
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "Dirección sur"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Boleto de Eventos Especiales"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "Se requiere boleto especial"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "Estación & Alertas de Servicio"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "Estación Accesibilidad"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "Estación Cierre"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "Características de la estación"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "problema en la estación"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estación que atiende a las líneas MBTA %{lines} %{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "estación"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "Estación y parqueadero"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "Estación y atajada"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Estado"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "¡Para %{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "cierre de parada"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "Parada modificada"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "Stop desvío"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "Atajada"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "Paradas desvío"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudiante"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "CharlieCard de estudiante"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "Enviar"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "Presentar una solicitud de acceso a registros públicos a la MBTA"
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "Subterráneo"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "Guía para principiantes de Subterráneo"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "Subterráneo Fares"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "Mapa de Subterráneo"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "Subterráneo solo ida"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "Estatus Subterráneo"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "Sugiere un minorista"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Resumen"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "Domingo"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "Suspensión"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Sostenibilidad"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "Ubicación de origen y destino del intercambio"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "A nivel de sistema"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "TAlerts/Cuentasatrás/Apps"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "Relé telefónico de texto (TTY)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "Relé telefónico de texto (TTY) Phone"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "Lleva a Subterráneo a votar"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Toma el ascensor"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "¿Vas en tren a un partido de la Copa del Mundo?"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "Dinos qué te parece"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "Cuéntanos sobre tus viajes habituales y recibe alertas por SMS o email que sean relevantes para ti, en los momentos en que las necesites."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "Temporalmente no disponible"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "Cerrado temporalmente"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "Descendencia temporal"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "Descendencia temporal"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "Términos de uso"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "Gracias por enviar tu comentario. Nuestro equipo de Atención al cliente revisará tus comentarios pronto."
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "Día de Acción de Gracias"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "El "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "El Coordinador de Compromiso con el Cliente en Accesibilidad a Nivel de Sistema y el Enlace con el Cliente para The RIDE son responsables de coordinar"
 " las resoluciones de las Quejas ADA/accesibilidad una vez que se reciben."
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "La línea de Eventos Especiales de Foxboro es solo para servicios ocasionales."
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "La Unidad Interna de Auditoría Especial dentro de la Oficina del Inspector General monitorear la calidad, eficiencia e integridad de los programas MassDOT."
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "El Viaje"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "El horario interactivo para"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "Actualmente no hay salidas en tiempo real disponibles."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "Actualmente no hay salidas en tiempo real disponibles. Las salidas programadas se muestran a continuación."
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "No hay"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "No hay "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "No hay características adicionales de accesibilidad, pero los colectivos siempre son accesibles para abordar."
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "No hay alertas"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "No hay prioridad alta"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "No hay otros Tren de cercanías alerta en este momento."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "No hay otras alertas Subterráneo en este momento."
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "No hay viajes %{direction} programados en %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "No hay viajes programados %{direction} ."
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "No hay viajes programados en %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "No hay viajes programados."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "Por el momento no hay actualizaciones."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "Actualmente no hay %{route_name}programadas."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "Por el momento no hay información sobre trabajo planeado."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "No hay servicio de %{route} programado en %{stop} durante este periodo."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "Hubo un problema para cargar las llegadas"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "Hubo un problema al cargar el horario"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "Hubo un problema para cargar los detalles del viaje"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "Hubo un problema para cargar las salidas de Próximo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "Este %{place} no es accesible."
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "Esta Semana"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "Esta lista no incluye a los minoristas actuales de la MBTA. Para ver las ubicaciones actuales, emplea nuestro"
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "Esta página ya no está en servicio."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "Esta estación no dispone de almacenamiento para bicicletas."
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "Esta estación no tiene ascensores."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "Esta estación no tiene escaleras mecánicas."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "Esta estación no tiene parqueadero."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "Esta atajada no tiene máquina expendedora de boletos, pero puedes comprar tarifas en un"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "Este tren suele tener<br /><strong>%{seats} asientos disponibles</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "Jueves"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "Horarios"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "A"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "Para informar de un problema o situación de emergencia en un paso a nivel, llame"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "Para enviar una queja ADA/accesibilidad o recibir comentarios, por favor llame"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Hoy"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "Hoy en"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "Número gratis"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "Cambio en el Track Board"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "Cambio de vía"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "Canción por anunciar"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "Sigue tu viaje de %{route_type_text} en directo con la app <strong>MBTA Go</strong>"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Tren"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "Tren %{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "Tren programado para abordar desde %{platform} a %{station}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "Traspasos"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "Transporte"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "Policía de Tránsito"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "Viaja a cualquier parte de las líneas Blue, Orange, Redy Green por el mismo precio."
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "Viaje"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Planificador de viajes"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "Tipo de viaje"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "Viajes de %{from} a %{to}"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "Prueba a buscar lo que buscas abajo."
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "Martes"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "Martes, el 5 de noviembre es el último día para votar en las elecciones generales de 2024. Usa Subterráneo para llegar a tu colegio electoral."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "Normalmente hay menos del 33% de los asientos disponibles y es poco probable que se mantenga el distanciamiento (~3+ personas por fila)"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "Normalmente más del 33% de los asientos permanecen disponibles y puede ser posible distanciar (~2-3 personas por fila)"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "Normalmente hay más del 66% de los asientos disponibles y es posible mantener el distanciamiento (~0-2 personas por fila)"
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "Pista no programada"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "Hasta %{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "Próximo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "Próximos Changes"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "Salidas de Próximo"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "Fiestas Próximo"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "Próximos Reuniones y Eventos Públicos"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "Actualizado"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "Actualizado: "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "Actualizaciones"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "Uso"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "Guías de usuario"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "Día de los Veteranos"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "Vía"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Vista"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "Consulta %{timetable_link} para información sobre las salidas."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "Ver alerta"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "Ver todos los números de contacto"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "Ver todas las opciones"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "Ver biografía"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "Ver biografía para %{name}"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "Ver horario en PDF"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "Consulta el horario en PDF en el sitio web de la MBTA."
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "Ver anterior"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Ver todo"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "Ver todas las rutas de colectivo"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "Ver todos los eventos"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "Ver todas las guías"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "Ver todos los partidos"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "Ver todas las noticias"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "Ver todas las actualizaciones del proyecto"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "Ver todos los proyectos"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "Consulta los ascensores disponibles."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "Consulta las escaleras mecánicas disponibles."
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "Consulta información de tarifas comunes para el colectivo MBTA, Subterráneo, Tren de cercanías, ferryy The RIDE. Encuentra servicios de CharlieCard online"
 " e infórmate sobre los programas de pedidos al por mayor."
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "Consulta el horario nocturno"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "Ver resumen de tarifas"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Ver más información sobre pagos"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "Ver horario matutino"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "Ver en Google Maps"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "Ver en MBTA Planificador de viajes"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "Consulta tarifas de parqueadero, información sobre las instalaciones y más."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "Ver números de teléfono"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visita"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "Visita el Centro de Movilidad"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Votar"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "Esperando resultados"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "Esperando para partir"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "Camina"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "Solo indicaciones a pie"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "El cumpleaños de Washington"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "Solo podemos proporcionar datos de viaje para el horario de %{rating} , válido hasta %{end_date}."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "Tuvimos un problema para enviar tu opinión; por favor, llámanos a la línea principal de abajo, o inténtalo de nuevo en unos minutos."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "Queremos cerciorarnos de que estamos construyendo una red de retail que funcione para ti. Puedes compartir tus comentarios usando el formulario que aparece"
 " a continuación."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "No pudimos encontrar un colegio electoral para tu dirección. También puedes visitar el"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "Te enviaremos directamente los comunicados de prensa y avisos de prensa de la MBTA."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "Pedimos al público que nos ayude a tomar decisiones mientras implementamos el proyecto de Transformación Tarifaria en los próximos años."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "Estamos ampliando nuestra red de lugares donde pasajero puede conseguir o cargar una CharlieCard y comprar pase."
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Sitio web"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Fin de semana pase"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "Fines de semana"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "Dirección oeste"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "Qué está pasando en la MBTA"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Cuando"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "Trabaja con nosotros"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "Trabaja con nosotros"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "Funcionamiento"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guía de la Copa del Mundo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "Partidos de la Copa del Mundo"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "Escríbenos"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "Todo el año"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "También puedes enviar un email"
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "Puedes esperar una respuesta a la mayoría de los boletos en un plazo de 5 días laborables. Algunas Quejas pueden requerir investigaciones más largas, hasta"
 " 30 días."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "Puedes pagar tu billete con"
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "Debes aceptar nuestra Política de Privacidad antes de enviar tus comentarios."
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Debes completar el reCAPTCHA antes de enviar tu feedback."
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "Tu viaje al Tren de cercanías se verá afectado por el Mundial."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "Tu colegio electoral"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "Zona"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zona %{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zonas 1A-10"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "Afiliado a la tripulación"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "Lugares accesibles"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "Alerta en ese momento"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "y"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "llegado a"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "Llegada"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "En ese momento"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "entre %{first} y %{last}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "Barco"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "autobús"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "parada de autobús"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Efectivo"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "Cambio"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "Cambios"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "Pago sin contacto"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "Actualidad"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "Partida"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "muelle"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "Este"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "pocos"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "para"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "de %{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "se fue"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "entrada a la ciudad"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "Info"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "temporalmente no está disponible debido a un cambio de servicio."
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "Línea"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "Ubicación"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplicación mTicket"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "muchos"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "Ubicación comercial cercana"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "Norte"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "de más de 30 minutos"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "de más de una hora"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "A"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "o"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "o "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "O completa el formulario de comentarios en esta página."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "o pagar con Efectivo en cualquier colectivo"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "salida de la ciudad"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papel ferry Boleto"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "Planeado"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "Tarifa reducida card"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "Registro con antelación"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "Reporta un problema"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "requiere"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "Localizador de ubicación de ventas al por menor"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "Ruta"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "Consulta un mapa de todas las ubicaciones de venta propuestas"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "Servicio"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "algunos"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "Sur"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "estación"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "estación"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "¡Para"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "atajada"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "la página principal de la MBTA"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "El director"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "a la mañana siguiente"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "a través de"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "Calendario para"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "a"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "para %{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "para encontrar tu colegio electoral y luego usar el"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "para planear tu viaje"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "Total de plazas de parqueadero"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "hacia"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "Pista "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "tren"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "Viajes para hoy"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "hasta 10 minutos"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "hasta 15 minutos"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "hasta 20 minutos"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "hasta 25 minutos"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "hasta 30 minutos"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "Sitio web"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "Oeste"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "con"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Con tu petición."
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " alerta"
 msgid " at "
 msgstr " en "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " en %{address}"
@@ -128,7 +128,7 @@ msgstr " en el "
 msgid " on track "
 msgstr " En pista "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y} de %{x} funcionando"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] "1 viaje más tarde hoy"
 msgstr[1] "%{count} viajes más tarde hoy"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Pase de 1 día"
@@ -350,8 +351,8 @@ msgstr "24 horas, 7 días a la semana"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Pase de 7 días"
@@ -362,12 +363,12 @@ msgstr "Pase de 7 días"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 para los oyentes de Relé telefónico de texto (TTY);  VRS para llamadores ASL"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Atracción ADA"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarifa de viaje ADA"
@@ -447,7 +448,7 @@ msgstr "Agregar al calendario"
 msgid "Admins Only"
 msgstr "Solo para administradores"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulto"
@@ -532,7 +533,7 @@ msgstr "Todos los trenes cancelados"
 msgid "All Updates"
 msgstr "Todas las actualizaciones"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Todas las rutas de ferry"
@@ -948,7 +949,7 @@ msgstr "Cambia de dirección del viaje."
 msgid "Changes"
 msgstr "Cambios"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -964,7 +965,7 @@ msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
@@ -981,8 +982,8 @@ msgstr "CharlieCards"
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & Boleto"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -997,12 +998,12 @@ msgstr "Comprobado"
 msgid "Check-In at South Station"
 msgstr "Registro en South Station"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Niño"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Menores de 3 años"
@@ -1058,7 +1059,7 @@ msgstr "Día de Colón"
 msgid "Comment"
 msgstr "Comentario"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Ferry de cercanías a Logan Airport"
@@ -1076,7 +1077,7 @@ msgstr "Ferry de cercanías a Logan Airport"
 msgid "Commuter Rail"
 msgstr "Tren de cercanías"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Tren de cercanías "
@@ -1194,7 +1195,7 @@ msgstr "Tarjeta de crédito/débito"
 msgid "Credit/debit cards"
 msgstr "Tarjetas de crédito/débito"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Ferry de Cross Harbor"
@@ -1265,7 +1266,7 @@ msgstr "Fecha"
 msgid "Date and Time"
 msgstr "Fecha y hora"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Día de día"
@@ -1406,7 +1407,7 @@ msgstr "Salida anticipada"
 msgid "Early Departure Stop"
 msgstr "Atajada de salida temprana"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1646,7 +1647,7 @@ msgstr "se esperan demoras"
 msgid "Explore stations by mode"
 msgstr "Explora estación por modo"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Autobús exprés"
@@ -1678,7 +1679,7 @@ msgstr "Información sobre la instalación"
 msgid "Facility Issue"
 msgstr "Problema de la instalación"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Paquete familiar de 4 (2 adultos, 2 niños)"
@@ -1776,7 +1777,7 @@ msgstr "Actualizaciones y proyectos destacados de la MBTA"
 msgid "Ferry"
 msgstr "ferry"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "ferry "
@@ -1919,7 +1920,7 @@ msgstr "Para preguntas o comentarios sobre este comunicado de prensa, por favor 
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Para el servicio regular del Día de semana a Foxboro por favor visite: "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evento Especial de Foxboro"
@@ -1942,7 +1943,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "Parqueadero seguro gratis para pedales y parqueadero"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Servicio gratis"
@@ -1962,7 +1963,7 @@ msgstr "De"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Andén de nivel alto completo para proporcionar un abordaje nivelado a cada vagón de un tren"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2043,7 +2044,7 @@ msgstr "Green Line %{branch} Rama"
 msgid "Group Name"
 msgstr "Nombre del grupo"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Ferry Harbor Loop"
@@ -2069,7 +2070,7 @@ msgstr "Escóndete"
 msgid "Hide Details"
 msgstr "Ocultar detalles"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2171,17 +2172,17 @@ msgstr "Ventas institucionales"
 msgid "Intended Audience"
 msgstr "Público objetivo"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "%{zone}Interzona"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Duración inválida"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarifa inválida"
@@ -2421,7 +2422,7 @@ msgstr "Cargando salidas de Próximo"
 msgid "Lobby inside Back Bay station"
 msgstr "Vestíbulo dentro de la estación Back Bay"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Colectivo local"
@@ -2449,7 +2450,7 @@ msgstr "Ubicación no disponible"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
@@ -2470,7 +2471,7 @@ msgstr "Objetos Perdidos y Objetos"
 msgid "Lost and Found"
 msgstr "Objetos extraviados"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2691,8 +2692,8 @@ msgstr "Autoridad de Transporte de la Bahía de Massachusetts, todos los derecho
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport enlace"
@@ -2793,7 +2794,7 @@ msgstr "Día de los caídos"
 msgid "Menu"
 msgstr "Menú"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militar"
@@ -2856,23 +2857,23 @@ msgstr "mensual"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensual"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "Mensual Colectivo Pase local"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "mensual pase"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mensual pase en mTicket App"
@@ -3077,7 +3078,7 @@ msgstr "Notas"
 msgid "Notice"
 msgstr "Aviso"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3121,12 +3122,12 @@ msgstr "A tiempo"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampas a bordo en la puerta principal de cada colectivo"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Pase de un día"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "solo ida"
@@ -3480,12 +3481,12 @@ msgstr "Los horarios previstos de salida aún no están disponibles, pero aparec
 msgid "Prefer accessible routes"
 msgstr "Prefiere rutas accesibles"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Atracción Premium"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarifa Premium Ride"
@@ -3692,7 +3693,7 @@ msgstr "no se permitirá el pasajero sin boleto de coincidencia para abordar Bos
 msgid "Right"
 msgstr "Derecha"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ida y vuelta"
@@ -3933,7 +3934,7 @@ msgstr "Seleccionar"
 msgid "Send Us Feedback"
 msgstr "Envíanos tus comentarios"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "adultos mayores CharlieCard o TAP ID"
@@ -3943,7 +3944,7 @@ msgstr "adultos mayores CharlieCard o TAP ID"
 msgid "Senior ID Cards"
 msgstr "Tarjetas de identificación de adultos mayores"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "adultos mayores"
@@ -4043,8 +4044,8 @@ msgid "Showing major stops."
 msgstr "Mostrando atajada importantes."
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "enlace"
@@ -4181,7 +4182,7 @@ msgstr "Perdona. Tuvimos problemas para cargar tu imagen. Por favor, inténtalo 
 msgid "Southbound"
 msgstr "Dirección sur"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Boleto de Eventos Especiales"
@@ -4216,13 +4217,13 @@ msgstr "Características de la estación"
 msgid "Station Issue"
 msgstr "problema en la estación"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estación que atiende a las líneas MBTA %{lines} %{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4284,12 +4285,12 @@ msgstr "Atajada"
 msgid "Stops Skipped"
 msgstr "Paradas desvío"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudiante"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "CharlieCard de estudiante"
@@ -4312,7 +4313,7 @@ msgstr "Presentar una solicitud de acceso a registros públicos a la MBTA"
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "Subterráneo"
@@ -5140,8 +5141,8 @@ msgstr "Sitio web"
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Fin de semana pase"
@@ -5167,11 +5168,6 @@ msgstr "Qué está pasando en la MBTA"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Cuando"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5251,12 +5247,12 @@ msgid "Zone"
 msgstr "Zona"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zona %{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zonas 1A-10"
@@ -5321,7 +5317,7 @@ msgstr "autobús"
 msgid "bus stop"
 msgstr "parada de autobús"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Efectivo"
@@ -5336,7 +5332,7 @@ msgstr "Cambio"
 msgid "changes"
 msgstr "Cambios"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "Pago sin contacto"
@@ -5408,7 +5404,7 @@ msgid "location"
 msgstr "Ubicación"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplicación mTicket"
@@ -5448,7 +5444,7 @@ msgstr "A"
 msgid "or"
 msgstr "o"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "o "
@@ -5468,7 +5464,7 @@ msgstr "o pagar con Efectivo en cualquier colectivo"
 msgid "outbound"
 msgstr "salida de la ciudad"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papel ferry Boleto"
@@ -5658,8 +5654,8 @@ msgstr "Sitio web"
 msgid "west"
 msgstr "Oeste"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5669,3 +5665,13 @@ msgstr "con"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Con tu petición."
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5547,9 +5547,9 @@ msgstr "Con tu petición."
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "Zona 1A del Puerto Interior"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop y Quincy Ferry"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -11,5668 +11,5546 @@ msgstr ""
 "Language: fr_FR\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " & Arrêts"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " Un service supplémentaire entre Boston, Hingham et Hull est disponible via la %{link}"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " Elle circule sur des arrêts limités entre Foxboro et soit Providence soit Downtown Boston (South Station)"
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " Lignes"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " Itinéraires"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " Le service se poursuit plus tard dans la journée dans la direction opposée. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " Le service est disponible plus tôt dans la journée dans la direction opposée. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Les trains partent de Foxboro 30 minutes après la fin des événements"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " alerte"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " à "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " à %{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " À ce moment-là."
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " Cela dépend de la distance parcourue (zones). Veuillez consulter les informations ci-dessous :"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " pour les modifications de suivi en temps réel."
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " pour le "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " est arrivé à "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " arrive à "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " est en route vers "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " peut partir avant l’horaire à ces arrêts."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " Minute à pied"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " sur "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " sur le "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " Sur la piste "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " ou "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " horaire"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " Horaire et carte"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " symbole. Vérifié "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " qu’ils souhaitent partir. le passage en attente de monter à bord doit être visible sur le quai pour le "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " D’arrêter."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "« Distance à pied »"
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg} minutes"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count} Arrêts"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count} alerte"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count} plus tard %{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date} à %{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date} à %{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date} est en dehors de notre horaire actuel."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date} jusqu’à nouvel ordre"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max} minutes"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1} et %{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label} Seulement"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name} Train de banlieue"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "%{place} Informations"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating} travaux planifiés"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating} horaire, fin %{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating} horaire, commence %{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name} à %{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time} sur %{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y} de %{x} de travailler"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ", "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ", Espèces, ou "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "1 Itinéraire accessible"
 msgstr[1] "%{count} itinéraires accessibles"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "1 Itinéraire inaccessible"
 msgstr[1] "%{count} Itinéraires inaccessibles"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "1 Itinéraire indisponible"
 msgstr[1] "%{count} itinéraires indisponibles"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 alerte"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "1 résultat"
 msgstr[1] "%{count} résultats"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "1 arrêt"
 msgstr[1] "%{count} arrêts"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "Un voyage plus tard aujourd’hui"
 msgstr[1] "%{count} voyages plus tard aujourd’hui"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Titre de transport d’un jour"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 zones où l’aide à la mobilité à roues peut être sécurisée"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "24 heures sur 24, 7 jours sur 7"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Titre de transport de 7 jours"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 pour les appelants TTY ;  VRS pour les appelants ASL"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Attraction ADA"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarif des courses ADA"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/accessibilité Réclamations"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "À propos"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "Accès"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "Problème d’accès"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "Problèmes d’accès"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "accessibilité"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "Ressources d’accessibilité"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "L’accessibilité chez %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "accessible"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Ajouter"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "Ajouter %{title} au calendrier"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "Ajouter un événement au calendrier"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "Ajouter au calendrier"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "Réservé aux administrateurs"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulte"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "Ordre du jour"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "alerte"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "alerte"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "alerte pour le MBTA %{description}"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "Tous en alerte"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "Tous les postes Boston Stadium train incluent un aller-retour après le match. Les trains commenceront à partir de Foxboro gare 30 minutes après le coup"
 " de sifflet final. Les trains de retour quitteront le stade environ toutes les 15 minutes jusqu’à ce que tous les trains soient partis."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "Tous à l’arrivée Trains"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "Tous les types de lieux"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "Tous les projets d’amélioration du MBTA"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "Tous en partance Trains"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "Tout horaire et cartes"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "Tous les trains"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "Tous les trains annulés"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "Toutes les mises à jour"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Toutes les routes de ferry"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "Tous les champs avec un astérisque* sont obligatoires."
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "Tous les modes"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "Tous les emplacements proposés sont soumis à l’adéquation du site, aux autorisations et à la disponibilité en magasin."
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "Alerte Amber"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Une photo extérieure de l’entrée de la station Downtown Crossing. Des drapeaux américains bordent la rue, et des gratte-ciel sont visibles en arrière-plan."
 " Beaucoup de piétons passent à côté."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "proche"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "Arrivée par"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "Arrivée"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "Arrivée par %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "Chez distributeur de titres de transport, vous pouvez"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "À la gare avec plusieurs voies à l’extérieur des gares Nord, Sud, Back Bayet Ruggles , les trains à l’arrivée montent à bord depuis la voie 2, et en partance"
 " trains montent à bord depuis la voie 1, sauf indication contraire. Les changements de voie programmés seront indiqués par le "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Participants"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "Données de cartes tarifaires regroupées incorrectes"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "Politique des sacs et articles interdits"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "Sois à South Station heure indiquée pour ton groupe d’embarquement. Votre groupe d’embarquement est inscrit sur votre billet pour le Boston Stadium Train."
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "Avant aujourd’hui"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "Projet Better Bus"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "Les vélos sont-ils autorisés ?"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "Vélos autorisés"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "Les vélos sont autorisés dans les trains avec le symbole vélo sous le numéro du train, sous réserve de restrictions."
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "Les vélos sont interdits"
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "vélo"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "Problème de vélo"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "vélo Storage"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "vélo Storage à %{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "vélo"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "vélo autorisé"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "Les vélo sont autorisés sur tous les ferry bateaux"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line métro quai à l’intérieur de State Street"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line train au départ Airport station"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "Internat"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "Groupe d’Embarquement A"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "Groupe d’accueil B"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "Groupe d’embarquement C"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "Groupe d’accueil D"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "Groupe d’accueil E"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "Groupes d’accueil"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Boston Stadium Poste de train requis"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "Boston Stadium billet de train doit être acheté à l’avance sur l’application mTicket . Pour plus d’informations, consultez notre %{world_cup_link}"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Trains"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "Guide du visiteur de Boston pour le métro"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "Les deux directions"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "Emmener votre voiture ou votre vélo"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "bus"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "bus %{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "Guide du débutant dans le bus"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "Tarifs de bus"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "Caractéristiques des bus"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "Carte des bus"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "bus Autres"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "Ligne de bus"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "arrêt de bus"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "Changements d’arrêt de bus"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "Bus abaissable pour faciliter l’embarquement et la sortie"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Affaires"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "Opportunités d’affaires"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "Vue calendrier"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "Appel"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "Appelez-nous"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Annuler"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "annulation"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "annulation"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Annulé"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "Capital Transformation"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "Carrières"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "Espèces"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Changement"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "Date de changement"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "Changer de direction du voyage."
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "Changements"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "Charlie Retailer"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCards"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & poste"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "Vérifié"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "Enregistrement à South Station"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Enfant"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Enfants de moins de 3 ans"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "Choisissez votre langue"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "Choisissez un type horaire parmi les options disponibles"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "Le jour de Noël"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "Droits civiques"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "Graphique cliquable pour les usagers Guides"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Fermer"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "Dialogue fermé"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "Pièce"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "Journée de Christophe Provincial"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Commentaire"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Ferry-banlieue vers Logan Airport"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "Train de banlieue"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Train de banlieue "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "Train de banlieue Fares"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "Carte du Train de banlieue"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "Train de banlieue mensuel titre de transport"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "Train de banlieue aller simple"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "Train de banlieue Contrôle positif de train"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "Train de banlieue Statut"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "Carte des zones du Train de banlieue"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "La disponibilité des sièges du train de banlieue est régulièrement mise à jour pour refléter la fréquentation typique d’un trajet basée sur les données"
 " automatisées et des contrôleurs des 14 à 30 derniers jours."
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "Réclamations"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "Compliment"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Contactez-nous"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "Numéros de contact"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "Contactez l’équipe client du service MBTA et consultez les numéros de contact supplémentaires pour la Police des Transports, les Objets trouvés et l’accessibilité."
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "Contactez la police des transports"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continuez"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "Coût"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "Supports vélo couverts"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "Des supports vélo couverts sont disponibles"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "Créez un compte"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "Carte de crédit/débit"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "Cartes de crédit/débit"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Ferry de Cross Harbor"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "Crosstown"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "Bondé"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "Actuel"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "Alerte actuelle"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "Évolutions actuelles"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "Situation actuelle"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "Les seuils actuels de disponibilité des sièges sont :"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "Service client"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Quotidien"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "Horaire quotidien"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Date"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "Date et heure"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Day titre de transport"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "retard"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "Retard %{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "retard"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "Départ"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "Départ à"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "Départs"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "L’emplacement de la destination n’est pas assez proche des arrêts de transit"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "La destination se trouve en dehors de notre zone de service"
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "Destinations"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "Détails"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "déviation"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Développeurs"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "Affichages numériques et annonces automatisées qui partagent les lignes principales et les informations des arrêts"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "Direction de votre voyage"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "Cartes d’identité de handicap"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "quai fermeture"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "Problème de quai"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "Documents"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "Ça ne s’arrête pas à"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "En raison du suivi unique"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "Carte EBT"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ titre de transport"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "Plus tôt"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "Première arrivée"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "Départ anticipé"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "Arrêt de départ anticipé"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "Direction est"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "Ascenseur"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "Ascenseur & Escalator"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "Fermeture de l’ascenseur"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "Fermeture de l’ascenseur"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "Ligne d’assistance ascenseur/escalators"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "Ascenseurs"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "Ascenseurs à %{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "situation d’urgence"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "situation d’urgence Contacts"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "Employé"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "Réclamations des employés"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "Terminé"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "Normes de conception technique"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "Saisissez une destination"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "Entrée d’un lieu"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "Entrer un lieu d’origine"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "Saisissez le ou les mots-clés"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "Saisissez les mots-clés du projet"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "Voici le station"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "Entrez dans le cercle routier"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "Saisissez votre adresse enregistrée"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "entrée à Blue et Green Lines à l’extérieur de Government Center"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "entrée à Green et Red Lines à l’extérieur de Park Street"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "entrée à Orange et Red Lines à l’extérieur de Downtown Crossing"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "Entrée à Ruggles station"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "entrée à Red Line et Train de banlieue à l’extérieur de South Station"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Erreur"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "Escalatore"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "Escalator (seulement en descente)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "Escalator (montée et descente)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "Escalater (uniquement en montée)"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "Fermeture de l’escalator"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "Fermeture de l’escalator"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "Escalators"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "Escalators à %{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "Arrivée estimée à la station de Foxboro"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "Description de l’événement"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "Résumé de l’événement pour "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "Événements"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "Sortez de la station"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "retard attendu"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "Explorez la station par mode"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Bus express"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "Bus express aller simple"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Extérieur de Wonderland station"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "Service supplémentaire"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "Informations sur l’installation"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "Problème d’installation"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Famille 4-pack (2 adultes, 2 enfants)"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "Évasion tarifaire"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "Options tarifaires"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "Options tarifaires à %{name}"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "Politique tarifaire"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "Points de vente au détail tarifaires"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "Transformation tarifaire"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "Types tarifaires"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "distributeur de titres de transport"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "distributeur de titres de transport"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "Tarifs"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "Informations sur les tarifs"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "Aperçu des tarifs"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "Tarifs par mode"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Les tarifs diffèrent entre les ferries Hingham/Hull et Charlestown ferrys. Veuillez consulter les informations ci-dessous :"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "Mises à jour et projets MBTA à l’honneur"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "ferry"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "ferry "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "Tarifs du ferry"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "Carte des ferries"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "Ferry mensuel titre de transport"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "Peu de places disponibles"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "Déposez une plainte pour discrimination"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "Remplissez le formulaire"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "Filtrer par type"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "Finances"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "Trouvez les emplacements proposés près de chez vous"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "Trouvez votre bureau de vote"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "Trouver un lieu"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "Trouvez un magasin près de chez vous"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "Découvrez comment vous impliquer"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "Terminer un autre voyage"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "Première %{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "Arrêt du drapeau"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "Signalez le bus dans n’importe quel endroit sûr le long de la route"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "Suivez@MBTA sur Twitter"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "Suivez@MBTA_CR sur Twitter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "Suivez les panneaux"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "Suivez le lien ci-dessous pour trouver le numéro associé au mode ou à l’itinéraire où vous avez perdu votre objet."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "Pour les tarifs des bus express, lisez la page complète de %{link} ."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "Pour toutes les informations sur le service ferroviaire pour la Coupe du Monde, consultez notre %{world_cup_link}"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "Pour plus d’informations"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "Pour toute question ou commentaire concernant ce communiqué de presse, veuillez contacter"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Pour un service régulier en semaine vers Foxboro veuillez visiter : "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Événement spécial de Foxboro"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Ligne Franklin"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratuit"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "Parking sécurisé gratuit pour pédales et parking"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Service gratuit"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "Vendredi"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Quai surélevé complet pour assurer l’embarquement à niveau de chaque wagon d’un train"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "Obtenez votre itinéraire"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "Impliquez-vous"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "Recevez des mises à jour sur le service"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "Va T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "Procurez-vous une CharlieCard"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "Recevez une facture par la poste moyennant des frais de 1 $"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "Obtenez votre chemin vers ce parking"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "Faites connaissance avec nous"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "Obtenez des suggestions de voyage"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "Allez"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "Aller à un match de Coupe du Monde au Boston Stadium ?"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Green Line %{branch} Branche"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "Nom du groupe"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Ferry Harbor Loop"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "Virage à gauche serrée"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "À droite complètement"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Cache-toi"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "Masquer les détails"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Hingham/Hull ferry"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Histoire"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "Horaire de vacances"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "Fêtes"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Accueil"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Adresse domiciliaire"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "Touche d’icône"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "Si applicable, veuillez indiquer l’heure et la date de l’incident, l’itinéraire et le numéro du véhicule."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "Si vous avez fourni vos coordonnées, vérifiez votre e-mail pour une confirmation avec un numéro d’incident. Si vous ne recevez pas de confirmation dans"
 " les 10 minutes, essayez de soumettre à nouveau votre retour ou appelez-nous à"
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "Si vous souhaitez que nous vous appelions, veuillez nous indiquer le meilleur numéro où nous pouvons vous joindre."
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "Si vos droits civils ont été violés, vous pouvez déposer une plainte auprès du Bureau de la diversité et des droits civils de la MBTA."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "Informations importantes"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "Liens importants"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "à l’arrivée Trains annulés"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "Fête de l’Indépendance"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "Informations et support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "Ventes institutionnelles"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "Public visé"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Interzone %{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Durée invalide"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarif invalide"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "Facture"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "Est-ce utile ? Envoyez-nous vos retours"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "Sauter à"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "Journée de l’Indépendance du Juneteenth"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "Connaissez votre groupe d’embarquement"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "Vous connaissez un propriétaire de magasin local qui pourrait être intéressé par notre réseau de vente au détail ? Suggérez un revendeur et nous le contacterons"
 " en votre nom."
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "Fête du Travail"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "Services linguistiques"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Langues"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "Dernier"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "Dernier %{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Plus tard"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "Direction"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "En savoir plus sur CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "En savoir plus sur les tarifs MBTA"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "En savoir plus sur l’accessibilité dans le métro"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "En savoir plus sur le stationnement vélo au métro"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "En savoir plus sur le stockage vélo à ce station."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "En savoir plus sur le vélo sur Train de banlieue"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "En savoir plus sur l’accessibilité des bus"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "En savoir plus sur les tarifs, les types de titre de transport et comment payer votre billet dans le métro."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "En savoir plus sur les tarifs"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "En savoir plus sur l’accessibilité ferry"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "En savoir plus sur le dépôt d’une réclamation"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "En savoir plus sur le stationnement au métro"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "En savoir plus sur le tarif réduit et son éligibilité"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "En savoir plus sur les tendances de disponibilité des places"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "En savoir plus sur les fonctionnalités d’accessibilité à ce %{place}."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "En savoir plus sur ce projet"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "Découvrez ce qui se passe après avoir déposé une réclamation"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "Moins de marches"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "Laisser à"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "Partir à %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "À gauche"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "Faites-le nous savoir"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "Lignes et itinéraires"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "Vue de liste"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "Alertes de service en direct pour tous les modes de transport de la MBTA, y compris le métro, le bus, le Train de banlieue et ferry. Mises à jour sur les"
 " retardés, travaux, pannes d’ascenseur, et plus encore."
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Chargez plus"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "Chargement des arrivées..."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "Chargement de l’horaire pour un service sélectionné"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "Détails du trajet de chargement"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "Chargement des départs à venir"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Hall d’entrée à l’intérieur de la station Back Bay"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Bus local"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "Aller de bus local simple"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Emplacement"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "L’emplacement n’est pas assez proche des arrêts de transit"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "Emplacement indisponible"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "Longue rampe"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "Objets Trouvés et Objets Trouvés"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "Objets trouvés"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "La MBTA %{name} %{type} gare et horaire, incluant cartes, mises à jour en temps réel, informations sur le stationnement et l’accessibilité, ainsi que correspondances."
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "%{route_name} %{station_name} et horaire MBTA, incluant horaires, cartes, tarifs, mises à jour en temps réel, informations sur le stationnement et l’accessibilité,"
 " ainsi que correspondance."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "Les arrêts et horaires du MBTA %{text} , incluant cartes, informations sur le stationnement et l’accessibilité, ainsi que les tarifs."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "La MBTA %{type} itinéraire %{name} arrêts et horaires, incluant cartes, mises à jour en temps réel, informations sur le stationnement et l’accessibilité,"
 " ainsi que correspondances."
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - Autorité des transports de la baie du Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "MBTA Facebook"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "Tarifs MBTA"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "Boutique de souvenirs MBTA"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "La MBTA Green Line la station de tramway et l’horaire, incluant cartes, mises à jour en temps réel, informations sur le stationnement et l’accessibilité,"
 " ainsi que correspondance."
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "Page d’accueil de la MBTA"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "Page d’accueil de la MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "MBTA Instagram"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "Programme adapté MBTA Transport"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "Projets/programmes MBTA"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "Station MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "Fils de discussion MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "Police de transport de la MBTA"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "MBTA Planificateur de trajet"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "MBTA Twitter"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "Guides d’utilisation du MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "MBTA YouTube"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA distributeur de titres de transport"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "Les voyageurs MBTA peuvent acheter des CharlieTickets, recharger et acheter %{charlie_card} pour le bus, le métro, le Train de banlieue et ferry dans des"
 " détaillants de toute la Grande Boston et Providence régions."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "MBTA.com Dernières actualités"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "MBTA.com Menu"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Principaux"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "Ligne directe principale"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "maintenance"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "Réclamations de maintenance"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "Fais demi-tour"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "Dirigé par"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "De nombreux sièges disponibles"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Cartes"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "Jour de Martin Luther King, Jr."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "Autorité des transports de la baie du Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "Massachusetts Bay Transportation Authority, tous droits réservés."
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport navette"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport navette %{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "Match 18"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "Match 30"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "Match 45"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "Match 5"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "Match 61"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "Match 74"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "Match 97"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "Poste de correspondance requis "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Ce n’est peut-être pas accessible"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "Informations de contact médias"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "Relations avec les médias"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "Informations sur la réunion"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "Les membres de la presse peuvent demander à rejoindre notre liste média en envoyant un e-mail "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "Les membres du public ont le droit de demander des copies des documents MBTA, à quelques exceptions près. Des frais s’appliquent et peuvent varier selon"
 " la demande."
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "Memorial Day"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militaire"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "Mini quai surélevé pour assurer l’embarquement à niveau de certains wagons dans un train"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "Procès-verbal"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "Application mobile"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "Poste mobile"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "Modes"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "Modes de transport"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "lundi"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "Du lundi au vendredi"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "Du lundi au vendredi"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "Du lundi au vendredi"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "mensuel"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensuel"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "mensuel Titre de transport de bus local"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "mensuel titre de transport"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mensuel titre de transport sur mTicket App"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "Plus de guides"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "Plus d’informations"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "Plus de "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "Les plus directs"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "Tarifs les plus populaires"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "La plupart, mais pas tous, des quai MBTA sont accessible à un passager avec un handicap. Selon le niveau de marée et le type de navire utilisé pour la"
 " navigation, vous pouvez rencontrer des pentes importantes et des passerelles étroites, même à accessible quai. Au quai, attendez qu’un membre d’équipage"
 " vous dise qu’il est sûr de continuer."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Navigation Menu"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Nouveau"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "Jour de l’An"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "Actualités"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Suivant"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "La semaine prochaine"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "Prochain arrêt"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "Aucune alerte %{group}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "Aucun service programmé"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "Aucun service"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "Aucune alerte ici."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "Aucun changement n’a été publié pour les 7 jours suivants"
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "Aucun événement"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Pas de stationnement"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "Pas de service aujourd’hui"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "Aucune correspondance de transit n’a été trouvée entre l’origine et la destination à cette date et heure"
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "Aucun mode de transport n’est sélectionné"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "Aucun itinéraire de transit n’a été trouvé dans les 2 heures suivant %{time_on_date}. Des itinéraires peuvent être disponibles à d’autres moments."
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "Aucun trajet trouvé"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "Pas de fêtes à venir"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "service normal"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "Direction nord"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "Non accessible"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "Non disponible"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "Pas bondé"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Note"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Note :"
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notes"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "Avis"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Maintenant"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "Maintenant à"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "Observé"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "Site officiel de la MBTA — horaire, cartes et informations tarifaires pour le système de transport en commun du Grand Boston, y compris le métro, le Train"
 " de banlieue, les itinéraires bus et les lignes de bateaux."
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "Site officiel de la MBTA — Planifiez un voyage en transports en commun dans la région du Grand Boston"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "Oh non ! Nous sommes en train de souffrir de retard."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "À l’heure"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampes d’embarquement à la porte d’entrée de chaque bus"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Titre de transport d’un jour"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "aller simple"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "en cours"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "Seuls les portefeuilles ou petits sacs transparents sont autorisés. Les objets interdits doivent être jetés avant l’embarquement."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "Ou,"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "Ou, allez à "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "Ordre mensuel titre de transport"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "L’emplacement d’origine n’est pas assez proche des arrêts de transit"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "L’emplacement d’origine est situé en dehors de notre zone de service"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "L’origine ou le lieu de destination se situe en dehors de notre zone de service"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Autres"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "Autres horaires"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "Notre travail"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "Nos guides d’utilisation peuvent vous aider à apprendre à naviguer dans le système, à vous rendre aux événements locaux, à utiliser les fonctionnalités"
 " d’accessibilité, et bien plus encore."
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "Hors de l’ordre"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "Trains en partance annulés"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "Supports vélo extérieurs"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "Des supports vélo extérieurs sont disponibles"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "Une nuit"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Aperçu"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF horaire"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF à venir"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Page non trouvée | MBTA - Autorité des transports de la baie du Massachusetts"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "Page non trouvée"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Pages"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "Transport adapté (The RIDE)"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "Stationnement"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "Fermeture de stationnement"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "Problème de stationnement"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "Tarifs de stationnement"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "Parking à %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Places de stationnement disponibles"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "Le passager doit le dire "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "Changements passés"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "Journée des patriotes"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "Payez votre billet"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Méthodes de paiement"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personnalités"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "Des gens attendent l’arrivée du train de la ligne orange à l’intérieur North Station"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "Les gens marchant au départ du train monter à bord à l’intérieur North Station"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "Des gens marchant vers Green Line train à l’intérieur North Station"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "Performances"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "Planifiez votre parcours"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "Planifiez un voyage"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "Planifiez un voyage accessible"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "Planifiez votre voyage"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "Alertes de service planifiées"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "travaux planifiés"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "Veuillez entrer un commentaire pour continuer."
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "Veuillez entrer un e-mail valide."
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "Veuillez entrer un numéro de véhicule valide avec uniquement des caractères numériques."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "Veuillez entrer une adresse située à moins de 100 miles d’une zone de service MBTA."
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "Veuillez entrer votre prénom pour continuer."
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "Veuillez entrer votre nom Dernier pour continuer."
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "Veuillez sélectionner une destination à un endroit différent de celui d’origine."
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "Veuillez sélectionner un lieu de destination."
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "Veuillez sélectionner un lieu d’origine."
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "Veuillez sélectionner au moins un mode de transport."
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "Veuillez sélectionner le type de préoccupation."
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "Veuillez préciser une date et une heure à l’avenir ou sélectionner « Maintenant »."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "Veuillez réessayer ou nous envoyer vos retours à mbta.com/customer-support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "Politiques et droits civils"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "Changement de politique"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "Ascenseur d’embarquement portable"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "Publié sur"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "Les heures de départ prévues ne sont pas encore disponibles, mais elles apparaîtront ici avant le premier voyage prévu."
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "Préfère accessible itinéraires"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Attraction Premium"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarif Premium Ride"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "Communiqués de presse"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "Version Aperçu"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Précédent"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "Projets"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "Emplacements de vente proposés"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "Réunions publiques"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "Les transports en commun dans la région du Grand Boston. Itinéraires, horaire, Planificateur de trajet, tarifs, alertes de service, mises à jour en temps"
 " réel et informations générales."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "Achetez des billets pour Charlie"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "Achetez une CharlieCard ou rechargez une existante"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "Achetez les tarifs sur distributeur de titres de transport."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "Achetez les tarifs dans les points de vente au détail à proximité."
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "Qualité, conformité et supervision"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "Quarts de finale"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "Question"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "rail"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "Lisez notre %{world_cup_link}"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "Recevez des notifications d’alertes de service MBTA par e-mail ou SMS."
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "Dernières actualités sur le métro"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "Horaire récemment visité"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "Tarif réduit"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "Inscrivez votre CharlieCard pour le parking vélo"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "Fichiers associés"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "Alertes de service connexes"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "Signaler la fraude, le gaspillage ou les abus"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Signaler un problème de porte de passage à niveau"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "Signaler un problème d’accessibilité"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "Signaler un problème d’ascenseur"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "Signalez un problème escalator"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "Signaler une fraude, un gaspillage ou un abus suspecté"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "Demande de documents publics"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "Points de vente au détail"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "Voyage retour inclus"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "Roulez sur le %{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "Prenez le train %{route} %{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "les passagers sans billet de correspondance ne seront pas autorisés à monter à bord Boston Stadium les trains."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "Exact"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "aller-retour"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "Huitièmes de finale"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "Itinéraire %{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "Itinéraire %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Itinéraires"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "Itinéraires avec alerte haute priorité"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sécurité"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "Samedi"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "Horaire & Cartes"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "Changement d’horaire"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "horaire pour"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "informations horaires pour les lignes MBTA Train de banlieue dans la région du Grand Boston, incluant des mises à jour en temps réel et des prédictions"
 " d’arrivée."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "informations horaires pour les itinéraires MBTA bus dans la région du Grand Boston, incluant des mises à jour en temps réel et des prévisions d’arrivée."
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "informations horaires pour les itinéraires MBTA ferry opérant dans la baie du Massachusetts, y compris des PDF téléchargeables."
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "informations horaires pour les lignes de métro MBTA dans le Grand Boston, incluant des mises à jour en temps réel et des prévisions d’arrivée."
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "informations horaire pour le métro, bus, Train de banlieue et ferry MBTA dans la région du Grand Boston, incluant des mises à jour en temps réel et des"
 " prévisions d’arrivée."
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "horaire sera bientôt disponible sur le site web de la MBTA."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Programmé"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "Le service régulier se poursuit jusqu’à %{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "Départ prévu"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "horaire"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "Horaire & Cartes"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "Horaire et cartes"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "Uniquement les jours scolaires"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Recherche"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "Recherche MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "Recherche d’un arrêt ou d’une station"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "Recherchez des itinéraires, des lieux, des informations et plus encore"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "Résultats de recherche pour"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "Recherche dans le MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "Saisonnier"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "Service saisonnier"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "Disponibilité des sièges"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "Site officiel du secrétaire de State"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "Un parking sécurisé est disponible mais nécessite l’enregistrement préalable de la carte Charlie."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "Voir alerte"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "Tu vois quelque chose, dis quelque chose"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "Voir tous les communiqués de presse"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "Voir toutes les réunions et événements publics"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "Voir toutes les alertes de service"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "Voir tous les guides d’utilisation"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "Voyez ce que vous pouvez apporter sur Boston Stadium Trains"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Sélectionner"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "Envoyez-nous vos retours"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "personnes âgées CharlieCard ou TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "Cartes d’identité personnes âgées"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "personnes âgées"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "Problème de serveur"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "Service"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "alertes de service"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "changement de service"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "Service Réclamations"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "Demande de service"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "alertes de service ou retard"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "changement de service est en vigueur du 6 juin au 12 juillet. Vérifiez chaque jour de la %{timetable_link} de votre ligne pour trouver l’horaire le plus"
 " récent."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "Service terminé"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "Le service fonctionne comme prévu"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "Service à la Coupe du Monde"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "Voyage le plus court"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Émission"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "Détails de l’émission"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "Moins d’arrêts"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "Montrer plus d’arrêts"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "Affichage de tout"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "On voit des arrêts majeurs."
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "navette"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "navettes"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "Inscrivez-vous à alertes de service"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "Connexion"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "Inscrivez-vous au paiement automatique"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "Inscrivez-vous aux T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "Inscrivez-vous pour recevoir des notifications d’alerte"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "Un voyage similaire arrive à %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "Un trajet similaire part à %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "Des trajets similaires arrivent à %{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "Des trajets similaires partent à %{times}"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "Suivi simple"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "Contourner vers le contenu principal"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "contourner"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "Légèrement à gauche"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "Légèrement à droite"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "Carte à puce"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "Route de la neige"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "Pelletage de neige"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "Quelques sièges disponibles"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "Un peu de surpeuplement"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "Quelque chose a mal tourné de notre côté."
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "Désolé ! On a raté ton arrêt."
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "Désolé. Quelque chose a mal tourné. Veuillez réessayer."
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "Désolé. Nous avons eu des difficultés à télécharger votre image. Veuillez réessayer."
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "Direction sud"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Poste d’événement spécial"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "Poste spécial requis"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "Station & alertes de service"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "Accessibilité de la station"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "Fermeture de la station"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "Caractéristiques de la station"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "Problème de la station"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "station desservant les lignes MBTA %{lines} %{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "station"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "gare et stationnement"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "Gare et arrêts"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Statut"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "Arrête %{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "fermeture de l’arrêt"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "arrêt reporté"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "Contourner d’arrêt"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "Arrêts"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "Contourner des jeux"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Étudiant"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "CharlieCard étudiante"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "Soumettre"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "Soumettez une demande de documents publics auprès de la MBTA"
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "métro"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "Guide du débutant dans le métro"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "Tarifs du métro"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "Carte du métro"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "métro aller simple"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "Statut du métro"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "Suggérez un détaillant"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Résumé"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "Suspension"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Durabilité"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "Lieux d’origine et de destination de l’échange"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "À l’échelle du système"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "TAlerts/Comptes/Applications"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "Téléphone TTY"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "Prenez le métro pour voter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Prends l’ascenseur"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "Prendre le train pour un match de Coupe du Monde ?"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "Dites-nous ce que vous en pensez"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "Parlez-nous de vos déplacements réguliers et recevez des SMS ou des alertes par email qui vous concernent, au moment où vous en avez besoin."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "Temporairement indisponible"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "Temporairement fermé"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "Issue temporaire"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "Issue temporaire"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "Conditions d’utilisation"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "Merci d’avoir envoyé votre retour. Notre équipe client Service examinera bientôt vos commentaires."
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "Jour de Thanksgiving"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "Le "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "Le coordinateur de l’engagement client en accessibilité à l’échelle du système et liaison client pour The RIDE est responsable de coordonner les résolutions"
 " des réclamations ADA/accessibilité une fois qu’elles sont reçues."
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "La file des événements spéciaux de Foxboro est réservée à des services occasionnels."
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "L’Unité d’audit spécial interne au sein du Bureau de l’Inspecteur général surveille la qualité, l’efficacité et l’intégrité des programmes MassDOT."
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "Le manège"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "Le planning interactif pour"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "Il n’y a actuellement aucun départ en temps réel disponible."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "Il n’y a actuellement aucun départ en temps réel disponible. Les départs programmés sont indiqués ci-dessous."
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "Il n’y en a pas"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "Il n’y en a pas "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "Il n’y a pas de fonctionnalités d’accessibilité supplémentaires, mais les bus sont toujours accessible au monter à bord."
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "Il n’y a aucune alerte"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "Il n’y a pas de priorité élevée"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "Il n’y a pas d’autres alertes Train de banlieue pour le moment."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "Il n’y a pas d’autre alerte métro pour le moment."
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "Il n’y a pas de %{direction} prévus pour %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "Il n’y a pas de voyages %{direction} prévus."
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "Il n’y a pas de trajets programmés sur %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "Il n’y a pas de voyages programmés."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "Il n’y a pas de mises à jour pour le moment."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "Il n’y a actuellement aucun %{route_name}programmé."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "Il n’y a pas d’informations sur les travaux planifiés pour le moment."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "Il n’y a pas de service %{route} régulier à %{stop} pour cette période."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "Il y a eu un problème de chargement des arrivées"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "Il y a eu un problème de chargement horaire"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "Il y a eu un problème pour charger les détails du trajet"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "Il y a eu un problème de chargement des départs à venir"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "Cette %{place} n’est pas accessible."
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "Cette semaine"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "Cette liste n’inclut pas les détaillants MBTA actuels. Pour voir les points de vente actuels, utilisez notre"
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "Cette page n’est plus en service."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "Ce station ne dispose pas de stockage vélo."
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "Cette station ne possède pas d’ascenseurs."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "Cette station n’a pas d’escalators."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "Ce station n’a pas de stationnement."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "Cet arrêt ne dispose pas de distributeur de titres de transport, mais vous pouvez acheter des tarifs à un"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "Ce train a généralement<br /><strong>%{seats} places disponibles</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "Horaire"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "À"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "Pour signaler un problème ou une situation d’urgence à un passage à niveau, appelez"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "Pour soumettre une réclamation ou un retour selon l’ADA/accessibilité, veuillez appeler"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Aujourd’hui"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "Aujourd’hui à"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "Gratuit"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "Changement de planche sur voie"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "Changement de voie"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "Piste à déterminer"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "Suivez votre %{route_type_text} voyage en direct avec l’application <strong>MBTA Go</strong>"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Train"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "Train %{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "Train prévu pour un monter à bord au départ de %{platform} à %{station}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "Transfert"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "Transferts"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "Transport en commun"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "Police des transports"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "Voyagez partout sur les lignes Blue, Orange, Redet Green pour le même prix."
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "Voyage"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Planificateur de trajet"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "Type de trajet"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "Voyages de %{from} à %{to}"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "Essayez de chercher ce que vous cherchez ci-dessous."
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "Mardi, le 5 novembre est le dernier jour pour voter lors des élections générales de 2024. Utilisez le métro pour vous rendre à votre bureau de vote."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "En général, moins de 33 % des places sont disponibles et la distanciation est peu probable (~3+ personnes par rangée)"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "En général, plus de 33 % des sièges restent disponibles et il peut être possible de mettre de l’écart (~2-3 personnes par rangée)"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "En général, plus de 66 % des sièges sont disponibles et la distanciation est possible (~0-2 personnes par rangée)"
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "Piste non programmée"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "Jusqu’à %{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "à venir"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "Changements à venir"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "Départs à venir"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "Fêtes à venir"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "Réunions et événements publics à venir"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "Mis à jour le"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "Mise à jour : "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "Mises à jour"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "Utilisation"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "Guides utilisateurs"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "Jour des anciens combattants"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "Via"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Vue"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "Consultez %{timetable_link} pour les informations sur les départs."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "Alerte de vue"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "Voir tous les numéros de contact"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "Voir toutes les options"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "Voir la bio"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "Voir la biographie pour %{name}"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "Voir le PDF Horaire"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "Consultez le calendrier PDF sur le site web de la MBTA."
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "Voir Précédent"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Voir tout"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "Voir toutes les lignes de bus"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "Voir tous les événements"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "Voir tous les guides"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "Voir tous les matchs"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "Voir toutes les actualités"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "Voir toutes les mises à jour du projet"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "Voir tous les projets"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "Consultez les ascenseurs disponibles."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "Consultez les escalators disponibles."
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "Consultez les informations tarifaires courantes pour le MBTA bus, le métro, le Train de banlieue, ferryet The RIDE. Trouvez en ligne les services CharlieCard"
 " et découvrez les programmes de commande en gros."
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "Voir l’horaire du soir"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "Voir l’aperçu des tarifs"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Voir plus d’informations sur les paiements"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "Voir l’horaire du matin"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "Voir sur Google Maps"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "Voir sur MBTA Planificateur de trajet"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "Consultez les tarifs de stationnement, les informations sur les installations, et bien plus encore."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "Voir les numéros de téléphone"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visite"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "Visitez le Centre de Mobilité"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Votez"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "Attente des résultats"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "En attente de partir"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "Marche"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "Itinéraires à pied uniquement"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "L’anniversaire de Washington"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "Nous ne pouvons fournir que les données de trajet pour l’horaire %{rating} , valables jusqu’à %{end_date}."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "Nous avons eu un problème pour soumettre vos retours — veuillez nous appeler à la ligne principale ci-dessous, ou réessayer dans quelques minutes."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "Nous voulons nous assurer de construire un réseau de vente au détail qui vous convient. Vous pouvez partager vos retours via le formulaire ci-dessous."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "Nous n’avons pas réussi à trouver de bureau de vote pour votre adresse. Vous pouvez également visiter le"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "Nous vous enverrons directement les communiqués de presse et les avis médias de la MBTA."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "Nous demandons au public de nous aider à guider nos décisions alors que nous déployons le projet de Transformation Tarifaire au cours des prochaines années."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "Nous élargissons notre réseau d’endroits où les passagers peuvent obtenir ou charger une CharlieCard et acheter un titre de transport."
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Site web"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Titre de transport week-end"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "Week-ends"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "Direction ouest"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "Que se passe-t-il au MBTA"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Quand"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "Travaillez avec nous"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "Travaillez avec nous"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "Fonctionnement"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guide de la Coupe du Monde"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "Matchs de la Coupe du Monde"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "Écrivez-nous"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "Toute l’année"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "Vous pouvez aussi envoyer un e-mail"
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "Vous pouvez vous attendre à une réponse à la plupart des postes sous 5 jours ouvrés. Certaines réclamations peuvent nécessiter des enquêtes plus longues,"
 " jusqu’à 30 jours."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "Vous pouvez payer votre billet avec"
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "Vous devez accepter notre Politique de confidentialité avant de soumettre votre retour."
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Vous devez remplir le reCAPTCHA avant de soumettre vos retours."
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "Votre voyage au Train de banlieue sera affecté par la Coupe du Monde."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "Votre bureau de vote"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "Zone"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zone %{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zones 1A-10"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "un membre d’équipage"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "accessible Spots"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "alerte à ce moment"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "et"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "arrivé à"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "Arrivée"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "À cette époque"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "entre %{first} et %{last}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "Bateau"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "bus"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "arrêt de bus"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Espèces"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "Changement"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "Changements"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "paiement sans contact"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "Actuel"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "Départ"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "quai"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "Est"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "peu"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "pour"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "de %{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "est parti"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "à l’arrivée"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "infos"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "est temporairement indisponible en raison d’un changement de service."
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "Ligne"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "Emplacement"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "application mTicket"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "beaucoup"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "Magasin commercial à proximité"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "Nord"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "de plus de 30 minutes"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "de plus d’une heure"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "On"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "ou"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "ou "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "Ou remplissez le formulaire de retour sur cette page."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "ou payer avec des Espèces sur n’importe quel bus"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "en partance"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "Poste ferry papier"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "Prévu"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "Tarif réduit card"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "Inscription préalable"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "signaler un problème"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "nécessite"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "Localisation de vente au détail"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "Tracé"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "Voir une carte de tous les emplacements de vente proposés"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "Service"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "certains"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "Sud"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "station"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "station"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "Stop"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "arrêts"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "la page d’accueil de la MBTA"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "Le chef d’orchestre"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "Le lendemain matin"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "à travers"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "Calendrier pour"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "à"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "pour %{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "pour trouver votre bureau de vote, puis utiliser le"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "pour planifier votre voyage"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "Places de stationnement totales"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "vers"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "Piste "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "train"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "Voyages pour aujourd’hui"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "jusqu’à 10 minutes"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "jusqu’à 15 minutes"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "jusqu’à 20 minutes"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "jusqu’à 25 minutes"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "jusqu’à 30 minutes"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "Site web"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "Ouest"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "avec"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Avec ta demande."
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " alerte"
 msgid " at "
 msgstr " à "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " à %{address}"
@@ -128,7 +128,7 @@ msgstr " sur le "
 msgid " on track "
 msgstr " Sur la piste "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y} de %{x} de travailler"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] "Un voyage plus tard aujourd’hui"
 msgstr[1] "%{count} voyages plus tard aujourd’hui"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Titre de transport d’un jour"
@@ -350,8 +351,8 @@ msgstr "24 heures sur 24, 7 jours sur 7"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Titre de transport de 7 jours"
@@ -362,12 +363,12 @@ msgstr "Titre de transport de 7 jours"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 pour les appelants TTY ;  VRS pour les appelants ASL"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Attraction ADA"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarif des courses ADA"
@@ -447,7 +448,7 @@ msgstr "Ajouter au calendrier"
 msgid "Admins Only"
 msgstr "Réservé aux administrateurs"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulte"
@@ -532,7 +533,7 @@ msgstr "Tous les trains annulés"
 msgid "All Updates"
 msgstr "Toutes les mises à jour"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Toutes les routes de ferry"
@@ -948,7 +949,7 @@ msgstr "Changer de direction du voyage."
 msgid "Changes"
 msgstr "Changements"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -964,7 +965,7 @@ msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
@@ -981,8 +982,8 @@ msgstr "CharlieCards"
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & poste"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -997,12 +998,12 @@ msgstr "Vérifié"
 msgid "Check-In at South Station"
 msgstr "Enregistrement à South Station"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Enfant"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Enfants de moins de 3 ans"
@@ -1058,7 +1059,7 @@ msgstr "Journée de Christophe Provincial"
 msgid "Comment"
 msgstr "Commentaire"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Ferry-banlieue vers Logan Airport"
@@ -1076,7 +1077,7 @@ msgstr "Ferry-banlieue vers Logan Airport"
 msgid "Commuter Rail"
 msgstr "Train de banlieue"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Train de banlieue "
@@ -1194,7 +1195,7 @@ msgstr "Carte de crédit/débit"
 msgid "Credit/debit cards"
 msgstr "Cartes de crédit/débit"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Ferry de Cross Harbor"
@@ -1265,7 +1266,7 @@ msgstr "Date"
 msgid "Date and Time"
 msgstr "Date et heure"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Day titre de transport"
@@ -1406,7 +1407,7 @@ msgstr "Départ anticipé"
 msgid "Early Departure Stop"
 msgstr "Arrêt de départ anticipé"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1646,7 +1647,7 @@ msgstr "retard attendu"
 msgid "Explore stations by mode"
 msgstr "Explorez la station par mode"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Bus express"
@@ -1678,7 +1679,7 @@ msgstr "Informations sur l’installation"
 msgid "Facility Issue"
 msgstr "Problème d’installation"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Famille 4-pack (2 adultes, 2 enfants)"
@@ -1776,7 +1777,7 @@ msgstr "Mises à jour et projets MBTA à l’honneur"
 msgid "Ferry"
 msgstr "ferry"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "ferry "
@@ -1919,7 +1920,7 @@ msgstr "Pour toute question ou commentaire concernant ce communiqué de presse, 
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Pour un service régulier en semaine vers Foxboro veuillez visiter : "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Événement spécial de Foxboro"
@@ -1942,7 +1943,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "Parking sécurisé gratuit pour pédales et parking"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Service gratuit"
@@ -1962,7 +1963,7 @@ msgstr "De"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Quai surélevé complet pour assurer l’embarquement à niveau de chaque wagon d’un train"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2043,7 +2044,7 @@ msgstr "Green Line %{branch} Branche"
 msgid "Group Name"
 msgstr "Nom du groupe"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Ferry Harbor Loop"
@@ -2069,7 +2070,7 @@ msgstr "Cache-toi"
 msgid "Hide Details"
 msgstr "Masquer les détails"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2171,17 +2172,17 @@ msgstr "Ventes institutionnelles"
 msgid "Intended Audience"
 msgstr "Public visé"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Interzone %{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Durée invalide"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarif invalide"
@@ -2421,7 +2422,7 @@ msgstr "Chargement des départs à venir"
 msgid "Lobby inside Back Bay station"
 msgstr "Hall d’entrée à l’intérieur de la station Back Bay"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Bus local"
@@ -2449,7 +2450,7 @@ msgstr "Emplacement indisponible"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
@@ -2470,7 +2471,7 @@ msgstr "Objets Trouvés et Objets Trouvés"
 msgid "Lost and Found"
 msgstr "Objets trouvés"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2692,8 +2693,8 @@ msgstr "Massachusetts Bay Transportation Authority, tous droits réservés."
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport navette"
@@ -2794,7 +2795,7 @@ msgstr "Memorial Day"
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militaire"
@@ -2857,23 +2858,23 @@ msgstr "mensuel"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensuel"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "mensuel Titre de transport de bus local"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "mensuel titre de transport"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mensuel titre de transport sur mTicket App"
@@ -3078,7 +3079,7 @@ msgstr "Notes"
 msgid "Notice"
 msgstr "Avis"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3122,12 +3123,12 @@ msgstr "À l’heure"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampes d’embarquement à la porte d’entrée de chaque bus"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Titre de transport d’un jour"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "aller simple"
@@ -3482,12 +3483,12 @@ msgstr "Les heures de départ prévues ne sont pas encore disponibles, mais elle
 msgid "Prefer accessible routes"
 msgstr "Préfère accessible itinéraires"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Attraction Premium"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarif Premium Ride"
@@ -3694,7 +3695,7 @@ msgstr "les passagers sans billet de correspondance ne seront pas autorisés à 
 msgid "Right"
 msgstr "Exact"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "aller-retour"
@@ -3934,7 +3935,7 @@ msgstr "Sélectionner"
 msgid "Send Us Feedback"
 msgstr "Envoyez-nous vos retours"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "personnes âgées CharlieCard ou TAP ID"
@@ -3944,7 +3945,7 @@ msgstr "personnes âgées CharlieCard ou TAP ID"
 msgid "Senior ID Cards"
 msgstr "Cartes d’identité personnes âgées"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "personnes âgées"
@@ -4045,8 +4046,8 @@ msgid "Showing major stops."
 msgstr "On voit des arrêts majeurs."
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "navette"
@@ -4183,7 +4184,7 @@ msgstr "Désolé. Nous avons eu des difficultés à télécharger votre image. V
 msgid "Southbound"
 msgstr "Direction sud"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Poste d’événement spécial"
@@ -4218,13 +4219,13 @@ msgstr "Caractéristiques de la station"
 msgid "Station Issue"
 msgstr "Problème de la station"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "station desservant les lignes MBTA %{lines} %{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4286,12 +4287,12 @@ msgstr "Arrêts"
 msgid "Stops Skipped"
 msgstr "Contourner des jeux"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Étudiant"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "CharlieCard étudiante"
@@ -4314,7 +4315,7 @@ msgstr "Soumettez une demande de documents publics auprès de la MBTA"
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "métro"
@@ -5141,8 +5142,8 @@ msgstr "Site web"
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Titre de transport week-end"
@@ -5168,11 +5169,6 @@ msgstr "Que se passe-t-il au MBTA"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Quand"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5252,12 +5248,12 @@ msgid "Zone"
 msgstr "Zone"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zone %{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zones 1A-10"
@@ -5322,7 +5318,7 @@ msgstr "bus"
 msgid "bus stop"
 msgstr "arrêt de bus"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Espèces"
@@ -5337,7 +5333,7 @@ msgstr "Changement"
 msgid "changes"
 msgstr "Changements"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "paiement sans contact"
@@ -5409,7 +5405,7 @@ msgid "location"
 msgstr "Emplacement"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "application mTicket"
@@ -5449,7 +5445,7 @@ msgstr "On"
 msgid "or"
 msgstr "ou"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "ou "
@@ -5469,7 +5465,7 @@ msgstr "ou payer avec des Espèces sur n’importe quel bus"
 msgid "outbound"
 msgstr "en partance"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "Poste ferry papier"
@@ -5659,8 +5655,8 @@ msgstr "Site web"
 msgid "west"
 msgstr "Ouest"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5670,3 +5666,13 @@ msgstr "avec"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Avec ta demande."
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5548,9 +5548,9 @@ msgstr "Avec ta demande."
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "Zone 1A du port intérieur"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop et Quincy Ferry"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -11,5655 +11,5533 @@ msgstr ""
 "Language: ht_HT\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " & Arè"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " Gen lòt sèvis ant Boston, Hingham, ak Hull disponib atravè %{link}la"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " Li vwayaje sou kèk arè ant Foxboro ak swa Providence oswa Downtown Boston (South Station)."
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " Liy yo"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " Wout yo"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " Sèvis la ap kontinye pita nan jounen an nan direksyon opoze a. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " Sèvis la disponib pi bonè nan jounen an nan direksyon opoze a. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Tren yo ap pati Foxboro 30 minit apre evènman yo fini."
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " avètisman"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " nan "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " nan %{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " nan moman sa a."
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " depann sou distans ki vwayaje a (zòn yo). Gade enfòmasyon ki anba a:"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " pou chanjman tras an tan reyèl."
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " pou la "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " rive nan "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " ap rive nan "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " se sou wout pou "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " ka kite pi bonè orè nan arè sa yo."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " mache yon minit"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " sou "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " sou la "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " sou bon chemen "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " oubyen "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " orè"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " orè ak kat jeyografik"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " senbòl. Tcheke "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " ke yo vle ale. Pasaj k ap tann pou monte a dwe vizib sou platfòm nan pou "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " pou sispann."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "\"Distans pou mache\""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg} minit"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count} Arè"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count} avètisman"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count} pita %{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date} nan %{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date} nan %{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date} pa nan orè aktyèl nou an."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date} jiskaske yo bay lòt avi"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max} minit"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1} ak %{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label} Sèlman"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name} Tren banlye"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "Enfòmasyon %{place}"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating} travay ki planifye"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating} orè, fini %{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating} orè, kòmanse %{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name} pou rive %{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time} sou %{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y} sou %{x} k ap travay"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ", "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ", Lajan chak, oubyen "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "1 Wout Aksesib"
 msgstr[1] "%{count} wout aksesib"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "1 Wout Enaksesib"
 msgstr[1] "%{count} Wout Enaksesib"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "1 Wout ki pa disponib"
 msgstr[1] "%{count} Wout ki pa disponib"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 avètisman"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "1 rezilta"
 msgstr[1] "%{count} rezilta"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "1 arè"
 msgstr[1] "%{count} arè"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "1 vwayaj pita jodi a"
 msgstr[1] "%{count} vwayaj pita jodi a"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Pas 1 jou"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 zòn kote yo ka mete aparèy mobilite sou wou an sekirite"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "24 èdtan, 7 jou pa semèn"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Pas 7 jou"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 pou moun k ap rele TTY; VRS pou moun k ap rele ASL"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA Ride"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Pri tikè woulib ADA"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/aksesibilite Plent"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "A pwopo"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "Aksè"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "Pwoblèm Aksè"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "Pwoblèm Aksè"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "aksesibilite"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "Resous Aksè"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "aksesiblite nan %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "aksesib"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Ajoute"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "Ajoute %{title} nan kalandriye a"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "Ajoute evènman nan kalandriye a"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "Ajoute nan Kalandriye"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "Administratè sèlman"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adilt"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "Ajanda"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "avètisman"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "avètisman"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "avtisman pou MBTA %{description}"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "Tout avètisman"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "Tout tikè tren Boston Stadium yo enkli yon vwayaj ale-retou apre match la. Tren yo ap kòmanse kite estasyon Foxboro 30 minit apre dènye siflèt la. Tren"
 " retou yo ap kite estad la apeprè chak 15 minit jiskaske tout tren yo fin pati."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "Tout tren riv yo"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "Tout kalite kote"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "Tout Pwojè Amelyorasyon MBTA yo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "Tout tren derape yo"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "Tout òrè ak Kat"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "Tout tren yo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "Tout tren anile"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "Tout Mizajou yo"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Tout wout bato yo"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "Tout chan ki gen yon asterisk* obligatwa."
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "Tout mòd yo"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "Tout kote yo pwopoze yo sijè a konvenabilite sit la, pèmi ak disponiblite lavant an detay."
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "Amber avètisman"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Yon foto deyò antre estasyon Downtown Crossing la. Drapo Ameriken yo aliyen lari a, epi ou ka wè gwo kay grat syèl yo nan background nan. Anpil pyeton"
 " ap pase bò la."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "ap apwoche"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "Rive pa"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "Rive"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "Rive pa %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "At machin pou vann biyè, ou kapab"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "Nan estasyon ki gen plizyè ray deyò Nò, Sid, Back Bay, ak estasyon Ruggles , tren dirèk yo monte ap monte soti nan Ray 2, epi tren dirèk yo monte ap monte"
 " soti nan Ray 1 sof si gen lòt espesifikasyon. Chanjman tras pwograme yo pral make pa "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Patisipan yo"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "Done kat tarif gwoupe ki pa kòrèk"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "Règleman sou Sak ak Atik Entèdi"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "Rete nan South Station nan lè yo endike pou gwoup anbakman ou an. Gwoup anbakman ou an sou tikè tren Boston Stadium ou a."
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "Anvan Jodi a"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "Pwojè Pi Bon Bis"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "Bisiklèt otorize?"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "Bisiklèt otorize"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "Yo otorize bisiklèt nan tren ki gen senbòl bisiklèt la anba nimewo tren an, avèk kèk restriksyon."
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "Bisiklèt pa otorize"
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "bisiklèt"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "Pwoblèm bisiklèt"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "Depo Bisiklèt"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "Depo bisiklèt nan %{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "bisiklèt"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "bisiklèt otorize"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "yo pèmèt yo sèvi ak tout bato bato"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Platfòm subway Blue Line a anndan State Street"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line tren k ap soti Airport"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "Anbakman"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "Gwoup Abò A"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "Gwoup Abò B"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "Gwoup Anbakman C"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "Gwoup Abò D"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "Gwoup Abò E"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "Gwoup Anbakman"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Tren Boston Stadium obligatwa"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "Ou dwe achte tikè tren pou Boston Stadium davans sou aplikasyon mTicket la. Pou plis enfòmasyon, li %{world_cup_link}nou an"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Tren Boston Stadium"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "Gid Vizitè Boston pou métro a"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "Tou de direksyon yo"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "Pote machin ou oswa bisiklèt ou"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "bis"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "bis %{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "Gid pou débutan nan bis"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "Pri tikè bis"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "Karakteristik bis"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "Kat jeyografik bis"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "bis Lòt"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "Wout bis"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "arè bis"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "Chanjman nan arè bis yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "Bis yo ka bese pou monte ak desann pi fasil"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Biznis"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "Opòtinite Biznis"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "View Kalandriye"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "Rele"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "Rele nou"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Anile"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "anilasyon"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "anilasyon"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Anile"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "Transfòmasyon Kapital"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "Karyè"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "Lajan kach"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Chanjman"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "Chanje Dat"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "Chanje direksyon vwayaj la."
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "Chanjman"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "Charlie Detayan"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "Kat Charlie"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCards"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "Kat Charlie ak tikè"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "Tcheke"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "Anrejistreman nan South Station"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Timoun"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Timoun ki poko gen 3 an"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "Chwazi Lang Ou"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "Chwazi yon kalite orè nan opsyon ki disponib yo"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "Jou Nwèl la"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "Dwa Sivil yo"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "Grafik ou ka klike sou li pou Gid itilize yo"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Fèmen"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "Fèmen dyalòg la"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "Pyès monnen"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "Jou Kolon an"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Kòmantè"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Vwayaj pasaje pou ale nan AirportLogan"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "Tren banlye"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Tren banlye "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "Pri tikè tren banlye"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "Kat jeyografik tren banlye"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "Chak mwa pase nan tren an"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "Tren banlye ale senp"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "Tren banlye Positive Train Control"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "Estati tren banlye"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "Kat Zòn Tren Banlye yo"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "Yo mete ajou disponiblite plas nan Tren banlye regilyèman pou reflete kantite pasaje tipik yon vwayaj, dapre done otomatik ak done kondiktè yo nan 14-30"
 " dènye jou yo."
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "Plent"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "Konpliman"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakte"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Kontakte nou"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "Nimewo kontak"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "Contact the MBTA Sipò customer team and view additional contact numbers for the Transit Police, Objè ki pèdi ak sa yo jwenn, ak aksesiblite."
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "Kontakte Lapolis Transpò a"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Kontinye"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "Pri"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "Etajè bisiklèt ki kouvri"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "Etajè bisiklèt ki kouvri yo disponib"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "Kreye yon Kont"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "Kat kredi/debi"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "Kat kredi/debi"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Bato Cross Harbor"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "Kwavil"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "Anpil moun"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "Kouran"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "Avètisman aktyèl"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "Chanjman aktyèl yo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "Sitiyasyon aktyèl la"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "Papòt disponiblite plas aktyèl yo se:"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "Sipò kliyan"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Chak jou"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "Orè chak jou"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Dat"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "Dat ak Lè"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Pas pou jounen an"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "reta"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "Anreta %{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "reta"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "Pati"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "Depa a"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "Depa"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "Kote destinasyon an pa ase pre okenn arè transpò piblik"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "Destinasyon an pa nan zòn sèvis nou an"
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "Destinasyon yo"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "Detay"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "detou"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Devlopè yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "Ekspozisyon dijital ak anons otomatik ki pataje enfòmasyon prensipal yo epi sispann yo."
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "Direksyon vwayaj ou a"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "Kat idantite andikap"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "waf fèmti"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "Pwoblèm waf"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "Dokiman yo"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "Pa rete nan"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "Akòz Suivi Single"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "Kat EBT"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "Pase fasil"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "Pi bonè"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "Arive Pi Bonè"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "Depa Bonè"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "Arè pou depa bonè"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "Direksyon lès"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "Asansè"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "Asansè ak Eskalatè"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "Asansè fèmti"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "Asansè fèmti"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "Liy dirèk pou asansè/eskalyatè"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "Asansè"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "Asansè nan %{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "sitiyasyon ijan"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "Kontak sityasyon ijan"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "Anplwaye"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "Plent Anplwaye"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "Fini"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "Nòm Konsepsyon Jeni"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "Antre yon kote destinasyon"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "Antre yon kote"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "Antre yon kote orijin"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "Antre mo kle(yo)"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "Antre mo kle pwojè a"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "Antre nan estasyon an"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "Antre nan sèk trafik la"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "Antre adrès anrejistre ou a"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "antre pou Blue ak Liy Green deyò Government Center"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "antre pou Liy Green ak Liy Red deyò Park Street"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "antre pou Liy Orange ak Liy Red deyò Downtown Crossing"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "antre nan estasyon Ruggles"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "antre pou Red Line ak Tren an deyò South Station"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Erè"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "Eskalatè"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "Eskalatè (desann sèlman)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "Eskalatè (monte desann)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "Eskalatè (monte sèlman)"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "Eskalatè fèmti"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "Eskalatè fèmti"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "Eskalatè"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "Eskalatè nan %{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "Lè yo estime rive nan estasyon Foxboro a"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "Deskripsyon Evènman an"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "Rezime evènman pou "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "Evènman yo"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "Sòti nan estasyon an"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "atann pou gen reta"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "Eksplore estasyon yo pa mòd"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Bis Express"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "Bis Express ale senp"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Eksteryè estasyon Wonderland la"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "Sèvis Siplemantè"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "Enfòmasyon sou etablisman an"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "Pwoblèm Enstalasyon"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Pake fanmi pou 4 moun (2 granmoun, 2 timoun)"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "Evazyon Pri"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "Opsyon Tarif"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "Opsyon pri tikè nan %{name}"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "Règleman sou pri tikè"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "Kote yo vann pri tikè"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "Transfòmasyon Tarif"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "Kalite Tarif"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "machin pou vann biyè"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "machin pou vann biyè"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "Tarif yo"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "Enfòmasyon sou pri tikè yo"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "Apèsi sou pri tikè yo"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "Tarif pa Mòd"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Tarif yo diferan ant Hingham/Hull bato yo ak Charlestown bato yo. Gade enfòmasyon ki anba a:"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "Mizajou ak Pwojè MBTA yo"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "Bato-Travèsye"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Bato-Travèsye "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "Bato Fares"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "Kat jeyografik Bato"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "bato chak mwa pase"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "Kèk plas disponib"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "Depoze yon plent pou diskriminasyon"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "Ranpli fòm lan"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "Filtre pa kalite"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "Finans"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "Jwenn Kote Pwopoze Toupre Ou"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "Jwenn Biwo Vòt ou a"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "Jwenn yon Kote"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "Jwenn yon magazen tou pre ou"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "Chèche konnen kijan pou patisipe"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "Fini yon lòt vwayaj"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "Premye %{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "Arè Drapo"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "Mete siyal nan bis la nan nenpòt kote ki an sekirite sou wout la"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "Swiv @MBTA sou Twitter"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "Swiv @MBTA_CR sou Twitter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "Swiv siy yo"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "Swiv lyen ki anba a pou jwenn nimewo ki asosye avèk mòd oswa wout kote ou te pèdi bagay ou a."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "Pou pri tikè Bis Express yo, li paj %{link} konplè a."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "Pou tout enfòmasyon sou sèvis tren koup di mond lan, li %{world_cup_link}nou an"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "Pou plis enfòmasyon"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "Pou kesyon oswa kòmantè sou kominike laprès sa a, tanpri kontakte"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Pou sèvis regilye Jou lasemèn pou Foxboro , tanpri vizite: "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evènman Espesyal Foxboro"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Liy Franklin"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratis"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "Pakin Pedal ak Park gratis ak sekirite"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Sèvis gratis"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "Vandredi"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "Soti nan"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Platfòm konplè ak nivo pou bay monte nan nivo pou chak machin nan yon tren."
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "Jwenn Direksyon yo"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "Patisipe"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "Jwenn Mizajou Sèvis yo"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "Jwenn T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "Jwenn yon Kat Charlie"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "Jwenn yon fakti pa lapòs pou yon frè $1"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "Jwenn direksyon pou ale nan pakin sa a"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "Vin konnen nou"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "Jwenn sijesyon vwayaj"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "Ale"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "Ou pral nan yon match koup di mond nan Boston Stadium?"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Branch Green Line %{branch}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "Non Gwoup la"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Bato Harbor Loop"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "Fèm agoch"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "Dwat nèt"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Kache"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "Kache Detay yo"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Bato Hingham/Hull"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Istwa"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "Jou ferye lò"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "Jou ferye"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Lakay"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Adrès lakay"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "Ikòn Kle"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "Si sa aplikab, tanpri asire w ou mete lè ak dat ensidan an, wout la, ak nimewo machin nan."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "Si ou te bay enfòmasyon kontak ou yo, tcheke imèl ou pou yon konfimasyon ak yon nimewo ensidan. Si ou pa resevwa yon konfimasyon nan 10 minit, eseye soumèt"
 " fidbak ou ankò oswa rele nou nan"
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "Si ou ta renmen nou rele ou, tanpri ban nou pi bon nimewo kote nou ka jwenn ou."
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "Si dwa sivil ou yo vyole, ou ka depoze yon plent nan Biwo Divèsite ak Dwa Sivil MBTA a."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "Enfòmasyon enpòtan"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "Lyen Enpòtan yo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "Tren anile"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "Jou Endepandans"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "Enfòmasyon ak Sipò"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "Vann Enstitisyonèl"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "Odyans sib la"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Entèzòn %{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Dire ki pa valab"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarif ki pa valab"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "Fakti"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "Èske sa itil? Voye nou fidbak"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "Ale nan"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "10yèm jou endepandans lan"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "Konnen Gwoup Anbakman ou an"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "Ou konnen yon pwopriyetè magazen lokal ki ta ka enterese rantre nan rezo lavant nou an? Sijere yon détayan epi n ap kontakte yo pou ou."
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "Fèt Travay la"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "Sèvis Lang"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Lang"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "Denye"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "Dènye %{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Pita"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "Lidèchip"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "Aprann plis bagay sou CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "Aprann plis bagay sou pri tikè MBTA yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "Aprann plis bagay sou aksesiblite nan métro a"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "Aprann plis bagay sou pakin bisiklèt nan métro a"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "Aprann plis bagay sou kote pou estoke bisiklèt nan estasyon sa a."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "Aprann plis sou wout sou Tren banlye"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "Aprann plis bagay sou aksesiblite ou"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "Aprann plis bagay sou pri tikè yo, kalite pas yo, ak kijan pou peye tikè ou nan métro a."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "Aprann plis bagay sou tarif yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "Aprann plis bagay sou aksesiblite bato"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "Aprann plis bagay sou kijan pou depoze yon Plent"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "Aprann plis bagay sou pakin nan métro a"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "Aprann plis bagay sou Tarif ki gen rabè ak kalifikasyon"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "Aprann plis bagay sou tandans disponiblite plas yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "Aprann plis bagay sou karakteristik aksesibilite yo nan %{place} sa a."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "Aprann plis bagay sou pwojè sa a"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "Aprann sa k ap pase apre ou fin depoze yon Plent"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "Mache ki pi piti a"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "Kite a"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "Ap kite a %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "Agòch"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "Fè nou konnen"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "Liy ak Wout"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "View Lis"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "Live avètisman sou sèvis pou tout mòd transpò MBTA, ki gen ladan subway, bis, Tren banlye, ak bato. Mizajou sou reta, konstriksyon, pann asansè, ak plis"
 " ankò."
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Chaje plis"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "Ap chaje arive yo..."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "Ap chaje orè pou sèvis yo chwazi a"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "Ap chaje detay vwayaj la"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "Ap chaje depa k ap vini yo"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Lobi andedan estasyon Back Bay la"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Bis lokal"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "Byè lokal senp"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Kote"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "Kote a pa ase pre okenn arè transpò piblik"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "Kote a pa disponib"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "Ranp long"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "Pèdi & Jwenn"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "Objè ki pèdi ak sa yo jwenn"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type} estasyon ak orè, ki gen ladan kat, mizajou an tan reyèl, enfòmasyon pakin ak aksesibilite, ak koneksyon."
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{route_name} %{station_name} ak lòt ankò, ki gen ladan orè, kat, pri tikè, dènye enfòmasyon an tan reyèl, enfòmasyon sou pakin ak aksè, ak koneksyon."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "Arè ak zòn MBTA %{text} yo, ki gen ladan kat, enfòmasyon sou pakin ak aksè, ak pri tikè yo."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "Arè ak lòt kote sou wout %{type} MBTA %{name} , ki gen ladan kat, dènye enfòmasyon an tan reyèl, enfòmasyon sou pakin ak aksè, ak koneksyon."
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - Otorite Transpò Bè Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "Facebook MBTA"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "Tarif MBTA yo"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "Boutik Kado MBTA"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "Estasyon ak zòn tramway Green Line MBTA a, ki gen ladan kat, dènye enfòmasyon an tan reyèl, enfòmasyon sou pakin ak aksè, ak koneksyon."
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "Paj Akèy MBTA a"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "Paj dakèy MBTA a"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "MBTA Instagram"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "Pwogram Paratranzit MBTA a"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "Pwojè/Pwogram MBTA yo"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "Estasyon MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "Fil MBTA yo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "Lapolis Transpò MBTA"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "MBTA Zouti planifikasyon vwayaj"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "Twitter MBTA"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "Gid pou itilizasyon MBTA yo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "YouTube MBTA"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "Machin MBTA pou vann biyè"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "Moun ki gen pasaje MBTA yo ka achte CharlieTickets epi rechaje epi achte %{charlie_card} pou bis, subway, Tren banlye, ak bato nan magazen nan tout zòn"
 " Gran Boston ak Providence yo."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "Dènye Nouvèl MBTA.com yo"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "Meni MBTA.com"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Prensipal"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "Liy dirèk prensipal la"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "Meni Prensipal"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "antretyen"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "antretyen Plent"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "Fè yon demi-tour"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "Jere pa"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "Anpil plas disponib"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Kat"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "Jounen Martin Luther King, Jr."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "Otorite Transpò Bè Massachusetts la"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "Otorite Transpò Bè Massachusetts, tout dwa rezève."
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport navèt"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport navèt %{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "Match 18"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "Match 30"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "Match 45"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "Match 5"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "Match 61"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "Match 74"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "Match 97"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "Match tikè obligatwa "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Li ka pa aksesib"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "Enfòmasyon pou Kontakte Medya yo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "Relasyon ak Medya yo"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "Enfòmasyon sou Reyinyon"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "Manm laprès yo ka mande pou rantre nan lis medya nou an lè yo voye yon imèl "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "Manm piblik la gen dwa pou mande kopi dokiman MBTA yo, sof sèten eksepsyon. Gen frè ki aplike epi yo ka varye selon demann lan."
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "Jou Memoryal la"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "Meni"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militè"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "Mini platfòm nivo pou bay sèten machin nan yon tren monte nan yon nivo."
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "Minit"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "Aplikasyon mobil"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "Tikè mobil"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "Mòd"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "Mòd Transpò"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "Lendi"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "Lendi - Vandredi"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "Lendi jiska Vandredi"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "Lendi pou rive Vandredi"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "chak mwa"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass chak mwa"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "chak mwa Lokal bis pase"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "chak mwa pase"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "chak mwa pase sou aplikasyon mTicket"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "Plis Gid"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "Plis Enfòmasyon"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "Plis nan men "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "Pi Dirèk"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "Tarif ki pi popilè yo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "Pifò, men pa tout, waf MBTA yo aksesib pou pase ak andikap. Selon nivo mare a ak kalite veso ou itilize pou vwayaj la, ou ka rankontre pant enpòtan ak"
 " pasaj pyeton etwat, menm nan waf aksesib. Nan tout waf yo, tann jiskaske yon manm ekipaj di ou ke li an sekirite pou ou kontinye."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Meni Navigasyon"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Nouvo"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "Jou Nouvèl Ane a"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "Nouvèl"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Swivan"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "Semèn Pwochen"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "Pwochen arè"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "Pa gen %{group} avètisman"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "pa gen sèvis pwograme"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "Pa gen sèvis"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "Pa gen avètisman isit la."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "Pa gen okenn chanjman ki afiche pou 7 jou kap vini yo"
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "Pa gen evènman"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Pa gen pakin"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "Pa gen sèvis jodi a"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "Pa gen okenn koneksyon transpò ki te jwenn ant orijin ak destinasyon an nan dat ak lè sa a."
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "Pa gen okenn mòd transpò ki chwazi"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "Pa gen okenn wout transpò piblik ki te jwenn nan mwens ke 2 èdtan apati %{time_on_date}. Wout yo ka disponib nan lòt lè."
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "Pa jwenn okenn vwayaj"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "Pa gen vakans k ap vini"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "sèvis nòmal"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "Direksyon nò"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "Pa aksesib"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "Pa disponib"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "Pa gen moun"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Remake"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Remak:"
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Nòt"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "Avi"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Kounye a"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "Kounye a nan"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "Obsève"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "Sitwèb ofisyèl MBTA a -- enfòmasyon sou pri tikè pou sistèm transpò piblik Gran Boston an, tankou subway, tren yo, wout li yo ak liy bato yo."
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "Sitwèb ofisyèl MBTA a — Planifye yon vwayaj nan transpò piblik nan rejyon Gran Boston an"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "O non! Nou gen reta."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "A lè"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Ranp abò nan pòt devan chak bis"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Pas pou yon jou"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "ale senp"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "ki prale"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "Se sèlman bous oswa ti sak transparan ki otorize. Fòk ou jete bagay ki entèdi yo anvan ou monte anbake."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "Oswa,"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "Oubyen, ale nan "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "Lòd chak mwa pase"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "Kote orijin lan pa ase pre okenn arè transpò piblik"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "Kote orijin lan se andeyò zòn sèvis nou an"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "Kote orijin oswa destinasyon an andeyò zòn sèvis nou an"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Lòt"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "Lòt orè"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "Travay nou an"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "Gid itilizatè nou yo ka ede w aprann kijan pou w navige nan sistèm nan, ale nan evènman lokal yo, itilize fonksyon aksesibilite, ak plis ankò."
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "Pa nan lòd"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "Tren Derape yo anile"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "Etajè bisiklèt deyò"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "Etajè bisiklèt deyò yo disponib"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "Lannwit lan"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Apèsi sou lekòl la"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF ou"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF k ap vini"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Paj Pa Jwenn | MBTA - Otorite Transpò Bè Massachusetts"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "Yo pa jwenn paj la"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Paj yo"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "Paratranzit (The RIDE)"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "Pakin"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "Pakin fèmti"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "Pwoblèm Pakin"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "Tarif Pakin"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "Pakin nan %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Pakin disponib"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "pasaje dwe di "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "Chanjman nan tan lontan yo"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "Jou Patriyòt yo"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "Peye tikè ou a"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Metòd Peman"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Moun"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "Moun k ap tann pandan tren liy zoranj lan rive andedan North Station"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "Moun k ap mache nan tren k ap depa moun ap monte andedan North Station"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "Moun k ap mache nan direksyon tren Green Line andedan North Station"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "Pèfòmans"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "Planifye Vwayaj Ou a"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "Planifye yon vwayaj"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "Planifye yon vwayaj aksesib"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "Planifye vwayaj ou a"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "Planifikasyon avètisman sou sèvis"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "travay ki planifye"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "Tanpri antre yon kòmantè pou kontinye."
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "Tanpri antre yon imèl ki valab."
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "Tanpri antre yon nimewo machin ki valab avèk karaktè nimerik sèlman."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "Tanpri antre yon adrès ki nan yon distans 100 mil parapò ak yon zòn sèvis MBTA."
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "Tanpri antre prenon ou pou kontinye."
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "Tanpri antre non Dènye ou pou kontinye."
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "Tanpri chwazi yon destinasyon ki diferan de kote orijin lan."
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "Tanpri chwazi yon kote pou ale."
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "Tanpri chwazi yon kote orijin."
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "Tanpri chwazi omwen yon mwayen transpò."
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "Tanpri chwazi kalite enkyetid la."
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "Tanpri presize yon dat ak yon lè nan lavni oubyen chwazi 'Kounye a'."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "Tanpri eseye ankò oswa voye nou fidbak ou nan mbta.com/customer-support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "Règleman ak Dwa Sivil"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "Chanjman Règleman"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "Asansè pòtab pou monte bisiklèt"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "Pibliye sou"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "Orè depa yo poko disponib, men y ap parèt isit la anvan premye vwayaj ki pwograme a."
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "Prefere wout aksesib yo"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Premium Ride"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Pri tikè vwayaj prim"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "Kominike pou laprès"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "Vèsyon Aperçu"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anvan"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Règleman sou enfòmasyon prive"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "Pwojè yo"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "Kote lavant yo pwopoze yo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "Reyinyon Piblik"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "Transpò piblik nan rejyon Gran Boston an. Routes, orè, Zouti planifikasyon vwayaj, fares, avètisman sou sèvis, actual-time updates, and general information."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "Achte tikè Charlie yo"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "Achte yon CharlieCard oubyen rechaje youn ki deja egziste"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "Purchase tarifs at machin pou vann biyè."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "Achte tikè nan magazen ki toupre yo."
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "Kalite, Konfòmite ak Sipèvizyon"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "Katriyèm de final"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "Kesyon"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "ranp"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "Li %{world_cup_link}nou an"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "Resevwa notifikasyon sou avètisman sou sèvis MBTA pa imèl oswa tèks."
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "Dènye nouvèl sou métro a"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "Dènyèman vizite orè"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "Pri Redwi"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "Anrejistre CharlieCard ou a pou pakin bisiklèt"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "Dosye ki gen rapò"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "Avètisman ki gen rapò ak sèvis"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "Rapòte Fwòd, Gaspiyaj, oswa Abi"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Rapòte yon pwoblèm baryè travèse tren"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "Rapòte yon pwoblèm aksesibilite"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "Rapòte yon pwoblèm asansè"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "Rapòte yon pwoblèm eskalye"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "Rapòte sispèk fwod, gaspiyaj oswa abi"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "Mande Dosye Piblik yo"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "Kote lavant an detay yo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "Vwayaj ale-retou enkli"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "Monte %{route} %{vehicle}la"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "Monte nan tren %{route} %{train}la"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "Yo p ap pèmèt pasaje san match tikè monte nan tren Boston Stadium yo."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "Dwa"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ale retou"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "32yèm tou"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "Wout %{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "Wout %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Wout yo"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "Wout ki gen gwo priyorite avètisman"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sekirite"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "Samdi"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "òrè & Kat"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "Chanjman nan orè"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "orè pou"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "Plis enfòmasyon pou liy banlye MBTA Tren nan rejyon Gran Boston an, ki gen ladan mizajou an tan reyèl ak prediksyon arive."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "plis enfòmasyon pou wout MBTA yo nan rejyon Gran Boston an, ki gen ladan mizajou an tan reyèl ak prediksyon arive."
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "Lòt enfòmasyon pou wout MBTA k ap opere nan Massachusetts Bay, ki gen ladan PDF ou ka telechaje."
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "lòt enfòmasyon pou liy subway MBTA yo nan Gran Boston, ki gen ladan mizajou an tan reyèl ak prediksyon arive."
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "Lòt enfòmasyon pou subway MBTA a, bis, tren banlye, ak bato nan rejyon Gran Boston an, ki gen ladan mizajou an tan reyèl ak prediksyon arive."
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "orè ap disponib byento sou sitwèb MBTA a."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Pwograme"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "Sèvis pwograme a ap kontinye jiska %{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "Pwograme pou ale"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "orè"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "òrè & Kat"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "orè ak Kat"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "Jou lekòl sèlman"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Rechèch"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "Chèche sou MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "Chèche yon arè oswa yon estasyon"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "Chèche wout, kote, enfòmasyon ak plis ankò"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "Rezilta rechèch pou"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "Chèche MBTA a"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "Sezonye"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "Sèvis sezonye"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "Disponibilite plas"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "Sitwèb ofisyèl Sekretè State"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "Gen pakin ki an sekirite, men ou dwe enskri ak Kat Charlie davans."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "Gade avètisman"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "Wè yon bagay, di yon bagay"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "Gade tout kominike laprès yo"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "Gade tout reyinyon ak evènman piblik yo"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "Gade tout avètisman sou sèvis yo"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "Gade tout gid itilizatè yo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "Gade sa ou ka pote nan tren Boston Stadium yo"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Chwazi"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "Voye nou kòmantè yo"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "Kat Charlie pou granmoun aje oswa ID TAP"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "Kat idantite granmoun"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Granmoun aje"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "Pwoblèm sèvè"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "Sèvis"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "avètisman sou sèvis"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "chanjman sèvis"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "Plent Sèvis"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "Demann Sèvis"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "avètisman sou sèvis oswa reta"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "Chanjman sèvis yo an vigè soti 6 jen rive 12 jiyè. Tcheke chak jou nan %{timetable_link} liy ou a pou jwenn dènye enfòmasyon yo."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "Sèvis la fini"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "Sèvis la ap fonksyone jan yo te prevwa a"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "Sèvis pou koup di mond lan"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "Vwayaj ki pi kout la"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Montre"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "Montre Detay yo"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "Montre mwens arè"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "Montre plis arè"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "Ap montre tout"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "Montre gwo arè yo."
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "navèt"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "machin transpò"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "Enskri pou avètisman sou sèvis"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "Siyen nan"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "Enskri pou Peman Otomatik"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "Enskri pou T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "Enskri pou notifikasyon avètisman"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "Vwayaj menm jan an rive nan %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "Vwayaj menm jan an ap pati a %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "Vwayaj menm jan an rive nan %{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "Vwayaj menm jan an ap pati a %{times}"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "Suivi Single"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "kontoune nan kontni prensipal la"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "kontoune"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "Yon ti kras agoch"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "Yon ti kras adwat"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "Kat Entelijan"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "Wout nèj"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "Pèle nèj"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "Gen kèk plas ki disponib"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "Gen kèk moun ki te twò chaje"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "Gen yon bagay ki te ale mal bò kote nou."
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "Padon! Nou rate arè ou a."
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "Padon. Gen yon bagay ki pa mache byen. Tanpri eseye ankò."
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "Padon. Nou te gen pwoblèm pou chanje imaj ou a. Tanpri eseye ankò."
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "Direksyon sid"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Tikè pou evènman espesyal"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "Tikè espesyal obligatwa"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "estasyon & avètisman sou sèvis"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "aksesiblite estasyon"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "estasyon fèmti"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "Karakteristik estasyon"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "Pwoblèm estasyon"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estasyon sèvi MBTA %{lines} liy%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "estasyon"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "estasyon ak pakin"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "estasyon ak arè"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Estati"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "Rete %{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "arè ki fèmen"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "arè yo deplase"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "Sispann kontoune"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "Arè"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "Arè kontoune"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Elèv"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Kat Charlie pou Elèv"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "Soumèt"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "Soumèt yon demann pou dosye piblik bay MBTA a"
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "subway"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "Gid pou débutan nan métro a"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "Pri tikè métro"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "Kat métro a"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "byè subway senp"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "Estati métro a"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "Sijere yon détaillant"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Rezime"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "Dimanch"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "Sispansyon"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Dirablite"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "Chanje kote orijin ak destinasyon yo"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "Sistèm nan tout"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "Alèt/Kontaj/Aplikasyon"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "Telefòn TTY"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "Pran métro a pou ale vote"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Pran asansè a"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "Pran tren pou ale nan yon match koup di mond lan?"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "Di nou sa ou panse"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "Di nou kijan vwayaj ou yo ye regilyèman epi resevwa mesaj tèks oswa imèl ki enpòtan pou ou, lè ou vle yo."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "Disponib tanporèman"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "Tanporèman fèmen"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "Pwoblèm Tanporè"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "Pwoblèm tanporè"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "Tèm itilizasyon"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "Mèsi paske ou te soumèt fidbak ou a. Ekip Sipò kliyan nou an pral revize kòmantè ou yo byento."
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "Jou Aksyon de Gras"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "La "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "Kowòdonatè Angajman Kliyan nan Aksesibilite Sistèm lan ak Lyèzon Kliyan pou The RIDE responsab pou kowòdone rezolisyon ADA/aksesibilite Plent yo yon fwa"
 " yo resevwa yo."
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "Liy Evènman Espesyal Foxboro a se sèlman pou sèvis detanzantan."
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "Inite Odit Espesyal Entèn nan Biwo Enspektè Jeneral la kontwole kalite, efikasite ak entegrite pwogram MassDOT yo."
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "Woulib la"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "Orè entèaktif la pou"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "Pa gen okenn depa an tan reyèl ki disponib kounye a."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "Pa gen okenn depa an tan reyèl ki disponib kounye a. Depa pwograme yo montre anba a."
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "Pa gen okenn"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "Pa gen okenn "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "Pa gen okenn karakteristik aksesiblite adisyonèl, men Bis yo toujou aksesib pou moun ap monte."
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "Pa gen avètisman"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "Pa gen okenn gwo priyorite"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "Pa gen okenn lòt otobis tren ki gen konpayi avyon kounye a."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "Pa gen okenn lòt estasyon subway kounye a."
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "Pa gen okenn vwayaj %{direction} pwograme pou %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "Pa gen okenn vwayaj %{direction} ki pwograme."
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "Pa gen okenn vwayaj pwograme pou %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "Pa gen vwayaj pwograme."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "Pa gen okenn nouvèl pou kounye a."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "Pa gen okenn %{route_name} ki pwograme kounye a."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "Pa gen okenn enfòmasyon sou plan vwayaj pou kounye a."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "Pa gen okenn sèvis %{route} pwograme nan %{stop} pou peryòd tan sa a."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "Te gen yon pwoblèm pou chaje arive yo"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "Te gen yon pwoblèm pou chaje orè yo"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "Te gen yon pwoblèm pou chaje detay vwayaj la"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "Te gen yon pwoblèm pou chaje depa k ap vini yo."
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "%{place} sa a pa aksesib."
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "Semèn sa a"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "Lis sa a pa gen ladan détaillants MBTA aktyèl yo. Pou wè kote magazen yo ye kounye a, sèvi ak nou an"
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "Paj sa a pa disponib ankò."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "Estasyon sa a pa gen depo."
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "Estasyon sa a pa gen asansè."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "Estasyon sa a pa gen eskalatè."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "Estasyon sa a pa gen pakin."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "Arè sa a pa gen machin pou vann machandiz, men ou ka achte tikè nan yon"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "Tren sa a anjeneral gen<br /><strong>%{seats} plas disponib.</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "Jedi"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "Orè"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "Pou"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "Pou rapòte yon pwoblèm oswa yon sitiyasyon ijan ak yon pasaj tren, rele"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "Pou soumèt yon dokiman ADA/aksesibilite Plent oubyen yon fidbak, tanpri rele"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Jodi a"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "Jodi a nan"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "Apèl gratis"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "Chanjman Anbakman Track"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "Suivi Chanjman"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "Tras la pou detèmine"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "Swiv vwayaj %{route_type_text} ou an dirèk avèk aplikasyon <strong>MBTA Go</strong> a"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Tren"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "Tren %{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "Tren pwograme pou moun ap monte apati %{platform} a %{station}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "Transfè"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "Transfè"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "Transpò piblik"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "Lapolis Transpò"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "Vwayaje nenpòt kote sou liy Blue, Orange, Red ak Green pou menm pri a."
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "Vwayaj"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Zouti planifikasyon vwayaj"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "Kalite Vwayaj"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "Vwayaj soti nan %{from} pou rive nan %{to}"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "Eseye chèche sa w ap chèche a anba a."
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "Madi"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "Madi, 5 novanm se jou Dènye pou vote nan eleksyon jeneral 2024 la. Sèvi ak métro a pou ale nan biwo vòt ou a."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "Tipikman mwens pase 33% plas disponib epi distansyasyon pa posib (apeprè 3+ moun pa ranje)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "Tipikman, plis pase 33% plas yo rete disponib epi distansyasyon an ka posib (apeprè 2-3 moun pa ranje)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "Tipikman gen plis pase 66% plas ki disponib epi distansyasyon posib (apeprè 0-2 moun pa ranje)."
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Enkoni"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "Tras ki pa pwograme"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "Jiska %{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "k ap vini"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "Chanjman k ap vini"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "Depa k ap vini"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "Vakans k ap vini"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "Reyinyon ak Evènman Piblik k ap vini"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "Mizajou sou"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "Mizajou: "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "Mizajou"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "Itilize"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "Gid itilizasyon"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "Jou Veteran yo"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "Via"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Gade"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "Gade %{timetable_link} pou enfòmasyon sou depa."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "Gade avètisman"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "Gade tout nimewo kontak yo"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "Gade tout opsyon yo"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "Gade Biyografi a"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "Gade Biyografi pou %{name}"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "Gade Orè PDF la"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "Gade Orè PDF la sou sitwèb MBTA a."
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "Gade Anvan"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Gade tout"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "Gade tout wout bis yo"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "Gade tout evènman yo"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "Gade tout gid yo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "Gade tout match yo"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "Gade tout nouvèl yo"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "Gade tout dènye nouvèl sou pwojè a"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "Gade tout pwojè yo"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "Gade asansè ki disponib yo."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "Gade eskalye mekanik ki disponib yo."
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "Gade enfòmasyon sou pri tikè komen pou MBTA bis, subway, Tren banlye, bato, ak The RIDE. Jwenn sèvis CharlieCard sou entènèt epi aprann sou pwogram kòmand"
 " an gwo."
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "Gade orè aswè a"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "Gade apèsi sou pri tikè yo"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Gade plis enfòmasyon sou peman"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "Gade orè maten an"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "Gade sou Google Maps"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "View on MBTA Zouti planifikasyon vwayaj"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "Gade pri pakin, enfòmasyon sou etablisman yo, ak plis ankò."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "Gade nimewo telefòn yo"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Vizite"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "Vizite Sant Mobilite a"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Vòt"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "Ap tann rezilta yo"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "Ap tann pou ale"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "Mache"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "Direksyon pou mache sèlman"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "Anivèsè nesans Washington"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "Nou ka sèlman bay done vwayaj pou orè %{rating} la, valab jiska %{end_date}."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "Nou te gen yon pwoblèm pou soumèt fidbak ou a -- tanpri rele nou nan Liy Dirèk Prensipal ki anba a, oubyen eseye ankò nan kèk minit."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "Nou vle asire nou ke n ap bati yon rezo lavant an detay ki mache pou ou. Ou ka pataje fidbak ou lè l sèvi avèk fòm ki anba a."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "Nou pa t kapab jwenn yon sant vòt pou adrès ou a. Ou kapab vizite tou"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "N ap voye kominike laprès ak avi medya MBTA yo ba ou dirèkteman."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "N ap mande piblik la pou ede nou pran desizyon pandan n ap deplwaye pwojè Transfòmasyon Tarif yo pandan plizyè ane kap vini yo."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "N ap agrandi rezo kote pasaje yo ka jwenn oswa chaje yon CharlieCard epi achte yon pas."
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Sit wèb"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "Mèkredi"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Wikenn pase"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "wikenn yo"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "Direksyon lwès"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "Sa k ap pase nan MBTA a"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Lè"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "Travay avèk nou"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "Travay avèk nou"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "Ap travay"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Gid pou koup di mond lan"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "Match koup di mond yo"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "Ekri nou"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "Tout ane a"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "Ou kapab tou voye yon imèl ba ou"
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "Ou ka espere yon repons pou pifò tikè yo nan lespas 5 jou ouvrab. Sèten Plent ka mande pou envestigasyon ki pi long, jiska 30 jou."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "Ou ka peye pou tikè ou a ak"
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "Ou dwe dakò ak Règleman sou enfòmasyon prive nou an anvan ou soumèt fidbak ou a."
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Ou dwe ranpli reCAPTCHA a anvan ou soumèt fidbak ou a."
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "Koup di mond lan pral afekte vwayaj Tren banlye ou a."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "Biwo Vòt ou a"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "Zòn"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zòn %{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zòn 1A-10"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "yon manm ekipaj"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "plas aksesib"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "avètisman nan moman sa a"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "epi"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "rive nan"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "rive"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "kounye a"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "ant %{first} ak %{last}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "bato"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "bis"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "arè bis"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Lajan kach"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "chanjman"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "chanjman"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "pèman san kontak"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "aktyèl"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "pati"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "waf"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "lès"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "kèk"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "pou"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "soti nan %{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "te kite"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "rive"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "enfòmasyon"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "pa disponib tanporèman akòz yon chanjman sèvis."
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "liy"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "kote"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplikasyon mTicket"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "anpil"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "kote komèsyal ki tou pre"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "nò"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "plis pase 30 minit"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "plis pase yon èdtan"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "sou"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "oubyen"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "oubyen "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "oubyen ranpli fòm fidbak la sou paj sa a."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "oubyen peye ak Lajan chak sou nenpòt bis"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "derape"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papye bato tikè"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "planifye"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "Kat tarif ki gen rabè"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "enskripsyon davans"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "rapòte yon pwoblèm"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "egzije"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "Jwenn kote pou vann an detay"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "wout"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "gade yon kat jeyografik tout kote lavant yo pwopoze yo"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "sèvis"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "kèk"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "sid"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "estasyon"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "estasyon"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "rete"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "arè"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "Paj dakèy MBTA a"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "kondiktè a"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "nan denmen maten"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "atravè"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "kalandriye pou"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "pou"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "pou %{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "pou jwenn biwo vòt ou a, epi sèvi ak"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "pou planifye vwayaj ou a"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "plas pakin total"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "nan direksyon"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "tras "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "tren"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "vwayaj pou jodi a"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "jiska 10 minit"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "jiska 15 minit"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "jiska 20 minit"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "jiska 25 minit"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "jiska 30 minit"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "sit entènèt"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "lwès"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "avèk"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "avèk demann ou an."
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5535,9 +5535,9 @@ msgstr "avèk demann ou an."
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "Zòn Pò Enteryè 1A"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop ak Quincy Ferry"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " avètisman"
 msgid " at "
 msgstr " nan "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " nan %{address}"
@@ -128,7 +128,7 @@ msgstr " sou la "
 msgid " on track "
 msgstr " sou bon chemen "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y} sou %{x} k ap travay"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] "1 vwayaj pita jodi a"
 msgstr[1] "%{count} vwayaj pita jodi a"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Pas 1 jou"
@@ -350,8 +351,8 @@ msgstr "24 èdtan, 7 jou pa semèn"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Pas 7 jou"
@@ -362,12 +363,12 @@ msgstr "Pas 7 jou"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 pou moun k ap rele TTY; VRS pou moun k ap rele ASL"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA Ride"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Pri tikè woulib ADA"
@@ -447,7 +448,7 @@ msgstr "Ajoute nan Kalandriye"
 msgid "Admins Only"
 msgstr "Administratè sèlman"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adilt"
@@ -532,7 +533,7 @@ msgstr "Tout tren anile"
 msgid "All Updates"
 msgstr "Tout Mizajou yo"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Tout wout bato yo"
@@ -948,7 +949,7 @@ msgstr "Chanje direksyon vwayaj la."
 msgid "Changes"
 msgstr "Chanjman"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -964,7 +965,7 @@ msgid "Charlie Service Center"
 msgstr "Charlie Service Center"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "Kat Charlie"
@@ -981,8 +982,8 @@ msgstr "CharlieCards"
 msgid "CharlieCards & Tickets"
 msgstr "Kat Charlie ak tikè"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -997,12 +998,12 @@ msgstr "Tcheke"
 msgid "Check-In at South Station"
 msgstr "Anrejistreman nan South Station"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Timoun"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Timoun ki poko gen 3 an"
@@ -1058,7 +1059,7 @@ msgstr "Jou Kolon an"
 msgid "Comment"
 msgstr "Kòmantè"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Vwayaj pasaje pou ale nan AirportLogan"
@@ -1076,7 +1077,7 @@ msgstr "Vwayaj pasaje pou ale nan AirportLogan"
 msgid "Commuter Rail"
 msgstr "Tren banlye"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Tren banlye "
@@ -1194,7 +1195,7 @@ msgstr "Kat kredi/debi"
 msgid "Credit/debit cards"
 msgstr "Kat kredi/debi"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Bato Cross Harbor"
@@ -1265,7 +1266,7 @@ msgstr "Dat"
 msgid "Date and Time"
 msgstr "Dat ak Lè"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Pas pou jounen an"
@@ -1406,7 +1407,7 @@ msgstr "Depa Bonè"
 msgid "Early Departure Stop"
 msgstr "Arè pou depa bonè"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1646,7 +1647,7 @@ msgstr "atann pou gen reta"
 msgid "Explore stations by mode"
 msgstr "Eksplore estasyon yo pa mòd"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Bis Express"
@@ -1678,7 +1679,7 @@ msgstr "Enfòmasyon sou etablisman an"
 msgid "Facility Issue"
 msgstr "Pwoblèm Enstalasyon"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Pake fanmi pou 4 moun (2 granmoun, 2 timoun)"
@@ -1776,7 +1777,7 @@ msgstr "Mizajou ak Pwojè MBTA yo"
 msgid "Ferry"
 msgstr "Bato-Travèsye"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Bato-Travèsye "
@@ -1919,7 +1920,7 @@ msgstr "Pou kesyon oswa kòmantè sou kominike laprès sa a, tanpri kontakte"
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Pou sèvis regilye Jou lasemèn pou Foxboro , tanpri vizite: "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evènman Espesyal Foxboro"
@@ -1942,7 +1943,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "Pakin Pedal ak Park gratis ak sekirite"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Sèvis gratis"
@@ -1962,7 +1963,7 @@ msgstr "Soti nan"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Platfòm konplè ak nivo pou bay monte nan nivo pou chak machin nan yon tren."
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2043,7 +2044,7 @@ msgstr "Branch Green Line %{branch}"
 msgid "Group Name"
 msgstr "Non Gwoup la"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Bato Harbor Loop"
@@ -2069,7 +2070,7 @@ msgstr "Kache"
 msgid "Hide Details"
 msgstr "Kache Detay yo"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2171,17 +2172,17 @@ msgstr "Vann Enstitisyonèl"
 msgid "Intended Audience"
 msgstr "Odyans sib la"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Entèzòn %{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Dire ki pa valab"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarif ki pa valab"
@@ -2420,7 +2421,7 @@ msgstr "Ap chaje depa k ap vini yo"
 msgid "Lobby inside Back Bay station"
 msgstr "Lobi andedan estasyon Back Bay la"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Bis lokal"
@@ -2448,7 +2449,7 @@ msgstr "Kote a pa disponib"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
@@ -2469,7 +2470,7 @@ msgstr "Pèdi & Jwenn"
 msgid "Lost and Found"
 msgstr "Objè ki pèdi ak sa yo jwenn"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2688,8 +2689,8 @@ msgstr "Otorite Transpò Bè Massachusetts, tout dwa rezève."
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport navèt"
@@ -2789,7 +2790,7 @@ msgstr "Jou Memoryal la"
 msgid "Menu"
 msgstr "Meni"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militè"
@@ -2852,23 +2853,23 @@ msgstr "chak mwa"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass chak mwa"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "chak mwa Lokal bis pase"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "chak mwa pase"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "chak mwa pase sou aplikasyon mTicket"
@@ -3072,7 +3073,7 @@ msgstr "Nòt"
 msgid "Notice"
 msgstr "Avi"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3115,12 +3116,12 @@ msgstr "A lè"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Ranp abò nan pòt devan chak bis"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Pas pou yon jou"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "ale senp"
@@ -3474,12 +3475,12 @@ msgstr "Orè depa yo poko disponib, men y ap parèt isit la anvan premye vwayaj 
 msgid "Prefer accessible routes"
 msgstr "Prefere wout aksesib yo"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Premium Ride"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Pri tikè vwayaj prim"
@@ -3685,7 +3686,7 @@ msgstr "Yo p ap pèmèt pasaje san match tikè monte nan tren Boston Stadium yo.
 msgid "Right"
 msgstr "Dwa"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ale retou"
@@ -3923,7 +3924,7 @@ msgstr "Chwazi"
 msgid "Send Us Feedback"
 msgstr "Voye nou kòmantè yo"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "Kat Charlie pou granmoun aje oswa ID TAP"
@@ -3933,7 +3934,7 @@ msgstr "Kat Charlie pou granmoun aje oswa ID TAP"
 msgid "Senior ID Cards"
 msgstr "Kat idantite granmoun"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Granmoun aje"
@@ -4033,8 +4034,8 @@ msgid "Showing major stops."
 msgstr "Montre gwo arè yo."
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "navèt"
@@ -4171,7 +4172,7 @@ msgstr "Padon. Nou te gen pwoblèm pou chanje imaj ou a. Tanpri eseye ankò."
 msgid "Southbound"
 msgstr "Direksyon sid"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Tikè pou evènman espesyal"
@@ -4206,13 +4207,13 @@ msgstr "Karakteristik estasyon"
 msgid "Station Issue"
 msgstr "Pwoblèm estasyon"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estasyon sèvi MBTA %{lines} liy%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4274,12 +4275,12 @@ msgstr "Arè"
 msgid "Stops Skipped"
 msgstr "Arè kontoune"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Elèv"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Kat Charlie pou Elèv"
@@ -4302,7 +4303,7 @@ msgstr "Soumèt yon demann pou dosye piblik bay MBTA a"
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "subway"
@@ -5129,8 +5130,8 @@ msgstr "Sit wèb"
 msgid "Wednesday"
 msgstr "Mèkredi"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Wikenn pase"
@@ -5156,11 +5157,6 @@ msgstr "Sa k ap pase nan MBTA a"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Lè"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5239,12 +5235,12 @@ msgid "Zone"
 msgstr "Zòn"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zòn %{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zòn 1A-10"
@@ -5309,7 +5305,7 @@ msgstr "bis"
 msgid "bus stop"
 msgstr "arè bis"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Lajan kach"
@@ -5324,7 +5320,7 @@ msgstr "chanjman"
 msgid "changes"
 msgstr "chanjman"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "pèman san kontak"
@@ -5396,7 +5392,7 @@ msgid "location"
 msgstr "kote"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplikasyon mTicket"
@@ -5436,7 +5432,7 @@ msgstr "sou"
 msgid "or"
 msgstr "oubyen"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "oubyen "
@@ -5456,7 +5452,7 @@ msgstr "oubyen peye ak Lajan chak sou nenpòt bis"
 msgid "outbound"
 msgstr "derape"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papye bato tikè"
@@ -5646,8 +5642,8 @@ msgstr "sit entènèt"
 msgid "west"
 msgstr "lwès"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5657,3 +5653,13 @@ msgstr "avèk"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "avèk demann ou an."
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -11,5663 +11,5541 @@ msgstr ""
 "Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " E paradas"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " Serviço adicional entre Boston, Hingham e Hull está disponível através do %{link}"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " Ele percorre um número limitado de paradas entre Foxboro e Providence ou Downtown Boston (South Station)."
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " Linhas"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " Rotas"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " O serviço continua mais tarde, no sentido oposto. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " O serviço está disponível mais cedo no sentido oposto. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Os trens partem de Foxboro 30 minutos após o término dos eventos."
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " alerta"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " no "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " em %{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " Neste momento."
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " dependem da distância percorrida (zonas). Consulte as informações abaixo:"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " para alterações de faixa em tempo real."
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " para o "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " chegou a "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " está chegando em "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " está a caminho de "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " Pode sair antes do horário previsto nestes pontos."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " caminhada de um minuto"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " sobre "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " no "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " na pista "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " ou "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " horário"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " horário e mapa"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " símbolo. Verificar "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " que eles desejam partir. passageiro aguardando embarque deve estar visível na plataforma para o "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " parar."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "\"A uma curta distância a pé\""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg} minutos"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count} Paradas"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count} alerta"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count} mais tarde %{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date} em %{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date} em %{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date} está fora do nosso horário atual."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date} até novo aviso"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max} minutos"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1} e %{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label} Somente"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name} Trem suburbano"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "%{place} Informação"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating} igual programadas"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating} horário, termina %{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating} horário, começa %{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name} para %{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time} em %{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y} de %{x} funcionando"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ", "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr "Dinheiro, ou "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "1ª Rota"
 msgstr[1] "%{count} rotas acessíveis"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "1 Rota Inacessível"
 msgstr[1] "%{count} Rotas Inacessíveis"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "1 Rota indisponível"
 msgstr[1] "%{count} rotas indisponíveis"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 alerta"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "1 resultado"
 msgstr[1] "%{count} resultados"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "1 parada"
 msgstr[1] "%{count} paradas"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "1 viagem mais tarde hoje"
 msgstr[1] "%{count} viagens mais tarde hoje"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Passe de 1 dia"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 áreas onde dispositivos de mobilidade com rodas podem ser protegidos"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "24 horas por dia, 7 dias por semana"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Passe de 7 dias"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 para chamadores TTY (telefone para pessoas com deficiência auditiva); VRS para chamadores ASL"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Passeio adaptado para pessoas com deficiência"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarifa de viagem ADA"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/acessibilidade Reclamações"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Sobre"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "Acesso"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "Problema de acesso"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "Problemas de acesso"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "acessibilidade"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "Recursos de acessibilidade"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "acesso em %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "acessível"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Adicionar"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "Adicione %{title} ao calendário"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "Adicionar evento ao calendário"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "Adicionar ao calendário"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "Acesso somente para administradores"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulto"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "Agenda"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "alerta"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "alerta"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "alerta para MBTA %{description}"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "Todos os alertas"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "Todas as passagens Boston Stadium Train incluem a viagem de volta após a partida. Os trens começarão a sair da estação Foxboro 30 minutos após o apito"
 " final. Os trens de retorno partirão do estádio aproximadamente a cada 15 minutos, até que todos os trens tenham partido."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "Todos os trens do centro de sentido"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "Todos os tipos de localização"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "Todos os projetos de melhoria do MBTA"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "Todo sentido bairro Trens"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "Todos os horários e mapas"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "Todos os trens"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "Todos os trens cancelados"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "Todas as atualizações"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Todas as rotas de balsa"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "Todos os campos com um asterisco* são obrigatórios."
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "Todos os modos"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "Todas as localizações propostas estão sujeitas à adequação do local, às licenças necessárias e à disponibilidade de espaço comercial."
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "Alerta âmbar"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Uma foto externa da estação de entrada Downtown Crossing . Bandeiras dos EUA enfeitam a rua, e arranha-céus são visíveis ao fundo. Muitos pedestres estão"
 " passando."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "aproximando-se"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "Chegue por"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "Chegando"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "Chegando por %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "Na máquina de venda de passagens você pode"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "Na estação com vários trilhos fora da estação Norte, Sul, Back Bay e Ruggles , os trens sentido centro embarcam da Trilha 2 e os trens sentido bairro embarcam"
 " da Trilha 1, salvo especificação em contrário. As alterações de trajeto programadas serão indicadas pelo(s) "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Participantes"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "Dados de cartão de tarifa agrupados incorretos"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "Política de Bolsas e Itens Proibidos"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "Esteja na South Station no horário indicado para o seu grupo de embarque. Seu grupo de embarque está no seu trem Boston Stadium Passage."
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "Antes de hoje"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "Projeto de ônibus melhorado"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "Bicicletas são permitidas?"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "Bicicletas permitidas"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "É permitido transportar bicicletas em trens identificados pelo símbolo de bicicleta abaixo do número do trem, sujeito a restrições."
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "Bicicletas não são permitidas."
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "bicicleta"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "bicicleta Edição"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "Armazenamento de bicicletas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "Armazenamento de bicicletas em %{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "bicicleta"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "bicicleta Permitido"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "Bicicletas são permitidas em todos os barcos de balsa."
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line ™ dentro da State Street"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Trem Blue Line saindo da estação Airport"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "Embarque"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "Grupo de internato A"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "Grupo de internato B"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "Grupo de internato C"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "Grupo de internato D"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "Grupo de internato E"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "Grupos de internato"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Passagem obrigatória do trem Boston Stadium"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "A passagem Boston Stadium Train deve ser comprada antecipadamente no aplicativo mTicket . Para obter mais informações, leia nosso %{world_cup_link}"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Trens Boston Stadium"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "Guia do visitante do metrô de Boston"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "Em ambas as direções"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "Traga seu carro ou bicicleta."
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "ônibus"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "ônibus %{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "Guia para Iniciantes em Ônibus"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "Tarifas de ônibus"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "Características do ônibus"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "Mapa de ônibus"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "ônibus Outro"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "Rota de ônibus"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "ponto de ônibus"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "ponto de ônibus Changes"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "ônibus que pode ser rebaixado para facilitar o embarque e o desembarque"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Negócios"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "Oportunidades de Negócios"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "Visualização de calendário"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "Chamar"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "Ligue para nós"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "cancelamento"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "cancelamento"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "Transformação de Capital"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "Carreiras"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "Dinheiro"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Mudar"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "Alterar data"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "Alterar a direção da viagem."
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "Mudanças"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "Varejista Charlie"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Centro de Serviços Charlie"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCards"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards e passagem"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "Verificar"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "Faça o check-in na South Station"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Criança"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Criança menor de 3 anos"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "Escolha seu idioma"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "Escolha um tipo de horário dentre as opções disponíveis."
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "Dia de Natal"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "Direitos civis"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "Gráfico clicável para guias do usuário"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Fechar"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "Fechar caixa de diálogo"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "Moeda"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "Dia de Colombo"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Comentário"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Balsa para passageiros até AirportLogan"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "Commuter Rail"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Commuter Rail "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "Trem suburbano Tarifas"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "Mapa do Trem Suburbano"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "Trem suburbano mensal passe"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "Trem suburbano só ida"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "Trem suburbano Controle Positivo de Trem"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "Trem suburbano Status"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "Mapa das Zonas do Trem Suburbano"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "A disponibilidade de assentos no Trem Suburbano é atualizada regularmente para refletir o número típico de passageiros em uma viagem, com base em dados"
 " automatizados e do condutor dos últimos 14 a 30 dias."
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "Reclamações"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "Elogio"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contato"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Contate-nos"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "Números de contato"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "Contacte a equipa de Atendimento ao Cliente da MBTA e consulte os contactos adicionais da Polícia de Trânsito, Achados e Perdidos e acessibilidades."
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "Contate a Polícia de Trânsito"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Continuar"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "Custo"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "Suportes cobertos para bicicletas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "Estão disponíveis suportes cobertos para bicicletas."
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "Criar uma conta"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "Cartão de crédito/débito"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "Cartões de crédito/débito"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "balsa Cross Harbor"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "Crosstown"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "Superlotado"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "Atual"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "Alerta atual"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "Alterações atuais"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "Situação atual"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "Os limites atuais de disponibilidade de assentos são:"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "Atendimento ao cliente"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Diário"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "Diariamente"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "Data e hora"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Passe diário"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "atraso"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "Atrasado %{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "atraso"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "Partir"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "Partida às"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "Partidas"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "O local de destino não fica suficientemente perto de nenhum ponto de transporte público."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "O local de destino está fora da nossa área de atendimento."
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "Destinos"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "Detalhes"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "desvio"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "Painéis digitais e anúncios automatizados que compartilham informações sobre as linhas principais e paradas."
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "Direção da sua viagem"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "Cartões de Identificação"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "píer interdição"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "Edição píer"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "Documentos"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "Não para em"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "Devido ao rastreamento único"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "Cartão EBT"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "Passe fácil"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "Mais cedo"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "Chegada mais cedo"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "Partida antecipada"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "Parada de partida antecipada"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "sentido leste"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "Elevador"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "Elevador e escada rolante"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "Interdição de elevador"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "Interdição de elevador"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "Linha direta para elevadores/escadas rolantes"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "Elevadores"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "Elevadores em %{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "situação de emergência"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "situação de emergência Contactos"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "Funcionário"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "Reclamações de funcionários"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "Terminou"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "Normas de projeto de engenharia"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "Insira um local de destino"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "Insira um local"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "Insira um local de origem"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "Digite a(s) palavra(s)-chave"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "Insira as palavras-chave do projeto"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "Entre na estação"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "Entre na rotatória"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "Insira seu endereço cadastrado"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "Entrada para as linhas Blue e Green em frente Government Center"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "Acesso às linhas Green e Red fora da Park Street"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "Entrada para as linhas Orange e Red fora do Downtown Crossing"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "entrada para a estação Ruggles"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "Entrada para a Red Line e Trem Suburbano fora South Station"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Erro"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "Escada rolante"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "Escada rolante (somente para baixo)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "Escada rolante (para cima e para baixo)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "Escada rolante (somente subida)"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "Interdição de escada rolante"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "Interdição de escada rolante"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "Escadas rolantes"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "Escadas rolantes em %{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "Chegada prevista à estação de Foxboro"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "Descrição do evento"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "Resumo do evento para "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "Eventos"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "Saia da estação"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "espere atrasos"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "Explore a estação por modo"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Ônibus expresso"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "Ônibus expresso só ida"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Exterior da estação Wonderland"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "Serviço Extra"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "Informações sobre as instalações"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "Problema com as instalações"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Pacote família para 4 pessoas (2 adultos, 2 crianças)"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "Evasão de tarifa"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "Opções de tarifa"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "Opções de tarifa em %{name}"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "Política de Tarifas"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "Locais de Venda a Retalho da Fare"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "Transformação de Tarifas"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "Tipos de tarifas"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "máquina de venda de passagens"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "máquina de venda de passagens"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "Tarifas"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "Informações sobre tarifas"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "Visão geral das tarifas"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "Tarifas por modalidade"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "As tarifas variam entre as balsas de Hingham/Hull e as balsas de Charlestown. Consulte as informações abaixo:"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "Novidades e projetos em destaque do MBTA"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "Balsa"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Balsa "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "balsa Tarifas"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "Mapa da balsa"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "balsa mensal passe"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "Poucas vagas disponíveis"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "Apresentar uma Reclamação de Discriminação"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "Preencha o formulário"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "Filtrar por tipo"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "Finanças"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "Encontre locais sugeridos perto de você"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "Encontre seu local de votação"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "Encontre um local"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "Encontre uma loja perto de você"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "Descubra como participar"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "Concluindo mais uma viagem."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "Primeiro %{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "Parada de bandeira"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "Sinalize para o ônibus em qualquer local seguro ao longo do trajeto."
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "Siga @MBTA no Twitter"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "Siga @MBTA_CR no Twitter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "Siga as placas."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "Siga o link abaixo para encontrar o número associado ao meio de transporte ou rota onde você perdeu seu item."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "Para tarifas de Ônibus expresso, leia a página %{link} completa."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "Para obter todas as informações sobre o serviço de trem da Copa do Mundo, leia nosso %{world_cup_link}"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "Para obter mais informações"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "Para dúvidas ou comentários sobre este comunicado de imprensa, entre em contato com"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Para serviço regular de Dias úteis para Foxboro , visite: "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evento especial de Foxboro"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Linha Franklin"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Gratuitamente"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "Estacionamento seguro gratuito Pedal and Park"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Serviço gratuito"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "Sexta-feira"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Plataforma completa em nível elevado para fornecer embarque nivelado a todos os vagões de um conjunto de trem"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "Obter instruções"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "Envolva-se"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "Receba atualizações de serviço"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "Receba T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "Obtenha um CharlieCard"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "Receba uma fatura pelo correio referente a uma taxa de US$ 1."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "Obtenha instruções de como chegar a este estacionamento."
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "Conheça-nos"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "Receba sugestões de viagem"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "Ir"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "Vai assistir a um jogo da Copa do Mundo no Boston Stadium?"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Ramo Green Line %{branch}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "Nome do grupo"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Balsa Harbor Loop"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "Virada brusca"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "Direita rígida"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Esconder"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "Ocultar detalhes"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Balsa Hingham/Hull"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "História"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "Feriado"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "Feriados"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Lar"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Endereço residencial"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "Legenda de ícones"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "Se aplicável, inclua a hora e a data do incidente, o trajeto e a placa do veículo."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "Se você forneceu suas informações de contato, verifique seu e-mail para obter uma confirmação com um número de protocolo. Se você não receber uma confirmação"
 " em 10 minutos, tente enviar seu feedback novamente ou ligue para nós."
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "Se desejar que entremos em contato por telefone, por favor, informe o melhor número para que possamos ligar para você."
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "Caso seus direitos civis tenham sido violados, você pode registrar uma Reclamação junto ao Escritório de Diversidade e Direitos Civis da MBTA."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "Informações importantes"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "Links importantes"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "sentido centro Trens cancelados"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "Dia da Independência"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "Informações e suporte"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "Vendas Institucionais"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "Público-alvo"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Interzona %{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Duração inválida"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarifa inválida"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "Fatura"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "Isso foi útil? Envie-nos seu feedback"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "Ir para"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "Dia da Independência de Juneteenth"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "Conheça o seu grupo de embarque"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "Conhece algum lojista local que possa estar interessado em se juntar à nossa rede de varejo? Sugira um revendedor e entraremos em contato com ele em seu"
 " nome."
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "Dia do Trabalho"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "Serviços de idiomas"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Idiomas"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "Sobrenome"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "Último %{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Mais tarde"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "Liderança"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "Saiba mais sobre o CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "Saiba mais sobre as tarifas do MBTA"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "Saiba mais sobre acessibilidade no metrô (T)."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "Saiba mais sobre estacionamento de bicicletas em:"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "Saiba mais sobre armazenamento de bicicletas nesta estação."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "Saiba mais sobre bicicleta no Trem suburbano"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "Saiba mais sobre acessibilidade em ônibus."
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "Saiba mais sobre preços de passagens, tipos de passes e como pagar sua passagem no metrô."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "Saiba mais sobre tarifas."
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "Saiba mais sobre balsa acessibilidade"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "Saiba mais sobre como registrar uma Reclamações"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "Saiba mais sobre estacionamento em"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "Saiba mais sobre a Tarifa reduzida e os critérios de elegibilidade."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "Saiba mais sobre as tendências de disponibilidade de assentos."
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "Saiba mais sobre os recursos de acessibilidade neste %{place}."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "Saiba mais sobre este projeto"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "Saiba o que acontece depois de registrar uma Reclamação."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "Caminhando o mínimo"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "Saia em"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "Saindo às %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "Esquerda"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "Informe-nos"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "Linhas e Rotas"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "Visualização em lista"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "Alertas de serviço ao vivo para todos os modais de transporte da MBTA, incluindo metrô, ônibus, trem suburbano e balsa. Atualizações sobre atrasos, obras,"
 " interrupções de elevadores e muito mais."
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "Carregando chegadas..."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "Carregando horário para serviço selecionado"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "Carregando detalhes da viagem"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "Carregando em breve partidas"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Hall de entrada da estação Back Bay"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Local Ônibus local"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "Ônibus local só ida"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Localização"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "A localização não é suficientemente próxima de nenhum ponto de transporte público."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "Localização indisponível"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "Rampa longa"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "Achados e Perdidos"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "Achados e perdidos"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type} estação e localização, incluindo mapas, atualizações em tempo real, informações sobre estacionamento e acessibilidade e conexões."
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{route_name} %{station_name} e horário, incluindo horários, mapas, tarifas, atualizações em tempo real, informações sobre estacionamento e acessibilidade"
 " e conexões."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "Paradas e horário MBTA %{text} , incluindo mapas, informações sobre estacionamento e acessibilidade e tarifas."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{type} rotas %{name} paradas e horários, incluindo mapas, atualizações em tempo real, informações sobre estacionamento e acessibilidade e conexões."
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - Autoridade de Transporte da Baía de Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "Facebook da MBTA"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "Tarifas do MBTA"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "Loja de presentes do MBTA"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "Estação e localização do bonde Green Line MBTA, incluindo mapas, atualizações em tempo real, informações de estacionamento e acessibilidade e conexões."
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "Página inicial do MBTA"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "Página inicial do MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "Instagram da MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "Programa MBTA Transporte paratrânsito"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "Projetos/Programas da MBTA"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "Estação MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "Tópicos do MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "Polícia de Trânsito da MBTA"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "Planejador de viagens do MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "Twitter do MBTA"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "Guias do usuário do MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "MBTA YouTube"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA máquina de venda de passagens"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "MBTA trip pode comprar CharlieTickets e recarregar e comprar %{charlie_card} para ônibus, metrô, Trem suburbano e balsa em lojas em toda a região metropolitana"
 " de Boston e Providence ."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "Últimas notícias do MBTA.com"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "Menu do MBTA.com"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Principal"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "Linha direta principal"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "manutenção"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "parte Reclamações"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "Faça um retorno em U."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "Gerenciado por"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "Muitos lugares disponíveis"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Mapas"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "Dia de Martin Luther King Jr."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "Autoridade de Transporte da Baía de Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "Autoridade de Transporte da Baía de Massachusetts, todos os direitos reservados."
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Circular de transporte da Massport"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Circular de transporte massport %{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "Jogo 18"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "Jogo 30"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "Partida 45"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "Partida 5"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "Partida 61"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "Jogo 74"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "Partida 97"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "Correspondência necessária "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Pode não ser acessível"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "Informações para contato com a mídia"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "Relações com a mídia"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "Informações sobre a reunião"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "Membros da imprensa podem solicitar a inclusão em nossa lista de mídia enviando um e-mail para "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "O público em geral tem o direito de solicitar cópias de documentos da MBTA, com algumas exceções. Aplicam-se taxas, que podem variar dependendo da solicitação."
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "Dia da Memória"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militares"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "Mini plataforma em nível elevado para fornecer embarque nivelado a determinados vagões de um conjunto de trens"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "Minutos"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "Aplicativo móvel"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "Móvel ️"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "Modos"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "Modos de transporte"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "Segunda a sexta-feira"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "De segunda a sexta-feira"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "De segunda a sexta-feira"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "mensal"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensal"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "Passe mensal de ônibus local"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "passe mensal"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "Passe mensal no aplicativo mTicket"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "Mais guias"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "Mais informações"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "Mais de "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "Mais direto"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "Tarifas mais populares"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "A maioria, mas não todos, dos píer MBTA são acessíveis a passageiros com deficiência. Dependendo do nível da maré e do tipo de embarcação utilizada para"
 " a viagem, você poderá encontrar declives acentuados e passarelas estreitas, mesmo em locais acessíveis. Em todas as situações, espere até que um membro"
 " da tripulação diga que é seguro prosseguir."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menu de navegação"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Novo"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "Dia de Ano Novo"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "Notícias"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Próximo"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "Próxima semana"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "Próxima parada"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "Nenhum alerta %{group}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "Sem serviço programado"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "Sem serviço"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "Nenhum alerta aqui."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "Nenhuma alteração será publicada nos próximos 7 dias."
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "Nenhum evento"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Proibido Estacionar"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "Sem serviço hoje"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "Não foi encontrado nenhum canal de trânsito entre a origem e o destino nesta data e hora."
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "Nenhum meio de transporte selecionado"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "Não foram encontradas rotas de transporte público a menos de 2 horas de %{time_on_date}. As rotas podem estar disponíveis em outros horários."
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "Nenhuma viagem encontrada"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "Não em breve feriados"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "serviço normal"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "Sentido norte"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "Não acessível"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "Não disponível"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "Não estava lotado"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Observação"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Obs.:"
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notas"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "Perceber"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Agora"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "Agora em"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "Observado"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "Site oficial da MBTA - informações sobre horários, mapas e tarifas do sistema de transporte público da Grande Boston, incluindo metrô, trem suburbano,"
 " rotas de ônibus e linhas de barco."
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "Site oficial da MBTA — Planeje uma viagem de transporte público na região metropolitana de Boston."
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "Oh não! Estamos com atraso."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "No prazo"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampas de acesso na porta dianteira de cada ônibus"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Passe de um dia"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "só ida"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "em andamento"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "Somente carteiras ou pequenas bolsas transparentes são permitidas. Os itens proibidos devem ser descartados antes do embarque."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "Ou,"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "Ou acesse "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "Encomende o passe mensal"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "O local de origem não fica suficientemente perto de nenhum ponto de transporte público."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "O local de origem está fora da nossa área de atendimento."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "O local de origem ou destino está fora da nossa área de cobertura."
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Outro"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "Outros horários"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "Nosso trabalho"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "Nossos guias do usuário podem ajudá-lo a aprender como navegar pelo sistema, chegar a eventos locais, usar recursos de acessibilidade e muito mais."
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "Fora de serviço"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "sentido bairro Trens Cancelados"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "Suportes externos para bicicletas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "Suportes para bicicletas para uso externo estão disponíveis."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "Durante a noite"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Visão geral"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF †"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF em breve"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Página não encontrada | MBTA - Autoridade de Transporte da Baía de Massachusetts"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "Página não encontrada"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Páginas"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "Transporte paratrânsito (The RIDE)"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "Estacionamento"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "Estacionamento proibido"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "Problema de estacionamento"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "Tarifas de estacionamento"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "Estacionamento em %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Estacionamento disponível"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "deve dizer "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "Mudanças passadas"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "Dia dos Patriotas"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "Pague sua passagem"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Métodos de pagamento"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Pessoas"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "Pessoas aguardam a chegada do trem da linha laranja na North Station"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "Pessoas caminhando junto à plataforma de embarque de trens dentro North Station"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "Pessoas caminhando em direção ao trem Green Line dentro North Station"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "Desempenho"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "Planeje sua jornada"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "Planeje uma viagem"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "Planeje uma viagem acessível."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "Planeje sua viagem"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "Alertas de serviço planejados"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "obras programadas"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "Por favor, insira um comentário para continuar."
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "Por favor, insira um endereço de e-mail válido."
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "Por favor, insira um número de veículo válido, utilizando apenas caracteres numéricos."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "Por favor, insira um endereço que esteja a até 160 quilômetros (100 milhas) de uma área atendida pelo MBTA."
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "Por favor, digite seu primeiro nome para continuar."
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "Por favor, digite seu nome Último para continuar."
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "Por favor, selecione um destino em um local diferente da origem."
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "Por favor, selecione um local de destino."
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "Por favor, selecione um local de origem."
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "Por favor, selecione pelo menos um meio de transporte."
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "Por favor, selecione o tipo de problema."
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "Por favor, especifique uma data e hora no futuro ou selecione 'Agora'."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "Por favor, tente novamente ou envie-nos seu feedback em mbta.com/customer-support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "Políticas e Direitos Civis"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "Mudança de política"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "elevador de embarque portátil"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "Publicado em"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "Os horários de partida previstos ainda não estão disponíveis, mas serão publicados aqui antes da primeira viagem programada."
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "Rotas preferenciais"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Passeio Premium"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarifa Premium para Viagens"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "Comunicados de imprensa"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "Versão de pré-visualização"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Política de privacidade"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "Projetos"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "Locais de Vendas Propostos"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "Reuniões públicas"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "Transporte público na região metropolitana de Boston. Rotas, horário, Planejador de viagens, tarifas, alertas de serviço, atualizações em tempo real e"
 " informações gerais."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "Compre ingressos para Charlie"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "Adquira um CharlieCard ou recarregue um já existente."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "Compre tarifas na máquina de venda de passagens."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "Adquira as passagens em pontos de venda próximos."
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "Qualidade, Conformidade e Supervisão"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "Quartas de final"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "Pergunta"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "trilho"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "Leia nosso %{world_cup_link}"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "Receba notificações de alertas de serviço do MBTA por e-mail ou SMS."
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "Notícias recentes sobre"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "Visitado recentemente"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "Tarifas reduzidas"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "Registre seu CharlieCard para estacionamento de bicicletas."
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "Arquivos relacionados"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "Alertas de serviço relacionados"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "Denuncie fraudes, desperdícios ou abusos."
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Reportar um problema na cancela da passagem de nível"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "Reportar um problema de acessibilidade"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "Reportar um problema com o elevador"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "Reportar um problema na escada rolante"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "Denuncie suspeitas de fraude, desperdício ou abuso."
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "Solicitar Registros Públicos"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "Locais de Venda a Varejo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "Viagem de ida e volta incluída"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "Ande no %{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "Ande no trem %{route} %{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "Passageiro sem ingresso correspondente não será permitido embarcar nos trens Boston Stadium ."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "Certo"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ida e volta"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "Rodada de 32"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "Rota %{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "Rota %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Rotas"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "Alerta de rotas com alta prioridade"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Segurança"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "Sábado"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "Horário e Mapas"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "Mudança de horário"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "horário para"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "Informações sobre os horários das linhas suburbanas do MBTA Trem na região metropolitana de Boston, incluindo atualizações em tempo real e previsões de"
 " chegada."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "Informações sobre os horários das linhas de ônibus da MBTA na região metropolitana de Boston, incluindo atualizações em tempo real e previsões de chegada."
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "Informações sobre os horários das rotas de balsa da MBTA que operam na Baía de Massachusetts, incluindo PDFs para download."
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "Informações sobre os horários das linhas de metrô da MBTA na região metropolitana de Boston, incluindo atualizações em tempo real e previsões de chegada."
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "informações de horário para MBTA metrô, ônibus, Trem suburbano e balsa na região da Grande Boston, incluindo atualizações em tempo real e previsões de"
 " chegada."
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "O horário estará disponível em breve no site da MBTA."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Agendado"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "O serviço programado continua até %{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "Partida programada"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "horário"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "Horário e Mapas"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "Horário e Mapas"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "Somente em dias letivos"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "Pesquise em MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "Procure uma parada ou estação."
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "Pesquise rotas, lugares, informações e muito mais."
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "Resultados da pesquisa para"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "Pesquise no MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "Sazonal"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "Serviço sazonal"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "Disponibilidade de assentos"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "Site oficial do Secretário de State"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "Há estacionamento seguro disponível, mas é necessário o cadastro prévio no Charlie Card."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "Veja o alerta"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "Se vir algo, diga algo."
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "Veja todos os comunicados de imprensa"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "Veja todas as reuniões e eventos públicos."
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "Veja todos os alertas de serviço"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "Consulte todos os guias do usuário"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "Veja o que você pode levar nos trens Boston Stadium ."
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Selecione"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "Envie-nos seu feedback"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "idosos CharlieCard ou TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "Carteiras de identidade de idosos"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Seniores"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "Problema no servidor"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "Serviço"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "alertas de serviço"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "alteração de serviço"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "Reclamações de serviço"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "Consulta de serviço"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "alertas de serviço ou atraso"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "As alterações de serviço estão em vigor de 6 de junho a 12 de julho. Verifique cada dia da %{timetable_link} da sua linha para obter o horário mais atualizado."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "Serviço encerrado"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "O serviço está funcionando conforme o esperado."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "Serviço prestado à Copa do Mundo"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "Viagem mais curta"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Mostrar"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "Mostrar detalhes"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "Mostrar menos paradas"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "Mostrar mais paradas"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "Exibindo tudo"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "Exibindo as principais paradas."
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "transporte circular"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "ônibus circulares"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "Cadastre-se para receber alertas de serviço"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "Entrar"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "Cadastre-se para pagamento automático"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "Cadastre-se para receber T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "Cadastre-se para receber notificações de alerta."
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "Viagem semelhante chega em %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "Viagem semelhante parte às %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "Viagens semelhantes chegam em %{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "Viagens semelhantes partem às %{times}"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "Rastreamento único"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "para o conteúdo principal"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "desvio"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "Ligeiramente à esquerda"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "Ligeiramente à direita"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "Cartão inteligente"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "Rota da Neve"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "Pá de neve"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "Algumas vagas disponíveis"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "Alguma aglomeração"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "Algo deu errado da nossa parte."
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "Desculpe! Não conseguimos parar no seu ponto."
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "Desculpe. Algo deu errado. Por favor, tente novamente."
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "Desculpe. Tivemos problemas para enviar sua imagem. Por favor, tente novamente."
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "Sentido sul"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Evento Especial"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "É necessário um requisito especial."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "estação e alertas de serviço"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "estação"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "estação interdição"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "Características da estação"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "Problema da estação"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estação atendendo MBTA %{lines} linhas%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "estação"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "Estação e estacionamento"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "Estação e paradas"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "Pare %{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "interdição de ponto"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "mudança de ponto"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "Pare"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "Paradas"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "Paradas"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudante"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Cartão CharlieCard para Estudantes"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "Enviar"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "Envie um pedido de acesso a registros públicos para o MBTA."
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "metrô"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "Guia para Iniciantes"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "Tarifas do metrô"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "Mapa do metrô"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "çō só ida"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "Status do metrô"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "Sugira um varejista"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Resumo"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "Domingo"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "Suspensão"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Sustentabilidade"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "Trocar locais de origem e destino"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "Em todo o sistema"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "Alertas/Contagens regressivas/Aplicativos"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY (telefone para pessoas com deficiência auditiva)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "TTY (telefone para pessoas com deficiência auditiva) Telefone"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "Pegue o metrô para votar."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Pegue o elevador."
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "Vai de trem para um jogo da Copa do Mundo?"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "Diga-nos o que você pensa."
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "Conte-nos sobre suas viagens regulares e receba alertas por SMS ou e-mail relevantes para você, nos horários que desejar."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "Temporariamente indisponível"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "Temporariamente fechado"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "Problema temporário"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "Problema temporário"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "Termos de Uso"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "Obrigado por enviar seu feedback. Nossa equipe de Atendimento ao Cliente analisará seus comentários em breve."
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "Dia de Ação de Graças"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "O "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "O Coordenador de Engajamento do Cliente em Acessibilidade em Todo o Sistema e o Contato com o Cliente The RIDE são responsáveis por coordenar as resoluções"
 " de ADA/acessibilidade Reclamações assim que recebidas."
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "A linha Foxboro Special Events é para uso ocasional."
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "A Unidade Especial de Auditoria Interna, vinculada ao Gabinete do Inspetor-Geral, monitora a qualidade, a eficiência e a integridade dos programas do MassDOT."
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "A Viagem"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "O cronograma interativo para"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "Atualmente não há partidas disponíveis em tempo real."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "Atualmente não há partidas disponíveis em tempo real. As partidas programadas estão indicadas abaixo."
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "Não há"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "Não há "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "Não há recursos adicionais de acessibilidade, mas os ônibus são sempre acessíveis para embarcar."
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "Não há alertas"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "Não há prioridades elevadas"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "Não há outros alertas de Trem suburbano neste momento."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "Não há outros alertas neste momento."
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "Não há viagens programadas %{direction} em %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "Não há viagens programadas %{direction} ."
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "Não há viagens programadas em %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "Não há viagens programadas."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "Não há atualizações no momento."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "Atualmente não há nenhum %{route_name} agendado."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "Não há informações sobre obras programadas no momento."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "Não há serviço %{route} programado em %{stop} para este período."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "Houve um problema ao carregar as chegadas."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "Ocorreu um problema ao carregar o horário"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "Ocorreu um problema ao carregar os detalhes da viagem."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "Houve um problema ao carregar as partidas em breve."
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "Este %{place} não é acessível."
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "Essa semana"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "Esta lista não inclui os atuais varejistas do MBTA. Para ver as localizações atuais das lojas, utilize nossa ferramenta."
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "Esta página não está mais em serviço."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "Esta estação não dispõe de arrecadação para bicicletas."
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "Esta estação não possui elevadores."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "Esta estação não possui escadas rolantes."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "Esta estação não possui estacionamento."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "Este ponto não possui máquina de venda de passagens, mas você pode comprar passagens em um"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "Este trem normalmente tem<br /><strong>%{seats} assentos disponíveis</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "Quinta-feira"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "Horário"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "Para"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "Para reportar um problema ou situação de emergência com cruzamento de ferrovia, ligue"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "Para enviar uma ADA/acessibilidade Reclamações ou feedback, ligue"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Hoje"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "Hoje em"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "Ligação gratuita"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "Alteração de embarque na trilha"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "Acompanhar alterações"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "Faixa a ser anunciada"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "Acompanhe sua viagem %{route_type_text} em tempo real com o aplicativo <strong>MBTA Go.</strong>"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Trem"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "Trem %{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "Trem com destino previsto a embarcar a partir de %{platform} às %{station}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "Transferir"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "Transferências"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "Trânsito"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "Polícia de Trânsito"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "Viaje para qualquer lugar nas linhas Blue, Orange, Red e Green pelo mesmo preço."
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "Viagem"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Planejador de viagens"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "Tipo de viagem"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "Viagens de %{from} para %{to}"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "Tente pesquisar o que você está procurando abaixo."
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "Terça-feira"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "Terça-feira, 5 de novembro, é o último dia para votar nas eleições gerais de 2024. Use o metrô (T) para chegar ao seu local de votação."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "Normalmente, menos de 33% dos assentos estão disponíveis e o distanciamento é improvável (cerca de 3 ou mais pessoas por fileira)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "Normalmente, mais de 33% dos assentos permanecem disponíveis e o distanciamento social pode ser possível (aproximadamente 2 a 3 pessoas por fileira)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "Normalmente, mais de 66% dos assentos estão disponíveis e o distanciamento é possível (aproximadamente 0 a 2 pessoas por fileira)."
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "Pista não programada"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "Até %{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "em breve"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "em breve Mudanças"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "em breve Partidas"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "em breve Férias"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "Em breve Reuniões e Eventos Públicos"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "Atualizado em"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "Atualizado: "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "Atualizações"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "Usar"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "Guias do usuário"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "Dia dos Veteranos"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "Via"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Visualizar"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "Veja %{timetable_link} para informações de partida."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "Ver alerta"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "Ver todos os números de contato"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "Ver todas as opções"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "Ver biografia"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "Ver biografia de %{name}"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "Ver tabela de horários em PDF"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "Consulte a tabela de horários em PDF no site da MBTA."
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "Ver anterior"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Ver tudo"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "Veja todas as rotas de ônibus"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "Ver todos os eventos"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "Ver todos os guias"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "Ver todos os jogos"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "Ver todas as notícias"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "Veja todas as atualizações do projeto"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "Ver todos os projetos"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "Veja os elevadores disponíveis."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "Veja as escadas rolantes disponíveis."
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "Veja informações sobre tarifas comuns do ônibus MBTA, metrô, trem suburbano, balsa e The RIDE. Encontre serviços online do CharlieCard e saiba mais sobre"
 " programas de pedidos em grande quantidade."
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "Veja o horário da noite."
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "Veja a visão geral das tarifas"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Veja mais informações sobre pagamento"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "Veja o horário da manhã"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "Ver no Google Maps"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "Ver em MBTA Planejador de viagens"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "Veja as tarifas de estacionamento, informações sobre as instalações e muito mais."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "Ver números de telefone"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visita"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "Visite o Centro de Mobilidade"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Voto"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "Aguardando resultados"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "Aguardando para partir"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "Andar"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "Apenas instruções para caminhada"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "Aniversário de Washington"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "Só podemos fornecer dados de viagem para o horário %{rating} , válido até %{end_date}."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "Ocorreu um problema ao enviar seu feedback. Por favor, ligue para nossa linha direta abaixo ou tente novamente em alguns minutos."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "Queremos garantir que estamos construindo uma rede de varejo que funcione para você. Você pode compartilhar sua opinião usando o formulário abaixo."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "Não foi possível encontrar um local de votação para o seu endereço. Você também pode visitar o"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "Enviaremos comunicados de imprensa e avisos à mídia do MBTA diretamente para você."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "Estamos pedindo a ajuda do público para orientar nossas decisões à medida que implementamos o projeto de Transformação Tarifária nos próximos anos."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "Estamos expandindo nossa rede de locais onde os passageiros podem obter ou carregar um CharlieCard e comprar passes."
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Site"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Passe de fim de semana"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "Fins de semana"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "sentido oeste"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "O que está acontecendo no MBTA?"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Quando"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "Trabalhe conosco"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "Trabalhe conosco"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "Trabalhando"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guia da Copa do Mundo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "Jogos da Copa do Mundo"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "Escreva-nos"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "Durante todo o ano"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "Você também pode enviar um e-mail."
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "Você pode esperar uma resposta para a maioria das passagens dentro de 5 dias úteis. Algumas Reclamações podem exigir investigações mais longas, de até"
 " 30 dias."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "Você pode pagar sua passagem com"
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "Você precisa concordar com nossa Política de Privacidade antes de enviar seu feedback."
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Você precisa completar o reCAPTCHA antes de enviar seu feedback."
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "Sua viagem de Trem Suburbano será afetada pela Copa do Mundo."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "Seu local de votação"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "Zona"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zona %{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zonas 1A-10"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "um membro da tripulação"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "pontos de inveja"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "alerta neste momento"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "chegou em"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "chegando"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "Neste momento"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "entre %{first} e %{last}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "barco"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "ônibus"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "ponto de ônibus"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Dinheiro"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "mudar"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "mudanças"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "pagamento por aproximação"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "atual"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "partiu"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "píer"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "leste"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "alguns"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "para"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "de %{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "saiu"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "sentido centro"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "informações"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "está temporariamente indisponível devido a uma alteração de serviço."
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "linha"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "localização"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplicativo mTicket"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "muitos"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "loja próxima"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "norte"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "de mais de 30 minutos"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "de mais de uma hora"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "para"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "ou"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "ou "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "ou preencha o formulário de feedback nesta página."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "ou pague com Dinheiro em qualquer ônibus"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "sentido bairro"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papel balsa"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "planejado"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "Cartão Tarifa"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "inscrição antecipada"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "Reportar um problema"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "requer"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "localizador de lojas de varejo"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "rota"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "Veja um mapa de todos os locais de venda propostos."
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "serviço"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "alguns"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "sul"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "estação"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "estação"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "parar"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "para"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "Página inicial do MBTA"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "o condutor"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "na manhã seguinte"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "através"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "cronograma para"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "para"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "para %{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "para encontrar seu local de votação e, em seguida, use o"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "para planejar sua viagem"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "total de vagas de estacionamento"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "em direção a"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "acompanhar "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "trem"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "Viagens para hoje"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "até 10 minutos"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "até 15 minutos"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "até 20 minutos"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "até 25 minutos"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "até 30 minutos"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "site"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "oeste"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "com"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Conforme sua solicitação."
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5543,9 +5543,9 @@ msgstr "Conforme sua solicitação."
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "Zona 1A do Porto Interior"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Balsa Winthrop e Quincy Ferry"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " alerta"
 msgid " at "
 msgstr " no "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " em %{address}"
@@ -128,7 +128,7 @@ msgstr " no "
 msgid " on track "
 msgstr " na pista "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y} de %{x} funcionando"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -332,7 +333,7 @@ msgid_plural "%{count} trips later today"
 msgstr[0] "1 viagem mais tarde hoje"
 msgstr[1] "%{count} viagens mais tarde hoje"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Passe de 1 dia"
@@ -350,8 +351,8 @@ msgstr "24 horas por dia, 7 dias por semana"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Passe de 7 dias"
@@ -362,12 +363,12 @@ msgstr "Passe de 7 dias"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 para chamadores TTY (telefone para pessoas com deficiência auditiva); VRS para chamadores ASL"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Passeio adaptado para pessoas com deficiência"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Tarifa de viagem ADA"
@@ -447,7 +448,7 @@ msgstr "Adicionar ao calendário"
 msgid "Admins Only"
 msgstr "Acesso somente para administradores"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Adulto"
@@ -532,7 +533,7 @@ msgstr "Todos os trens cancelados"
 msgid "All Updates"
 msgstr "Todas as atualizações"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Todas as rotas de balsa"
@@ -948,7 +949,7 @@ msgstr "Alterar a direção da viagem."
 msgid "Changes"
 msgstr "Mudanças"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -964,7 +965,7 @@ msgid "Charlie Service Center"
 msgstr "Centro de Serviços Charlie"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
@@ -981,8 +982,8 @@ msgstr "CharlieCards"
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards e passagem"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -997,12 +998,12 @@ msgstr "Verificar"
 msgid "Check-In at South Station"
 msgstr "Faça o check-in na South Station"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Criança"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Criança menor de 3 anos"
@@ -1058,7 +1059,7 @@ msgstr "Dia de Colombo"
 msgid "Comment"
 msgstr "Comentário"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Balsa para passageiros até AirportLogan"
@@ -1076,7 +1077,7 @@ msgstr "Balsa para passageiros até AirportLogan"
 msgid "Commuter Rail"
 msgstr "Commuter Rail"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Commuter Rail "
@@ -1194,7 +1195,7 @@ msgstr "Cartão de crédito/débito"
 msgid "Credit/debit cards"
 msgstr "Cartões de crédito/débito"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "balsa Cross Harbor"
@@ -1265,7 +1266,7 @@ msgstr "Data"
 msgid "Date and Time"
 msgstr "Data e hora"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Passe diário"
@@ -1406,7 +1407,7 @@ msgstr "Partida antecipada"
 msgid "Early Departure Stop"
 msgstr "Parada de partida antecipada"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1646,7 +1647,7 @@ msgstr "espere atrasos"
 msgid "Explore stations by mode"
 msgstr "Explore a estação por modo"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Ônibus expresso"
@@ -1678,7 +1679,7 @@ msgstr "Informações sobre as instalações"
 msgid "Facility Issue"
 msgstr "Problema com as instalações"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Pacote família para 4 pessoas (2 adultos, 2 crianças)"
@@ -1776,7 +1777,7 @@ msgstr "Novidades e projetos em destaque do MBTA"
 msgid "Ferry"
 msgstr "Balsa"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Balsa "
@@ -1919,7 +1920,7 @@ msgstr "Para dúvidas ou comentários sobre este comunicado de imprensa, entre e
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Para serviço regular de Dias úteis para Foxboro , visite: "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Evento especial de Foxboro"
@@ -1942,7 +1943,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "Estacionamento seguro gratuito Pedal and Park"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Serviço gratuito"
@@ -1962,7 +1963,7 @@ msgstr "De"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Plataforma completa em nível elevado para fornecer embarque nivelado a todos os vagões de um conjunto de trem"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2043,7 +2044,7 @@ msgstr "Ramo Green Line %{branch}"
 msgid "Group Name"
 msgstr "Nome do grupo"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Balsa Harbor Loop"
@@ -2069,7 +2070,7 @@ msgstr "Esconder"
 msgid "Hide Details"
 msgstr "Ocultar detalhes"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2171,17 +2172,17 @@ msgstr "Vendas Institucionais"
 msgid "Intended Audience"
 msgstr "Público-alvo"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Interzona %{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Duração inválida"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Tarifa inválida"
@@ -2421,7 +2422,7 @@ msgstr "Carregando em breve partidas"
 msgid "Lobby inside Back Bay station"
 msgstr "Hall de entrada da estação Back Bay"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Local Ônibus local"
@@ -2449,7 +2450,7 @@ msgstr "Localização indisponível"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
@@ -2470,7 +2471,7 @@ msgstr "Achados e Perdidos"
 msgid "Lost and Found"
 msgstr "Achados e perdidos"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2690,8 +2691,8 @@ msgstr "Autoridade de Transporte da Baía de Massachusetts, todos os direitos re
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Circular de transporte da Massport"
@@ -2791,7 +2792,7 @@ msgstr "Dia da Memória"
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Militares"
@@ -2854,23 +2855,23 @@ msgstr "mensal"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "LinkPass mensal"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "Passe mensal de ônibus local"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "passe mensal"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "Passe mensal no aplicativo mTicket"
@@ -3075,7 +3076,7 @@ msgstr "Notas"
 msgid "Notice"
 msgstr "Perceber"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3119,12 +3120,12 @@ msgstr "No prazo"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Rampas de acesso na porta dianteira de cada ônibus"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Passe de um dia"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "só ida"
@@ -3478,12 +3479,12 @@ msgstr "Os horários de partida previstos ainda não estão disponíveis, mas se
 msgid "Prefer accessible routes"
 msgstr "Rotas preferenciais"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Passeio Premium"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Tarifa Premium para Viagens"
@@ -3690,7 +3691,7 @@ msgstr "Passageiro sem ingresso correspondente não será permitido embarcar nos
 msgid "Right"
 msgstr "Certo"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "ida e volta"
@@ -3930,7 +3931,7 @@ msgstr "Selecione"
 msgid "Send Us Feedback"
 msgstr "Envie-nos seu feedback"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "idosos CharlieCard ou TAP ID"
@@ -3940,7 +3941,7 @@ msgstr "idosos CharlieCard ou TAP ID"
 msgid "Senior ID Cards"
 msgstr "Carteiras de identidade de idosos"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Seniores"
@@ -4040,8 +4041,8 @@ msgid "Showing major stops."
 msgstr "Exibindo as principais paradas."
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "transporte circular"
@@ -4178,7 +4179,7 @@ msgstr "Desculpe. Tivemos problemas para enviar sua imagem. Por favor, tente nov
 msgid "Southbound"
 msgstr "Sentido sul"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Evento Especial"
@@ -4213,13 +4214,13 @@ msgstr "Características da estação"
 msgid "Station Issue"
 msgstr "Problema da estação"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "estação atendendo MBTA %{lines} linhas%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4281,12 +4282,12 @@ msgstr "Paradas"
 msgid "Stops Skipped"
 msgstr "Paradas"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudante"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Cartão CharlieCard para Estudantes"
@@ -4309,7 +4310,7 @@ msgstr "Envie um pedido de acesso a registros públicos para o MBTA."
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "metrô"
@@ -5136,8 +5137,8 @@ msgstr "Site"
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Passe de fim de semana"
@@ -5163,11 +5164,6 @@ msgstr "O que está acontecendo no MBTA?"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Quando"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5247,12 +5243,12 @@ msgid "Zone"
 msgstr "Zona"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Zona %{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Zonas 1A-10"
@@ -5317,7 +5313,7 @@ msgstr "ônibus"
 msgid "bus stop"
 msgstr "ponto de ônibus"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Dinheiro"
@@ -5332,7 +5328,7 @@ msgstr "mudar"
 msgid "changes"
 msgstr "mudanças"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "pagamento por aproximação"
@@ -5404,7 +5400,7 @@ msgid "location"
 msgstr "localização"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Aplicativo mTicket"
@@ -5444,7 +5440,7 @@ msgstr "para"
 msgid "or"
 msgstr "ou"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "ou "
@@ -5464,7 +5460,7 @@ msgstr "ou pague com Dinheiro em qualquer ônibus"
 msgid "outbound"
 msgstr "sentido bairro"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "papel balsa"
@@ -5654,8 +5650,8 @@ msgstr "site"
 msgid "west"
 msgstr "oeste"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5665,3 +5661,13 @@ msgstr "com"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Conforme sua solicitação."
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " cảnh báo"
 msgid " at "
 msgstr " Tại "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " tại %{address}"
@@ -128,7 +128,7 @@ msgstr " trên "
 msgid " on track "
 msgstr " trên đường ray "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y} trong số %{x} đang làm việc"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -326,7 +327,7 @@ msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "%{count} chuyến đi nữa vào hôm nay"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Vé 1 ngày"
@@ -344,8 +345,8 @@ msgstr "24 giờ một ngày, 7 ngày một tuần"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Vé 7 ngày"
@@ -356,12 +357,12 @@ msgstr "Vé 7 ngày"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 cho người gọi TTY;  VRS cho người gọi ASL"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Xe dành cho người khuyết tật"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Giá vé xe ADA"
@@ -441,7 +442,7 @@ msgstr "Thêm vào lịch"
 msgid "Admins Only"
 msgstr "Chỉ dành cho quản trị viên"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Người lớn"
@@ -526,7 +527,7 @@ msgstr "Tất cả các chuyến tàu bị hủy"
 msgid "All Updates"
 msgstr "Tất cả các bản cập nhật"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Tất cả các tuyến phà"
@@ -942,7 +943,7 @@ msgstr "Thay đổi hướng đi của chuyến đi."
 msgid "Changes"
 msgstr "Thay đổi"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -958,7 +959,7 @@ msgid "Charlie Service Center"
 msgstr "Trung Tâm Dịch Vụ Charlie"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
@@ -975,8 +976,8 @@ msgstr "CharlieCard"
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & vé"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -991,12 +992,12 @@ msgstr "Kiểm tra"
 msgid "Check-In at South Station"
 msgstr "Nhận phòng tại South Station"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Đứa trẻ"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Trẻ em dưới 3 tuổi"
@@ -1052,7 +1053,7 @@ msgstr "Ngày Columbus"
 msgid "Comment"
 msgstr "Bình luận"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Commuter phà đến Logan Airport"
@@ -1070,7 +1071,7 @@ msgstr "Commuter phà đến Logan Airport"
 msgid "Commuter Rail"
 msgstr "Đi lại bằng Đường sắt"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Đi lại bằng Đường sắt "
@@ -1188,7 +1189,7 @@ msgstr "Thẻ tín dụng/thẻ ghi nợ"
 msgid "Credit/debit cards"
 msgstr "Thẻ tín dụng/thẻ ghi nợ"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Băng qua cảng phà"
@@ -1259,7 +1260,7 @@ msgstr "Ngày"
 msgid "Date and Time"
 msgstr "Ngày và giờ"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Đĩa vé"
@@ -1400,7 +1401,7 @@ msgstr "Khởi hành sớm"
 msgid "Early Departure Stop"
 msgstr "Điểm dừng khởi hành sớm"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1640,7 +1641,7 @@ msgstr "dự kiến trễ chuyến"
 msgid "Explore stations by mode"
 msgstr "Khám phá nhà ga theo chế độ"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Xe buýt tốc hành"
@@ -1672,7 +1673,7 @@ msgstr "Thông tin về cơ sở"
 msgid "Facility Issue"
 msgstr "Vấn đề cơ sở vật chất"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Gói gia đình 4 người (2 người lớn, 2 trẻ em)"
@@ -1770,7 +1771,7 @@ msgstr "Các cập nhật và dự án nổi bật của MBTA"
 msgid "Ferry"
 msgstr "Phà"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Phà "
@@ -1913,7 +1914,7 @@ msgstr "Mọi thắc mắc hoặc góp ý về thông cáo báo chí này, vui l
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Đối với dịch vụ thường xuyên trong tuần đến Foxboro vui lòng truy cập: "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Sự kiện đặc biệt của Foxboro"
@@ -1936,7 +1937,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "Đỗ xe an toàn miễn phí cho chương trình Pedal and Park"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Dịch vụ miễn phí"
@@ -1956,7 +1957,7 @@ msgstr "Từ"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Sân ga cao đầy đủ để cung cấp khả năng lên máy bay ngang bằng cho mọi toa trong một đoàn tàu"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2037,7 +2038,7 @@ msgstr "Chi nhánh %{branch} Green Line"
 msgid "Group Name"
 msgstr "Tên nhóm"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Harbor Loop phà"
@@ -2063,7 +2064,7 @@ msgstr "Trốn"
 msgid "Hide Details"
 msgstr "Ẩn chi tiết"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2165,17 +2166,17 @@ msgstr "Bán hàng cho tổ chức"
 msgid "Intended Audience"
 msgstr "Đối tượng mục tiêu"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Vùng xen kẽ %{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Thời lượng không hợp lệ"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Giá vé không hợp lệ"
@@ -2415,7 +2416,7 @@ msgstr "Đang tải các chuyến khởi hành sắp tới"
 msgid "Lobby inside Back Bay station"
 msgstr "Sảnh bên trong Back Bay nhà ga"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Xe buýt địa phương"
@@ -2443,7 +2444,7 @@ msgstr "Vị trí không có sẵn"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
@@ -2464,7 +2465,7 @@ msgstr "Đồ Thất Lạc & Tìm Thấy"
 msgid "Lost and Found"
 msgstr "Đồ thất lạc"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2685,8 +2686,8 @@ msgstr "Cơ quan Giao thông Vận tải Vịnh Massachusetts, mọi quyền đ�
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport xe đưa đón"
@@ -2786,7 +2787,7 @@ msgstr "Ngày tưởng niệm"
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Quân đội"
@@ -2849,23 +2850,23 @@ msgstr "vé tháng"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "vé tháng LinkPass"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "vé tháng Local xe buýt vé"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "vé tháng vé"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "vé tháng vé trên ứng dụng mTicket"
@@ -3070,7 +3071,7 @@ msgstr "Ghi chú"
 msgid "Notice"
 msgstr "Để ý"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3114,12 +3115,12 @@ msgstr "Đúng giờ"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Đường dốc trên xe ở cửa trước của mỗi xe buýt"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Một ngày vé"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "vé một chiều"
@@ -3474,12 +3475,12 @@ msgstr "Hiện tại chưa có thông tin về thời gian khởi hành dự ki�
 msgid "Prefer accessible routes"
 msgstr "Prefer có thể tiếp cận được routes"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Chuyến đi cao cấp"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Giá vé xe hạng sang"
@@ -3686,7 +3687,7 @@ msgstr "hành khách không có vé phù hợp sẽ không được phép lên x
 msgid "Right"
 msgstr "Phải"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "vé khứ hồi"
@@ -3925,7 +3926,7 @@ msgstr "Lựa chọn"
 msgid "Send Us Feedback"
 msgstr "Gửi phản hồi cho chúng tôi"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "người cao tuổi CharlieCard hoặc TAP ID"
@@ -3935,7 +3936,7 @@ msgstr "người cao tuổi CharlieCard hoặc TAP ID"
 msgid "Senior ID Cards"
 msgstr "Thẻ ID người cao tuổi"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Người cao tuổi"
@@ -4036,8 +4037,8 @@ msgid "Showing major stops."
 msgstr "Hiển thị các điểm dừng chính."
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "xe đưa đón"
@@ -4174,7 +4175,7 @@ msgstr "Lấy làm tiếc. Chúng tôi đã gặp sự cố khi tải lên hình
 msgid "Southbound"
 msgstr "Hướng Nam"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Special Event vé"
@@ -4209,13 +4210,13 @@ msgstr "Tính năng nhà ga"
 msgid "Station Issue"
 msgstr "Nhà ga Vấn đề"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "nhà ga phục vụ MBTA %{lines} dây chuyền%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4277,12 +4278,12 @@ msgstr "Dừng lại"
 msgid "Stops Skipped"
 msgstr "Stops đường vòng"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Học sinh"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Thẻ sinh viên Charlie"
@@ -4305,7 +4306,7 @@ msgstr "Gửi yêu cầu cung cấp hồ sơ công khai đến MBTA."
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "tàu điện ngầm"
@@ -5133,8 +5134,8 @@ msgstr "Trang web"
 msgid "Wednesday"
 msgstr "Thứ Tư"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Ngày cuối tuần vé"
@@ -5160,11 +5161,6 @@ msgstr "Điều gì đang xảy ra tại MBTA?"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Khi"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5243,12 +5239,12 @@ msgid "Zone"
 msgstr "Vùng"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Khu vực %{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Khu vực 1A-10"
@@ -5313,7 +5309,7 @@ msgstr "xe buýt"
 msgid "bus stop"
 msgstr "trạm xe buýt"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Tiền mặt"
@@ -5328,7 +5324,7 @@ msgstr "thay đổi"
 msgid "changes"
 msgstr "thay đổi"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "thanh toán không tiếp xúc"
@@ -5400,7 +5396,7 @@ msgid "location"
 msgstr "vị trí"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Ứng dụng mTicket"
@@ -5440,7 +5436,7 @@ msgstr "lên"
 msgid "or"
 msgstr "hoặc là"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "hoặc là "
@@ -5460,7 +5456,7 @@ msgstr "hoặc thanh toán bằng Tiền mặt trên bất kỳ xe buýt nào"
 msgid "outbound"
 msgstr "hướng đi ra ngoại thành"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "paper phà vé"
@@ -5650,8 +5646,8 @@ msgstr "trang web"
 msgid "west"
 msgstr "phía tây"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5661,3 +5657,13 @@ msgstr "với"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Theo yêu cầu của bạn."
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5539,9 +5539,9 @@ msgstr "Theo yêu cầu của bạn."
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "Khu vực cảng nội địa 1A"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop và Quincy Ferry"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -11,5659 +11,5537 @@ msgstr ""
 "Language: vi_VN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " & Điểm dừng"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " Dịch vụ bổ sung giữa Boston, Hingham và Hull có sẵn qua %{link}"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " Nó đi dọc theo các điểm dừng giới hạn giữa Foxboro và Providence hoặc Downtown Boston (South Station)"
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " Dòng"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " Tuyến đường"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " Dịch vụ sẽ tiếp tục hoạt động vào cuối ngày theo hướng ngược lại. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " Dịch vụ có sẵn vào đầu ngày theo hướng ngược lại. %{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Tàu khởi hành từ Foxboro 30 phút sau khi kết thúc sự kiện"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " cảnh báo"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " Tại "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " tại %{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " vào thời điểm này."
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " Tùy thuộc vào khoảng cách di chuyển (vùng). Vui lòng tham khảo thông tin bên dưới:"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " Để theo dõi sự thay đổi trong thời gian thực."
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " cho "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " đã đến "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " đang đến "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " đang trên đường đến "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " có thể khởi hành trước lịch trình tại các điểm dừng này."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " đi bộ vài phút"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " TRÊN "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " trên "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " trên đường ray "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " hoặc là "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " lịch trình"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " lịch trình và bản đồ"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " biểu tượng. Kiểm tra "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " Họ muốn rời đi. hành khách waiting to lên xe phải được nhìn thấy trên sân ga cho "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " dừng lại."
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "\"Có thể đi bộ đến\""
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg} phút"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count} Dừng lại"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count} cảnh báo"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count} sau đó %{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date} tại %{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date} tại %{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date} nằm ngoài lịch trình hiện tại của chúng tôi."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date} cho đến khi có thông báo mới"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max} phút"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1} và %{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "Chỉ %{mode_label}"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name} Đường sắt ngoại ô"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "Thông tin %{place}"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating} công việc đã lên kế hoạch"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating} lịch trình, kết thúc %{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating} lịch trình, bắt đầu %{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name} đến %{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time} trên %{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y} trong số %{x} đang làm việc"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr ", "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr ", Tiền mặt, hoặc "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "%{count} có thể tiếp cận được Routes"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "%{count} Tuyến đường không thể tiếp cận"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "%{count} không có sẵn Routes"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 cảnh báo"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "%{count} kết quả"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "%{count} điểm dừng"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "%{count} chuyến đi nữa vào hôm nay"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "Vé 1 ngày"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 khu vực có thể đảm bảo thiết bị hỗ trợ di chuyển"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "24 giờ một ngày, 7 ngày một tuần"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "Vé 7 ngày"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "711 cho người gọi TTY;  VRS cho người gọi ASL"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "Xe dành cho người khuyết tật"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "Giá vé xe ADA"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/khả năng tiếp cận Khiếu nại"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Về"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "Truy cập"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "Vấn đề truy cập"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "Vấn đề truy cập"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "khả năng tiếp cận"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "khả năng tiếp cận Tài nguyên"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "khả năng tiếp cận at %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "có thể tiếp cận được"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Thêm vào"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "Thêm %{title} vào lịch"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "Thêm sự kiện vào lịch"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "Thêm vào lịch"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "Chỉ dành cho quản trị viên"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "Người lớn"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "Chương trình nghị sự"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "cảnh báo"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "cảnh báo"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "cảnh báo for MBTA %{description}"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "Tất cả cảnh báo"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "Tất cả vé Boston Stadium Train đều bao gồm một chuyến trở về sau trận đấu. Các chuyến tàu sẽ bắt đầu khởi hành Foxboro nhà ga 30 phút sau tiếng còi mãn"
 " cuộc. Các chuyến tàu trở về sẽ rời sân vận động khoảng 15 phút một chuyến cho đến khi tất cả các chuyến tàu đã khởi hành."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "All hướng đi vào trung tâm Trains"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "Tất cả các loại địa điểm"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "Tất cả các dự án cải tiến của MBTA"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "All hướng đi ra ngoại thành Trains"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "Tất cả lịch trình và bản đồ"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "Tất cả các chuyến tàu"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "Tất cả các chuyến tàu bị hủy"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "Tất cả các bản cập nhật"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "Tất cả các tuyến phà"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "Tất cả các trường có dấu sao (*) đều bắt buộc."
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "Tất cả các chế độ"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "Tất cả các địa điểm được đề xuất đều phụ thuộc vào sự phù hợp của khu đất, giấy phép và khả năng cung cấp dịch vụ bán lẻ."
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "Amber cảnh báo"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Ảnh chụp bên ngoài của ngôi nhà Downtown Crossing ga lối vào. Những lá cờ Mỹ được treo dọc con phố, và những tòa nhà chọc trời hiện lên ở phía xa. Có rất"
 " nhiều người đi bộ ngang qua."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "đang tiến vào ga"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "Đến bằng"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "Đến nơi"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "Đến lúc %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "Tại các máy bán vé tự động, bạn có thể"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "Tại nhà ga có nhiều đường ray bên ngoài Phía Bắc, Hướng Nam, Back Bayvà Ruggles nhà ga, hướng đi vào trung tâm trains lên xe từ Track 2, và hướng đi ra"
 " ngoại thành trains lên xe từ Track 1 trừ khi có quy định khác. Những thay đổi về lộ trình dự kiến sẽ được đánh dấu bằng... "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Người tham dự"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "Dữ liệu thẻ thanh toán được nhóm không chính xác"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "Quy định về túi xách và các vật dụng bị cấm"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "Có mặt tại South Station vào thời gian hiển thị cho nhóm nội trú của quý vị. Nhóm lên máy bay của bạn đang ở trên Boston Stadium Train vé."
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "Trước ngày hôm nay"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "Dự án xe buýt tốt hơn"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "Được phép mang xe đạp?"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "Cho phép xe đạp"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "Xe đạp được phép mang lên các chuyến tàu có biểu tượng xe đạp bên dưới số hiệu tàu, nhưng phải tuân thủ một số quy định."
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "Không được phép mang xe đạp vào."
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "xe đạp"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "Vấn đề xe đạp"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "Lưu trữ xe đạp"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "Chỗ để xe đạp tại %{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "xe đạp"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "xe đạp Allowed"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "Xe đạp được phép trên tất cả các thuyền phà"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line tàu điện ngầm sân ga bên trong Phố State"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line tàu khởi hành Airport nhà ga"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "Lên tàu"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "Nhóm lên máy bay A"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "Nhóm lên máy bay B"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "Nhóm lên máy bay C"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "Nhóm lên máy bay D"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "Nhóm lên máy bay E"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "Nhóm lên máy bay"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Boston Stadium Train vé Required"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "Boston Stadium Train vé phải được mua trước trên ứng dụng mTicket . Để biết thêm thông tin, hãy đọc %{world_cup_link}của chúng tôi."
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Tàu hỏa"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "Hướng dẫn du khách Boston đến tàu điện ngầm"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "Cả hai hướng"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "Mang theo ô tô hoặc xe đạp của bạn"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "xe buýt"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "xe buýt %{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "Hướng dẫn dành cho người mới bắt đầu đi xe buýt"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "Giá vé xe buýt"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "Tính năng xe buýt"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "Bản đồ xe buýt"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "xe buýt Khác"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "Tuyến xe buýt"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "trạm xe buýt"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "trạm xe buýt Thay đổi"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "Xe buýt có thể hạ xuống để lên và xuống dễ dàng hơn"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Việc kinh doanh"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "Cơ hội kinh doanh"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "Chế độ xem lịch"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "Gọi"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "Hãy gọi cho chúng tôi"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Hủy"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "huỷ chuyến"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "huỷ chuyến"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Đã hủy"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "Chuyển đổi vốn"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "Nghề nghiệp"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "Tiền mặt"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Thay đổi"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "Ngày thay đổi"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "Thay đổi hướng đi của chuyến đi."
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "Thay đổi"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "Charlie Retailer"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Trung Tâm Dịch Vụ Charlie"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCard"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "CharlieCards & vé"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "Kiểm tra"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "Nhận phòng tại South Station"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Đứa trẻ"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "Trẻ em dưới 3 tuổi"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "Chọn ngôn ngữ của bạn"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "Chọn loại lịch trình từ các tùy chọn có sẵn"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "Ngày Giáng sinh"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "Quyền công dân"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "Đồ họa có thể nhấp cho người dùng Hướng dẫn"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Đóng"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "Đóng hộp thoại"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "Đồng xu"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "Ngày Columbus"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Bình luận"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "Commuter phà đến Logan Airport"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "Đi lại bằng Đường sắt"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "Đi lại bằng Đường sắt "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "Đường sắt ngoại ô Fares"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "Đường sắt ngoại ô Map"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "Đường sắt ngoại ô vé tháng vé"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "Đường sắt ngoại ô vé một chiều"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "Đường sắt ngoại ô Positive Train Control"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "Đường sắt ngoại ô Status"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "Đường sắt ngoại ô Zones Map"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "Tình trạng chỗ ngồi của Đường sắt ngoại ô được cập nhật thường xuyên để phản ánh lượng hành khách điển hình của chuyến đi dựa trên dữ liệu tự động và người"
 " điều khiển trong 14-30 ngày qua."
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "Khiếu nại"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "Lời khen"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Liên hệ"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Liên hệ với chúng tôi"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "Số điện thoại liên hệ"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "Liên hệ với nhóm MBTA Hỗ trợ khách hàng và xem các số liên lạc bổ sung cho Cảnh sát Giao thông, Đồ thất lạc và khả năng tiếp cận."
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "Liên hệ với Cảnh sát Giao thông"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Tiếp tục"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "Trị giá"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "Giá để xe đạp có mái che"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "Giá để xe đạp có mái che có sẵn"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "Tạo tài khoản"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "Thẻ tín dụng/thẻ ghi nợ"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "Thẻ tín dụng/thẻ ghi nợ"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "Băng qua cảng phà"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "Crosstown"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "Đông đúc"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "Hiện hành"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "Current cảnh báo"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "Những thay đổi hiện tại"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "Tình trạng hiện tại"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "Số lượng chỗ ngồi tối thiểu hiện tại là:"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "Hỗ trợ khách hàng"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "Hằng ngày"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "Daily lịch trình"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Ngày"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "Ngày và giờ"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "Đĩa vé"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "trễ chuyến"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "Bị trì hoãn %{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "trễ chuyến"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "Khởi hành"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "Khởi hành lúc"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "Khởi hành"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "Địa điểm cần đến không đủ gần với bất kỳ trạm giao thông công cộng nào."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "Địa điểm nhận hàng nằm ngoài khu vực phục vụ của chúng tôi."
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "Điểm đến"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "Chi tiết"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "đường vòng"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Các nhà phát triển"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "Màn hình kỹ thuật số và thông báo tự động chia sẻ Thông tin Các tuyến chính và dừng"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "Hướng đi của chuyến đi của bạn"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "Thẻ ID người khuyết tật"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "bến tàu đóng đường"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "bến tàu Issue"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "Tài liệu"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "Không dừng lại ở"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "Do chỉ có một kênh theo dõi."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "Thẻ EBT"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ vé"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "Trước đó"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "Đến sớm nhất"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "Khởi hành sớm"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "Điểm dừng khởi hành sớm"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "Hướng Đông"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "Thang máy"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "Thang máy & Thang cuốn"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "Elevator đóng đường"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "Elevator đóng đường"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "Đường dây nóng thang máy/thang cuốn"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "Thang máy"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "Thang máy tại %{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "tình huống khẩn cấp"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "tình huống khẩn cấp Danh bạ"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "Người lao động"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "Khiếu nại của nhân viên"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "Đã kết thúc"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "Tiêu chuẩn thiết kế kỹ thuật"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "Nhập địa điểm đích đến"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "Nhập vị trí"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "Nhập vị trí xuất phát"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "Nhập từ khóa"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "Nhập từ khóa dự án"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "Vào nhà ga"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "Đi vào vòng tròn giao thông"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "Nhập địa chỉ đã đăng ký của bạn"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "lối vào to Blue và Green Lines bên ngoài Government Center"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "lối vào to Green và Red Lines bên ngoài Park Street"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "lối vào to Orange và Red Lines bên ngoài Downtown Crossing"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "lối vào to Ruggles nhà ga"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "lối vào to Red Line và Đường sắt ngoại ô outside South Station"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Lỗi"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "Thang cuốn"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "Thang cuốn (chỉ đi xuống)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "Thang cuốn (lên và xuống)"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "Thang cuốn (chỉ đi lên)"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "Thang cuốn đóng đường"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "Thang cuốn đóng đường"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "Thang cuốn"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "Thang cuốn tại %{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "Dự kiến đến nhà Foxboro ga"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "Mô tả sự kiện"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "Tóm tắt sự kiện cho "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "Sự kiện"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "Ra khỏi nhà ga"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "dự kiến trễ chuyến"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "Khám phá nhà ga theo chế độ"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "Xe buýt tốc hành"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "Xe buýt tốc hành vé một chiều"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Bên ngoài nhà ga Wonderland"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "Dịch vụ bổ sung"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "Thông tin về cơ sở"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "Vấn đề cơ sở vật chất"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "Gói gia đình 4 người (2 người lớn, 2 trẻ em)"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "Trốn vé"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "Các lựa chọn giá vé"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "Các tùy chọn giá vé tại %{name}"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "Chính sách giá vé"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "Địa điểm bán vé"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "Chuyển đổi giá vé"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "Các loại vé"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "máy bán vé tự động"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "máy bán vé tự động"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "Giá vé"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "Thông tin giá vé"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "Tổng quan về giá vé"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "Giá vé theo phương thức vận chuyển"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Giá vé khác nhau giữa Hingham/Hull phà và Charlestown phà. Vui lòng tham khảo thông tin bên dưới:"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "Các cập nhật và dự án nổi bật của MBTA"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "Phà"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "Phà "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "Giá vé phà"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "Bản đồ phà"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "Phà vé tháng vé"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "Chỉ còn vài chỗ ngồi."
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "Nộp đơn phân biệt đối xử Khiếu nại"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "Điền vào mẫu đơn"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "Lọc theo loại"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "Tài chính"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "Tìm các địa điểm được đề xuất gần bạn"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "Tìm địa điểm bỏ phiếu của bạn"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "Tìm một địa điểm"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "Tìm cửa hàng gần bạn"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "Tìm hiểu cách tham gia"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "Kết thúc một chuyến đi khác"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "Đầu tiên %{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "Dừng cờ"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "Gắn cờ xe buýt ở bất kỳ nơi an toàn nào dọc theo tuyến đường"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "Theo dõi @MBTA trên Twitter"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "Hãy theo dõi @MBTA_CR trên Twitter"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "Hãy làm theo biển báo."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "Hãy nhấp vào đường dẫn bên dưới để tìm số hiệu liên quan đến phương thức hoặc tuyến đường mà bạn đã làm mất đồ."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "Để biết giá vé Xe buýt tốc hành, hãy đọc trang %{link} đầy đủ."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "Để biết tất cả thông tin về dịch vụ tàu hỏa World Cup, hãy đọc %{world_cup_link}của chúng tôi."
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "Để biết thêm thông tin"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "Mọi thắc mắc hoặc góp ý về thông cáo báo chí này, vui lòng liên hệ"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "Đối với dịch vụ thường xuyên trong tuần đến Foxboro vui lòng truy cập: "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Sự kiện đặc biệt của Foxboro"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Tuyến Franklin"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Miễn phí"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "Đỗ xe an toàn miễn phí cho chương trình Pedal and Park"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "Dịch vụ miễn phí"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "Thứ sáu"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "Từ"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "Sân ga cao đầy đủ để cung cấp khả năng lên máy bay ngang bằng cho mọi toa trong một đoàn tàu"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "Chỉ đường"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "Hãy tham gia!"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "Nhận thông tin cập nhật dịch vụ"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "Nhận T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "Nhận thẻ CharlieCard"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "Nhận hóa đơn qua đường bưu điện với phí 1 đô la."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "Tìm đường đến bãi đậu xe này"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "Tìm hiểu thêm về chúng tôi"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "Nhận gợi ý chuyến đi"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "Đi"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "Đi xem một trận đấu World Cup tại Boston Stadium?"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Chi nhánh %{branch} Green Line"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "Tên nhóm"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "Harbor Loop phà"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "Cực trái"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "Cực hữu"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Trốn"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "Ẩn chi tiết"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Hingham/Hull phà"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Lịch sử"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "Holiday lịch trình"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "Ngày lễ"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Trang chủ"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Địa chỉ nhà"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "Chú thích biểu tượng"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "Nếu có thể, vui lòng ghi rõ thời gian và ngày xảy ra sự cố, tuyến đường và biển số xe."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "Nếu bạn đã cung cấp thông tin liên hệ, hãy kiểm tra email để nhận thư xác nhận kèm số hiệu sự cố. Nếu bạn không nhận được xác nhận trong vòng 10 phút,"
 " hãy thử gửi phản hồi lại hoặc gọi cho chúng tôi theo số điện thoại..."
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "Nếu bạn muốn chúng tôi gọi lại, vui lòng cung cấp số điện thoại thuận tiện nhất để chúng tôi có thể liên lạc được với bạn."
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "Nếu quyền công dân của bạn bị vi phạm, bạn có thể nộp đơn khiếu nại cho Văn phòng Đa dạng và Dân quyền MBTA."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "Thông tin quan trọng"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "Các liên kết quan trọng"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "hướng đi vào trung tâm Trains Cancelled"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "Ngày Độc lập"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "Thông tin & Hỗ trợ"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "Bán hàng cho tổ chức"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "Đối tượng mục tiêu"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "Vùng xen kẽ %{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "Thời lượng không hợp lệ"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "Giá vé không hợp lệ"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "Hóa đơn"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "Thông tin này có hữu ích không? Hãy gửi phản hồi cho chúng tôi"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "Chuyển đến"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "Ngày Độc lập Juneteenth"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "Tìm hiểu về nhóm lên máy bay của bạn"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "Bạn có quen chủ cửa hàng địa phương nào có thể quan tâm đến việc tham gia mạng lưới bán lẻ của chúng tôi không? Hãy đề xuất một nhà bán lẻ và chúng tôi"
 " sẽ liên hệ với họ thay mặt bạn."
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "Ngày Lao động"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "Dịch vụ ngôn ngữ"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Ngôn ngữ"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "Cuối cùng"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "Chuyến cuối cùng %{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Sau đó"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "Khả năng lãnh đạo"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "Tìm hiểu thêm về CharlieCard"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "Tìm hiểu thêm về giá vé MBTA"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "Tìm hiểu thêm về khả năng tiếp cận trên tàu điện ngầm"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "Tìm hiểu thêm về bãi đậu xe đạp tại tàu điện ngầm"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "Tìm hiểu thêm về kho xe đạp tại nhà ga này."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "Tìm hiểu thêm về xe đạp trên Đường sắt ngoại ô"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "Tìm hiểu thêm về khả năng tiếp cận xe buýt"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "Tìm hiểu thêm về giá vé, loại vé và cách thanh toán giá vé trên tàu điện ngầm."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "Tìm hiểu thêm về giá vé"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "Tìm hiểu thêm về khả năng tiếp cận bằng phà"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "Tìm hiểu thêm về cách nộp đơn Khiếu nại"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "Tìm hiểu thêm về bãi đậu xe tại tàu điện ngầm"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "Tìm hiểu thêm về Vé giảm giá và tính đủ điều kiện"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "Tìm hiểu thêm về xu hướng chỗ ngồi có sẵn"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "Tìm hiểu thêm về khả năng tiếp cận các tính năng tại %{place}này."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "Tìm hiểu thêm về dự án này"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "Tìm hiểu điều gì sẽ xảy ra sau khi bạn nộp đơn Khiếu nại"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "Ít đi bộ"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "Rời đi lúc"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "Khởi hành lúc %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "Bên trái"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "Hãy cho chúng tôi biết"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "Các tuyến và lộ trình"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "Chế độ xem danh sách"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "Live cảnh báo dịch vụ cho tất cả các phương thức vận chuyển MBTA, bao gồm tàu điện ngầm, xe buýt, Đường sắt ngoại ô, và phà. Cập nhật về trễ chuyến, động"
 " thi công, ngừng hoạt động thang máy, v.v."
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Tải thêm"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "Đang tải thông tin về..."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "Đang tải lịch trình cho dịch vụ đã chọn"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "Chi tiết chuyến hàng"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "Đang tải các chuyến khởi hành sắp tới"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Sảnh bên trong Back Bay nhà ga"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "Xe buýt địa phương"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "Local xe buýt vé một chiều"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Vị trí"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "Vị trí này không đủ gần với bất kỳ trạm giao thông công cộng nào."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "Vị trí không có sẵn"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "Logan Express"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "Đường dốc dài"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "Đồ Thất Lạc & Tìm Thấy"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "Đồ thất lạc"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type} nhà ga và lịch trình, bao gồm bản đồ, cập nhật thời gian thực, thông tin đỗ xe và khả năng tiếp cận cũng như các điểm kết nối."
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "%{route_name} %{station_name} và lịch trình MBTA, bao gồm thời gian biểu, bản đồ, giá vé, cập nhật theo thời gian thực, thông tin đỗ xe và khả năng tiếp"
 " cận cũng như các điểm kết nối."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "MBTA %{text} các điểm dừng và lịch trình, bao gồm bản đồ, thông tin đỗ xe và khả năng tiếp cận cũng như giá vé."
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{type} tuyến đường %{name} điểm dừng và lịch trình, bao gồm bản đồ, cập nhật theo thời gian thực, thông tin đỗ xe và khả năng tiếp cận cũng như các"
 " điểm kết nối."
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - Cơ quan Giao thông Vịnh Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "Trang Facebook của MBTA"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "Giá vé MBTA"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "Cửa hàng quà tặng MBTA"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA Green Line xe đẩy nhà ga và lịch trình, bao gồm bản đồ, cập nhật thời gian thực, thông tin đỗ xe và khả năng tiếp cận cũng như các điểm kết nối."
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "Trang chủ MBTA"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "Trang chủ MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "Instagram của MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "Chương trình MBTA Vận chuyển hành khách khuyết tật"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "Các dự án/chương trình của MBTA"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "MBTA nhà ga"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "Các chủ đề thảo luận về MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "Cảnh sát giao thông MBTA"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "MBTA Lập kế hoạch chuyến đi"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "Twitter của MBTA"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "Hướng dẫn người dùng MBTA"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "Kênh YouTube của MBTA"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA máy bán vé tự động"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "MBTA hành khách có thể mua CharlieTickets và nạp lại và mua %{charlie_card} cho xe buýt, tàu điện ngầm, Đường sắt ngoại ô, và phà tại các nhà bán lẻ trên"
 " khắp Greater Boston và các khu vực Providence ."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "Tin tức mới nhất trên MBTA.com"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "Thực đơn MBTA.com"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Chủ yếu"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "Đường dây nóng chính"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "Menu chính"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "bảo trì"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "Khiếu nại bảo trì"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "Quay đầu xe"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "Được quản lý bởi"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "Còn nhiều chỗ ngồi trống"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Bản đồ"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "Ngày Martin Luther King, Jr."
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "Cơ quan Giao thông Vịnh Massachusetts"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "Cơ quan Giao thông Vận tải Vịnh Massachusetts, mọi quyền được bảo lưu."
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport xe đưa đón"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport xe đưa đón %{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "Trận đấu 18"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "Trận đấu 30"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "Trận đấu thứ 45"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "Trận đấu 5"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "Trận đấu 61"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "Trận đấu 74"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "Trận đấu 97"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "Yêu cầu vé trận đấu "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "May not be có thể tiếp cận được"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "Thông tin liên hệ truyền thông"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "Quan hệ truyền thông"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "Thông tin cuộc họp"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "Các thành viên báo chí có thể yêu cầu được thêm vào danh sách truyền thông của chúng tôi bằng cách gửi email. "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "Người dân có quyền yêu cầu bản sao các tài liệu của MBTA, trừ một số trường hợp ngoại lệ. Có thu phí và mức phí có thể thay đổi tùy thuộc vào yêu cầu."
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "Ngày tưởng niệm"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "Quân đội"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "Mini sân ga cao để cung cấp khả năng lên máy bay ngang bằng cho một số toa nhất định trong một đoàn tàu"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "Phút"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "Ứng dụng di động"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "Bán vé trên thiết bị di động"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "Chế độ"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "Các phương thức vận chuyển"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "Thứ hai"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "Thứ Hai - Thứ Sáu"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "Thứ Hai đến Thứ Sáu"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "Thứ Hai đến Thứ Sáu"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "vé tháng"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "vé tháng LinkPass"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "vé tháng Local xe buýt vé"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "vé tháng vé"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "vé tháng vé trên ứng dụng mTicket"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "Các hướng dẫn khác"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "Thông tin thêm"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "Xem thêm từ "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "Trực tiếp nhất"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "Giá vé phổ biến nhất"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "Hầu hết, nhưng không phải tất cả, MBTA bến tàu đều có thể tiếp cận được to hành khách với người khuyết tật. Dựa trên mức thủy triều và loại tàu được sử"
 " dụng để đi lại, bạn có thể gặp phải những con dốc đáng kể và lối đi hẹp, ngay cả tại có thể tiếp cận được bến tàu. Tại tất cả các bến tàu, hãy đợi cho"
 " đến khi một thành viên thủy thủ đoàn nói với bạn rằng có thể tiếp tục an toàn."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menu điều hướng"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Mới"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "Ngày đầu năm mới"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "Tin tức"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Tiếp theo"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "Tuần tới"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "Điểm dừng tiếp theo"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "Không có cảnh báo %{group}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "Không có dịch vụ theo lịch trình"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "Không có dịch vụ"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "Không có cảnh báo ở đây."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "Không có thay đổi nào được đăng tải trong 7 ngày tới."
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "Không có sự kiện nào"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Cấm đỗ xe"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "Hôm nay không có dịch vụ."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "Không tìm thấy phương tiện công cộng nào giữa điểm xuất phát và điểm đến vào ngày và giờ này"
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "Không có phương thức vận chuyển nào được chọn."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "Không tìm thấy tuyến giao thông công cộng nào trong vòng 2 giờ tính từ %{time_on_date}. Các tuyến đường có thể khả dụng vào những thời điểm khác."
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "Không tìm thấy chuyến đi nào"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "Không có ngày lễ sắp tới"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "dịch vụ bình thường"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "Hướng Bắc"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "Not có thể tiếp cận được"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "Không có sẵn"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "Không đông đúc"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Ghi chú"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Ghi chú:"
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Ghi chú"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "Để ý"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Hiện nay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "Hiện tại"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "Đã quan sát"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "Trang web chính thức của MBTA -- lịch trình, bản đồ và thông tin giá vé cho hệ thống giao thông công cộng của Greater Boston, bao gồm tàu điện ngầm, Đường"
 " sắt ngoại ô, các tuyến xe buýt và các tuyến thuyền."
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "Trang web chính thức của MBTA — Lên kế hoạch cho chuyến đi bằng phương tiện giao thông công cộng tại khu vực Đại Boston"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "Ôi không! Chúng tôi đang trải qua tình trạng trễ chuyến."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "Đúng giờ"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "Đường dốc trên xe ở cửa trước của mỗi xe buýt"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "Một ngày vé"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "vé một chiều"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "đang diễn ra"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "Chỉ được phép mang ví hoặc túi nhỏ trong suốt. Các vật dụng bị cấm phải được bỏ lại trước khi lên máy bay."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "Hoặc,"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "Hoặc, hãy truy cập vào "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "Order vé tháng vé"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "Địa điểm xuất phát không đủ gần với bất kỳ trạm dừng phương tiện công cộng nào."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "Địa điểm xuất phát nằm ngoài khu vực phục vụ của chúng tôi."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "Địa điểm xuất phát hoặc điểm đến nằm ngoài khu vực phục vụ của chúng tôi."
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Khác"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "Other lịch trình"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "Công việc của chúng tôi"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "Hướng dẫn người dùng của chúng tôi có thể giúp bạn tìm hiểu cách điều hướng hệ thống, tham gia các sự kiện địa phương, sử dụng các tính năng tiếp cận và"
 " hơn thế nữa."
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "Hỏng"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "hướng đi ra ngoại thành Trains Cancelled"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "Giá để xe đạp ngoài trời"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "Giá để xe đạp ngoài trời có sẵn"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "Qua đêm"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Tổng quan"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF lịch trình"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF sắp tới"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Trang không tìm thấy | MBTA - Cơ quan Giao thông Vịnh Massachusetts"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "Không tìm thấy trang"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Trang"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "Vận chuyển hành khách khuyết tật (The RIDE)"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "Đỗ xe"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "Bãi đậu xe đóng đường"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "Vấn đề đỗ xe"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "Giá phí đậu xe"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "Đỗ xe tại %{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Có chỗ đậu xe"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "hành khách phải nói "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "Những thay đổi trong quá khứ"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "Ngày của những người yêu nước"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "Trả tiền vé"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Phương thức thanh toán"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Mọi người"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "Mọi người chờ đợi khi đoàn tàu tuyến màu cam đến bên trong North Station"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "Những người đi bộ bằng tàu khởi hành lên xe bên trong North Station"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "Mọi người đi bộ về phía Green Line tàu bên trong North Station"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "Hiệu suất"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "Lên kế hoạch cho chuyến đi của bạn"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "Lên kế hoạch cho chuyến đi"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "Plan an có thể tiếp cận được trip"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "Lên kế hoạch cho chuyến đi của bạn"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "Planned cảnh báo dịch vụ"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "công việc đã lên kế hoạch"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "Vui lòng nhập bình luận để tiếp tục."
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "Vui lòng nhập địa chỉ email hợp lệ."
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "Vui lòng nhập biển số xe hợp lệ, chỉ bao gồm các ký tự số."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "Vui lòng nhập địa chỉ nằm trong phạm vi 100 dặm tính từ khu vực phục vụ của MBTA."
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "Vui lòng nhập tên của bạn để tiếp tục."
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "Vui lòng nhập tên Chuyến cuối cùng của bạn để tiếp tục."
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "Vui lòng chọn điểm đến ở một vị trí khác với điểm xuất phát."
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "Vui lòng chọn địa điểm đến."
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "Vui lòng chọn địa điểm xuất phát."
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "Vui lòng chọn ít nhất một phương thức di chuyển."
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "Vui lòng chọn loại vấn đề cần quan tâm."
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "Vui lòng chỉ định ngày và giờ trong tương lai hoặc chọn 'Ngay bây giờ'."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "Vui lòng thử lại hoặc gửi phản hồi cho chúng tôi tại mbta.com/customer-support"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "Chính sách và Quyền công dân"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "Thay đổi chính sách"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "Thang nâng lên xuống di động"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "Đăng tải vào"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "Hiện tại chưa có thông tin về thời gian khởi hành dự kiến, nhưng chúng sẽ được cập nhật tại đây trước chuyến đi đầu tiên theo lịch trình."
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "Prefer có thể tiếp cận được routes"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "Chuyến đi cao cấp"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "Giá vé xe hạng sang"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "Thông cáo báo chí"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "Phiên bản xem trước"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Trước"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Chính sách Quyền riêng tư"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "Dự án"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "Các địa điểm bán hàng được đề xuất"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "Các cuộc họp công cộng"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "Hệ thống giao thông công cộng tại khu vực Đại Boston. Tuyến đường, lịch trình, Lập kế hoạch chuyến đi, giá vé, cảnh báo dịch vụ, cập nhật theo thời gian"
 " thực và thông tin chung."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "Mua vé CharlieTickets"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "Mua thẻ CharlieCard hoặc nạp tiền vào thẻ hiện có."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "Mua vé tại máy bán vé tự động."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "Mua vé tại các điểm bán lẻ gần đó."
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "Chất lượng, Tuân thủ & Giám sát"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "Tứ kết"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "Câu hỏi"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "đường ray"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "Đọc %{world_cup_link}của chúng tôi"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "Nhận thông báo về cảnh báo dịch vụ MBTA qua email hoặc tin nhắn."
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "Tin tức gần đây về tàu điện ngầm"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "Recently Visited lịch trình"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "Vé giảm giá"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "Đăng ký CharlieCard của bạn để đậu xe đạp"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "Các tệp liên quan"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "Related cảnh báo dịch vụ"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "Báo cáo gian lận, lãng phí hoặc lạm dụng"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Báo cáo sự cố liên quan đến rào chắn đường sắt"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "Báo cáo sự cố khả năng tiếp cận"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "Báo cáo sự cố thang máy"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "Báo cáo sự cố thang cuốn"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "Báo cáo các trường hợp nghi ngờ gian lận, lãng phí hoặc lạm dụng."
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "Yêu cầu hồ sơ công khai"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "Địa điểm bán lẻ"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "Bao gồm vé khứ hồi"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "Đi %{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "Đi tàu %{route} %{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "hành khách không có vé phù hợp sẽ không được phép lên xe Boston Stadium Tàu."
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "Phải"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "vé khứ hồi"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "Vòng 32"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "Tuyến đường %{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "Tuyến đường %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Tuyến đường"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "Các tuyến đường có cảnh báo ưu tiên cao"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sự an toàn"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "Thứ bảy"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "lịch trình & Maps"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "Thay đổi lịch trình"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "lịch trình for"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "lịch trình thông tin cho các tuyến MBTA Đường sắt ngoại ô trong khu vực Greater Boston, bao gồm cập nhật theo thời gian thực và dự đoán điểm đến."
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "Thông tin lịch trình cho các tuyến xe buýt MBTA trong khu vực Greater Boston, bao gồm cập nhật theo thời gian thực và dự đoán điểm đến."
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "Thông tin lịch trình cho các tuyến phà MBTA hoạt động ở Vịnh Massachusetts, bao gồm các tệp PDF có thể tải xuống."
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "Thông tin lịch trình cho các tuyến tàu điện ngầm MBTA ở Greater Boston, bao gồm cập nhật theo thời gian thực và dự đoán điểm đến."
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "lịch trình thông tin về MBTA tàu điện ngầm, xe buýt, Đường sắt ngoại ô, và phà ở khu vực Greater Boston, bao gồm các bản cập nhật theo thời gian thực và"
 " dự đoán điểm đến."
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "lịch trình sẽ sớm có trên trang web MBTA."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Đã lên lịch"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "Dịch vụ theo lịch trình tiếp tục cho đến %{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "Dự kiến khởi hành"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "lịch trình"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "lịch trình & Maps"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "lịch trình và Maps"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "Chỉ hoạt động vào các ngày đi học"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "Tìm kiếm trên MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "Tìm kiếm điểm dừng hoặc nhà ga"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "Tìm kiếm tuyến đường, địa điểm, thông tin và nhiều hơn nữa"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "Kết quả tìm kiếm cho"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "Tìm kiếm MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "Theo mùa"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "Dịch vụ theo mùa"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "Số lượng chỗ ngồi còn trống"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "Trang web chính thức của Bộ trưởng State"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "Có chỗ đỗ xe an toàn nhưng yêu cầu đăng ký Charlie Card trước."
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "Xem cảnh báo"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "Nếu thấy điều gì bất thường, hãy báo cáo ngay!"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "Xem tất cả thông cáo báo chí"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "Xem tất cả các cuộc họp và sự kiện công cộng"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "Xem tất cả cảnh báo dịch vụ"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "Xem tất cả hướng dẫn người dùng"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "Xem những gì bạn có thể mang theo trên Boston Stadium Tàu"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Lựa chọn"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "Gửi phản hồi cho chúng tôi"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "người cao tuổi CharlieCard hoặc TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "Thẻ ID người cao tuổi"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "Người cao tuổi"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "Sự cố máy chủ"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "Dịch vụ"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "cảnh báo dịch vụ"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "thay đổi dịch vụ"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "Khiếu nại dịch vụ"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "Yêu cầu dịch vụ"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "cảnh báo dịch vụ hoặc trễ chuyến"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "thay đổi dịch vụ có hiệu lực từ ngày 6 tháng 6 đến ngày 12 tháng 7. Kiểm tra từng ngày trong %{timetable_link} của dây chuyền của bạn để biết lịch trình"
 " cập nhật nhất."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "Dịch vụ đã kết thúc"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "Dịch vụ đang hoạt động như mong đợi."
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "Cống hiến cho World Cup"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "Chuyến đi ngắn nhất"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Trình diễn"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "Hiển thị chi tiết"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "Hiển thị ít điểm dừng hơn"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "Hiển thị thêm điểm dừng"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "Hiển thị tất cả"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "Hiển thị các điểm dừng chính."
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "xe đưa đón"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "xe đưa đón"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "Đăng ký cảnh báo dịch vụ"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "Đăng nhập"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "Đăng ký thanh toán tự động"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "Đăng ký T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "Đăng ký nhận thông báo cảnh báo"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "Chuyến đi tương tự đến %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "Chuyến đi tương tự khởi hành lúc %{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "Các chuyến đi tương tự đến lúc %{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "Các chuyến đi tương tự khởi hành lúc %{times}"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "Theo dõi đơn"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "đường vòng đến nội dung chính"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "đường vòng"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "Hơi lệch sang trái"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "Hơi lệch sang phải"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "Thẻ thông minh"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "Tuyến đường tuyết"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "Xúc tuyết"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "Còn một số chỗ ngồi trống."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "Một số chỗ chật chội"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "Đã xảy ra lỗi ở phía chúng tôi."
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "Lấy làm tiếc! Chúng tôi đã lỡ chuyến dừng của bạn."
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "Lấy làm tiếc. Đã xảy ra lỗi. Vui lòng thử lại."
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "Lấy làm tiếc. Chúng tôi đã gặp sự cố khi tải lên hình ảnh của bạn. Vui lòng thử lại."
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "Hướng Nam"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "Special Event vé"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "Yêu cầu vé đặc biệt"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "nhà ga & cảnh báo dịch vụ"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "nhà ga khả năng tiếp cận"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "nhà ga đóng đường"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "Tính năng nhà ga"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "Nhà ga Vấn đề"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "nhà ga phục vụ MBTA %{lines} dây chuyền%{location}."
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "nhà ga"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "nhà ga và bãi đậu xe"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "nhà ga và điểm dừng"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Trạng thái"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "Dừng %{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "đóng điểm dừng"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "điểm dừng đã di chuyển"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "Stop đường vòng"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "Dừng lại"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "Stops đường vòng"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Học sinh"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "Thẻ sinh viên Charlie"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "Nộp"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "Gửi yêu cầu cung cấp hồ sơ công khai đến MBTA."
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "tàu điện ngầm"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "tàu điện ngầm Hướng dẫn cho người mới bắt đầu"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "Giá vé tàu điện ngầm"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "Bản đồ tàu điện ngầm"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "tàu điện ngầm vé một chiều"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "Tình trạng tàu điện ngầm"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "Đề xuất một nhà bán lẻ"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Bản tóm tắt"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "Chủ nhật"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "Đình chỉ"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Tính bền vững"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "Hoán đổi vị trí xuất phát và điểm đến"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "Trên toàn hệ thống"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "Thông báo/Đếm ngược/Ứng dụng"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "Điện thoại TTY"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "Đi tàu điện ngầm để bỏ phiếu"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Đi thang máy"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "Đi tàu đến xem một trận đấu World Cup?"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "Hãy cho chúng tôi biết suy nghĩ của bạn!"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "Hãy cho chúng tôi biết về các chuyến đi thường xuyên của bạn và nhận tin nhắn hoặc email cảnh báo có liên quan đến bạn, vào những thời điểm bạn muốn."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "Tạm thời không có sẵn"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "Tạm thời đã đóng"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "Vấn đề tạm thời"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "Vấn đề tạm thời"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "Điều khoản Sử dụng"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "Cảm ơn bạn đã gửi phản hồi. Nhóm Hỗ trợ khách hàng của chúng tôi sẽ sớm xem xét ý kiến của bạn."
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "Ngày Lễ Tạ Ơn"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "Cái "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "Khách hàng Engagement Coordinator in System-Wide khả năng tiếp cận & khách hàng Liaison for The RIDE chịu trách nhiệm điều phối các nghị quyết của ADA/khả"
 " năng tiếp cận Khiếu nại khi chúng được nhận."
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "Dòng Sự kiện Đặc biệt của Foxboro chỉ dành cho dịch vụ không thường xuyên."
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "Đơn vị Kiểm toán Đặc biệt Nội bộ thuộc Văn phòng Tổng Thanh tra giám sát chất lượng, hiệu quả và tính liêm chính của các chương trình của MassDOT."
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "Chuyến đi"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "Thời khóa biểu tương tác cho"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "Hiện tại không có thông tin về giờ khởi hành thực tế."
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "Hiện tại không có thông tin về giờ khởi hành thực tế. Lịch trình khởi hành được hiển thị bên dưới."
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "Không có"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "Không có "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "Không có khả năng tiếp cận bổ sung các tính năng, nhưng Xe buýt luôn có thể tiếp cận được để lên xe."
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "Không có cảnh báo"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "Không có ưu tiên cao nào cả."
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "Không có Đường sắt ngoại ô cảnh báo nào khác vào thời điểm này."
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "Không có cảnh báo tàu điện ngầm nào khác tại thời điểm này."
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "Không có chuyến đi %{direction} được lên lịch vào %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "Không có chuyến đi nào được lên lịch %{direction} ."
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "Không có chuyến đi nào được lên lịch vào ngày %{date}."
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "Không có chuyến đi theo lịch trình."
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "Hiện tại chưa có thông tin cập nhật nào."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "Hiện tại không có lịch trình %{route_name}."
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "Không có công việc đã lên thông tin kế hoạch tại thời điểm này."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "Không có dịch vụ %{route} được lên lịch tại %{stop} trong khoảng thời gian này."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "Đã xảy ra sự cố khi tải thông tin khách đến."
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "Đã xảy ra sự cố khi tải lịch trình"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "Đã xảy ra lỗi khi tải thông tin chi tiết chuyến đi"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "Đã xảy ra sự cố khi tải các chuyến khởi hành sắp tới"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "This %{place} không có thể tiếp cận được."
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "Tuần này"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "Danh sách này không bao gồm các nhà bán lẻ hiện tại của MBTA. Để xem các địa điểm bán lẻ hiện tại, hãy sử dụng công cụ của chúng tôi."
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "Trang này hiện không còn hoạt động."
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "Nhà ga này không có kho xe đạp"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "Nhà ga này không có thang máy."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "Nhà ga này không có thang cuốn."
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "Nhà ga này không có chỗ đậu xe."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "Điểm dừng này không có máy bán vé tự động, nhưng bạn có thể mua vé tại"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "Chuyến tàu này thường có<br /><strong>%{seats} chỗ ngồi còn trống</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "Thứ Năm"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "Thời khóa biểu"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "ĐẾN"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "Để báo cáo sự cố hoặc tình huống khẩn cấp với giao cắt đường sắt, hãy gọi"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "Để gửi ADA/khả năng tiếp cận Khiếu nại hoặc phản hồi, vui lòng gọi"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Hôm nay"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "Hôm nay lúc"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "Số điện thoại miễn phí"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "Thay đổi lịch trình lên tàu"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "Theo dõi thay đổi"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "Bài hát sẽ được thông báo sau."
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "Theo dõi hành trình %{route_type_text} của bạn trực tiếp với ứng dụng <strong>MBTA Go</strong>"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Xe lửa"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "Tàu %{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "Chuyến tàu dự kiến lên xe từ %{platform} lúc %{station}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "Chuyển khoản"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "Chuyển nhượng"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "Giao thông công cộng"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "Cảnh sát giao thông"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "Du lịch bất cứ đâu trên các tuyến Blue, Orange, Redvà Green với cùng một mức giá."
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "Chuyến đi"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Lập kế hoạch chuyến đi"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "Loại chuyến đi"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "Các chuyến đi từ %{from} đến %{to}"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "Hãy thử tìm kiếm những gì bạn cần ở bên dưới."
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "Thứ Ba"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "Thứ Ba, ngày 5 tháng 11 là ngày cuối cùng để bỏ phiếu trong cuộc tổng tuyển cử năm 2024. Sử dụng tàu điện ngầm để đến địa điểm bỏ phiếu của quý vị."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "Thông thường chỉ có dưới 33% số ghế có sẵn và việc giữ khoảng cách là không khả thi (khoảng 3 người trở lên mỗi hàng)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "Thông thường, hơn 33% số ghế vẫn còn trống và việc giữ khoảng cách có thể được thực hiện (~2-3 người mỗi hàng)."
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "Thông thường, hơn 66% số ghế còn trống và việc giữ khoảng cách là hoàn toàn khả thi (khoảng 0-2 người mỗi hàng)."
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Không rõ"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "Đường ray không theo lịch trình"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "Cho đến khi %{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "sắp tới"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "Những thay đổi sắp tới"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "Khởi hành sắp tới"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "Những ngày lễ sắp tới"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "Các cuộc họp và sự kiện công khai sắp tới"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "Đã cập nhật vào"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "Đã cập nhật: "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "Cập nhật"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "Sử dụng"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "Hướng dẫn người dùng"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "Ngày Cựu Chiến Binh"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "Thông qua"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Xem"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "Xem %{timetable_link} để biết thông tin khởi hành."
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "Xem cảnh báo"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "Xem tất cả số điện thoại liên hệ"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "Xem tất cả các tùy chọn"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "Xem tiểu sử"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "Xem tiểu sử của %{name}"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "Xem lịch trình PDF"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "Xem lịch trình dạng PDF trên trang web của MBTA."
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "Xem trước"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Xem tất cả"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "Xem tất cả các tuyến xe buýt"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "Xem tất cả sự kiện"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "Xem tất cả hướng dẫn"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "Xem tất cả các trận đấu"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "Xem tất cả tin tức"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "Xem tất cả các cập nhật dự án"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "Xem tất cả dự án"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "Xem các thang máy hiện có."
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "Xem các thang cuốn hiện có."
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "Xem thông tin giá vé phổ biến cho MBTA xe buýt, tàu điện ngầm, Đường sắt ngoại ô, phà và The RIDE. Tìm hiểu các dịch vụ CharlieCard trực tuyến và các chương"
 " trình đặt hàng số lượng lớn."
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "Xem lịch trình buổi tối"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "Xem tổng quan về giá vé"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Xem thêm thông tin thanh toán"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "Xem lịch trình buổi sáng"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "Xem trên Google Maps"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "Xem trên MBTA Lập kế hoạch chuyến đi"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "Xem bảng giá đỗ xe, thông tin về tiện ích và nhiều hơn nữa."
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "Xem số điện thoại"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Thăm nom"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "Ghé thăm Trung tâm Di động"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Bỏ phiếu"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "Đang chờ kết quả"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "Đang chờ khởi hành"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "Đi bộ"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "Chỉ dẫn đường đi bộ"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "Ngày sinh nhật của Washington"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "Chúng tôi chỉ có thể cung cấp dữ liệu chuyến đi cho lịch trình %{rating} , có giá trị đến %{end_date}."
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "Chúng tôi gặp sự cố khi gửi phản hồi của bạn -- vui lòng gọi cho chúng tôi theo số điện thoại đường dây nóng bên dưới hoặc thử lại sau vài phút."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "Chúng tôi muốn đảm bảo rằng chúng tôi đang xây dựng một mạng lưới bán lẻ hoạt động hiệu quả cho bạn. Bạn có thể chia sẻ phản hồi của mình bằng cách sử"
 " dụng biểu mẫu bên dưới."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "Chúng tôi không tìm thấy điểm bỏ phiếu nào cho địa chỉ của bạn. Bạn cũng có thể ghé thăm"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "Chúng tôi sẽ gửi trực tiếp cho bạn các thông cáo báo chí và thông báo truyền thông của MBTA."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "Chúng tôi đang kêu gọi công chúng giúp định hướng các quyết định của chúng tôi khi triển khai dự án Chuyển đổi Giá vé trong vài năm tới."
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "Chúng tôi đang mở rộng mạng lưới những nơi hành khách có thể nhận hoặc nạp CharlieCard và mua vé."
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Trang web"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "Thứ Tư"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "Ngày cuối tuần vé"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "Cuối tuần"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "Hướng Tây"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "Điều gì đang xảy ra tại MBTA?"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "Khi"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "Làm việc với chúng tôi"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "Làm việc với chúng tôi"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "Đang làm việc"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Hướng dẫn World Cup"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "Các trận đấu World Cup"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "Hãy viết thư cho chúng tôi"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "Quanh năm"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "Bạn cũng có thể gửi email."
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "Bạn có thể mong đợi phản hồi cho hầu hết các vé trong vòng 5 ngày làm việc. Một số Khiếu nại có thể yêu cầu điều tra lâu hơn, lên đến 30 ngày."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "Bạn có thể thanh toán tiền vé bằng"
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "Bạn phải đồng ý với Chính sách Bảo mật của chúng tôi trước khi gửi phản hồi."
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Bạn phải hoàn thành xác minh reCAPTCHA trước khi gửi phản hồi."
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "Chuyến đi Đường sắt ngoại ô của bạn sẽ bị ảnh hưởng bởi World Cup."
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "Địa điểm bỏ phiếu của bạn"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "Vùng"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "Khu vực %{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "Khu vực 1A-10"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "một thành viên phi hành đoàn"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "có thể tiếp cận được spots"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "cảnh báo tại thời điểm này"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "và"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "đã đến"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "đến"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "vào thời điểm này"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "giữa %{first} và %{last}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "thuyền"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "xe buýt"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "trạm xe buýt"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "Tiền mặt"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "thay đổi"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "thay đổi"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "thanh toán không tiếp xúc"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "hiện hành"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "đã rời đi"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "bến tàu"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "phía đông"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "một vài"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "vì"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "từ %{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "đã rời đi"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "hướng đi vào trung tâm"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "thông tin"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "là tạm thời không có sẵn do thay đổi dịch vụ."
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "đường kẻ"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "vị trí"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "Ứng dụng mTicket"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "nhiều"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "địa điểm bán lẻ gần đó"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "phía bắc"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "hơn 30 phút"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "hơn một giờ"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "lên"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "hoặc là"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "hoặc là "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "Hoặc điền vào mẫu phản hồi trên trang này."
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "hoặc thanh toán bằng Tiền mặt trên bất kỳ xe buýt nào"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "hướng đi ra ngoại thành"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "paper phà vé"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "đã lên kế hoạch"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "Vé giảm giá card"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "đăng ký trước"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "báo cáo sự cố"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "yêu cầu"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "công cụ tìm địa điểm bán lẻ"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "tuyến đường"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "Xem bản đồ tất cả các địa điểm bán hàng được đề xuất"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "dịch vụ"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "một số"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "phía nam"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "nhà ga"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "nhà ga"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "dừng lại"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "dừng lại"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "Trang chủ của MBTA"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "người chỉ huy"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "sáng hôm sau"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "bởi vì"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "thời khóa biểu cho"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "ĐẾN"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "đến %{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "Để tìm địa điểm bỏ phiếu của bạn, sau đó sử dụng"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "để lên kế hoạch cho chuyến đi của bạn"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "tổng số chỗ đậu xe"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "đối với"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "theo dõi "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "xe lửa"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "các chuyến đi hôm nay"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "tối đa 10 phút"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "tối đa 15 phút"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "tối đa 20 phút"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "tối đa 25 phút"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "tối đa 30 phút"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "trang web"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "phía tây"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "với"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "Theo yêu cầu của bạn."
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5519,9 +5519,9 @@ msgstr "满足您的要求。"
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "内港区 1A"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop和Quincy Ferry"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -11,5639 +11,5517 @@ msgstr ""
 "Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " 和站点"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " 波士顿、 Hingham和Hull之间可通过%{link}列车提供额外服务。"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " 它沿途停靠站点有限，往返于Foxboro和Providence或波士顿Downtown （ South Station ）之间。"
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " 线条"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " 路线"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " 当天晚些时候，该服务将继续以相反的方向运行。%{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " 当天早些时候，反方向的服务也已开通。%{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " 活动结束后30分钟，列车将从Foxboro出发。"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " 警报"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " 在 "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " 在%{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " 此时。"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " 取决于行驶距离（区域）。请参考以下信息："
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " 用于实时跟踪更改。"
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " 为了 "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " 已到达 "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " 正在到达 "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " 正在前往 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " 可能会在这些站点的时刻表之前出发。"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " 步行几分钟"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " 在 "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " 在 "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " 进展顺利 "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " 或 "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " 时刻表"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " 时刻表和地图"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " 象征。查看 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " 他们想离开。等待上车的乘客必须在车站台上可见 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " 停止。"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "步行距离"
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg}分钟"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count}停止"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count}警报"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count}稍后%{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date}在%{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date}在%{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date}不在我们当前的时刻表之内。"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date}直至另行通知"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max}分钟"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1}和%{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label}仅"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name}通勤铁路"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "%{place}信息"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating}计划工作"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating}时刻表，结束%{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating}时刻表，开始于%{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name}到%{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time}在%{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y}的%{x}工作"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr "， "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr "现金，或 "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "%{count}条无障碍路线"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "%{count}条无法通行的路线"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "%{count}条不可使用路线"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 条警报"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "共 %{count} 个结果"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "%{count}站"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "今天又去了%{count}趟"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "1日通票"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 个可以保护轮式助行设备的区域"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "每周 7 天，每天 24 小时"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "7天通票"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "TTY用户请拨打711；ASL用户请拨打VRS。"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA乘车"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "ADA乘车费用"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/无障碍投诉"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "关于"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "使用权"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "访问问题"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "访问问题"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "无障碍"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "无障碍资源"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "无障碍访问%{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "无障碍"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "添加"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "将%{title}添加到日历"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "将事件添加到日历"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "添加到日历"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "仅限管理员"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "成人"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "议程"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "警报"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "警报"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "MBTA %{description}的警报"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "所有警报"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "所有Boston Stadium火车车票均包含赛后返程车票。 列车将在终场哨响后 30 分钟开始从Foxboro车站出发。 返程列车大约每 15 分钟一班从体育场出发，直到所有列车都出发为止。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "所有进站列车"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "所有位置类型"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "所有MBTA改进项目"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "所有出站列车"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "所有时刻表和地图"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "所有列车"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "所有列车取消"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "所有更新"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "所有渡轮航线"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "标有星号*的字段均为必填项。"
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "所有模式"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "所有拟定地点均需视场地适宜性、许可证办理情况和零售供应情况而定。"
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "安珀警报"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Downtown Crossing车站入口的外部照片。 街道两旁飘扬着美国国旗，远处可见摩天大楼。许多行人正从旁边经过。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "即将进站"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "到达时间"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "到达"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "到达时间： %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "在自动售票机上，您可以"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "在北行、南行、 Back Bay和Ruggles车站外有多条轨道的车站，进站列车从 2 号轨道上车，出站列车从 1 号轨道上车，除非另有说明。 计划中的轨道变更将以以下方式标示： "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "与会者"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "错误的团体票价卡数据"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "背包政策及违禁物品"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "请按照您所在登车组别的指定时间到South Station 。 您的登车组号在您的Boston Stadium火车车票上。"
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "今天之前"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "更好的巴士项目"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "允许骑自行车吗？"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "允许骑自行车"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "列车车次下方带有自行车标志的列车允许携带自行车上车，但需遵守相关限制。"
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "禁止骑自行车"
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "自行车"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "自行车问题"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "自行车存放处"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "自行车存放处%{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "自行车"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "允许骑自行车"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "所有渡轮都允许携带自行车。"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line地铁站台位于State Street 内"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line火车从Airport车站出发"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "A组登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "B组登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "C组登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "D组登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "E组登机"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "登船组"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Boston Stadium需要火车票"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "前往Boston Stadium火车车票必须提前在mTicket应用程序上购买。 欲了解更多信息，请阅读我们的%{world_cup_link}"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium专列"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "波士顿地铁游客指南"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "双向"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "开车或骑自行车"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "巴士"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "巴士%{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "巴士初学者指南"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "巴士票价"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "巴士特色"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "巴士地图"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "巴士其他"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "巴士路线"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "巴士站"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "巴士站变更"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "可降低车身高度以便乘客上下车的巴士"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "商业"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "商业机会"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "日历视图"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "称呼"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "致电我们"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "取消"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "取消"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "取消"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "已取消"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "资本转型"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "职业生涯"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "现金"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "改变"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "更改日期"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "改变行程方向。"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "变化"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "查理零售商"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Charlie 服务中心"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "查理卡"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCard"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "查理卡和车票"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "查看"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "在South Station办理登机手续"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "孩子"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "3岁以下儿童"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "选择您的语言"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "从可用选项中选择时刻表类型"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "圣诞节"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "民权"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "用户可点击的图形指南"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "关闭"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "关闭对话框"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "硬币"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "哥伦布日"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "评论"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "通勤渡轮到洛根Airport"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "通勤火车"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "通勤火车 "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "通勤铁路票价"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "通勤铁路地图"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "通勤铁路月票 通票"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "通勤铁路单程票"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "通勤铁路正线控制系统"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "通勤铁路状况"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "通勤铁路区域地图"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "通勤铁路座位可用性会定期更新，以反映过去 14-30 天的自动和乘务员数据所显示的典型客流量。"
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "投诉"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "赞扬"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "联系"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "联系我们"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "联系电话"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "联系 MBTA 客户支持团队，并查看交通警察、失物招领处和无障碍设施的更多联系电话。"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "请联系交通警察"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "继续"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "成本"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "带顶棚的自行车架"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "有带顶棚的自行车架。"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "创建一个帐户"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "信用卡/借记卡"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "信用卡/借记卡"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "跨港渡轮"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "克罗斯敦"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "挤"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "当前的"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "当前警报"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "当前变化"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "当前状态"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "当前座位可用阈值为："
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "客户支持"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "日常的"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "每日表时刻"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "日期"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "日期和时间"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "日通票"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "延误"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "延迟%{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "延误"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "出发"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "出发"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "出港"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "目的地距离任何公交站点都太远。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "目的地位于我们的服务区域之外"
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "目的地"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "细节"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "绕行"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "开发者"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "共享主要线路和停靠信息的数字显示器和自动广播"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "您的旅行方向"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "残障身份证"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "码头关闭"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "码头问题"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "文件"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "并未就此止步"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "由于单轨"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "EBT卡"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ 通票"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "早些时候"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "最早到达"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "提前出发"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "提前出发停靠站"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "东行"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "电梯"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "电梯和自动扶梯"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "电梯关闭"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "电梯关闭"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "电梯/自动扶梯热线"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "电梯"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "电梯位于%{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "紧急情况"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "紧急情况 联系方式"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "员工"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "员工投诉"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "结束"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "工程设计标准"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "输入目的地"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "输入位置"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "输入起始位置"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "输入关键词"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "输入项目关键词"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "进入车站"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "进入交通圈"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "请输入您的注册地址"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "Government Center外的Blue和Green线入口"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "Park Street外的Green和Red入口"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "Downtown Crossing外的Orange和Red入口"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "进入Ruggles车站"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "South Station外进入Red Line并通勤铁路"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "错误"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "自动扶梯"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "扶梯（仅下行）"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "自动扶梯（上下）"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "扶梯（仅上行）"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "自动扶梯关闭"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "自动扶梯关闭"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "自动扶梯"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "扶梯位于%{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "预计抵达Foxboro车站"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "活动描述"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "事件概要 "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "活动"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "离开车站"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "预计延误"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "按模式探索车站"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "快速巴士"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "快速巴士单程票"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Wonderland车站外观"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "额外服务"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "设施信息"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "设施问题"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "家庭四人套餐（2 位成人，2 位儿童）"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "逃票"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "票价选项"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "%{name}处的票价选项"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "票价政策"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "票价零售地点"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "票价转换"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "票价类型"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "自动售票机"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "自动售票机"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "票价"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "票价信息"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "票价概览"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "各交通方式票价"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Hingham / Hull渡轮和Charlestown渡轮之间的票价有所不同。 请参考以下信息："
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "MBTA 最新动态和项目"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "渡轮"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "渡轮 "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "渡轮票价"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "渡轮地图"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "渡轮 月票 通票"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "座位有限"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "提交歧视投诉"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "填写表格"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "按类型筛选"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "财务"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "查找您附近的拟建地点"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "查找您的投票地点"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "查找位置"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "查找您附近的门店"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "了解如何参与"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "又一次旅行结束了"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "第一%{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "旗停"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "在沿途任何安全地点拦停巴士"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "请在 Twitter 上关注 @MBTA"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "请在推特上关注@MBTA_CR"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "遵循指示牌"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "请点击以下链接查找与您丢失物品的交通方式或路线相关的编号。"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "有关快速巴士票价，请阅读完整的%{link}页面。"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "有关世界杯列车服务的全部信息，请阅读我们的%{world_cup_link}"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "更多信息"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "如有任何关于此新闻稿的问题或意见，请联系我们。"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "如需前往Foxboro定期工作日服务，请访问： "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Foxboro特别活动"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Franklin线"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "免费"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "免费踏板和停车安全停车场"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "免费服务"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "星期五"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "从"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "全高站台，为列车组中的每节车厢提供平缓的登车通道。"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "获取路线"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "介入"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "获取服务更新"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "获取T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "办一张查理卡"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "您将收到一张邮寄的发票，费用为 1 美元。"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "获取前往此停车场的路线"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "了解我们"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "获取旅行建议"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "去"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "打算去Boston Stadium看世界杯比赛吗？"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Green Line %{branch}支线"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "组名"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "港口环线渡轮"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "极左"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "极右翼"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "隐藏"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "隐藏详情"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Hingham / Hull渡轮"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "历史"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "假期表时刻"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "假期"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "家"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "家庭住址"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "图标图例"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "如有需要，请务必注明事件发生的时间和日期、路线以及车辆编号。"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "如果您提供了联系方式，请查看您的电子邮件，您会收到一封包含事件编号的确认邮件。如果您在 10 分钟内没有收到确认信息，请尝试再次提交反馈或致电我们。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "如果您希望我们给您打电话，请提供我们能联系到您的最佳电话号码。"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "如果您的公民权利受到侵犯，您可以向 MBTA 多元化和公民权利办公室提出投诉。"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "重要信息"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "重要链接"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "进站列车取消"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "独立日"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "信息与支持"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "机构销售"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "目标受众"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "区域间%{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "无效持续时间"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "无效票价"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "发票"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "这有帮助吗？请向我们发送反馈"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "跳转至"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "六月节独立日"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "了解你的登船组"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "您认识有兴趣加入我们零售网络的本地店主吗？请推荐一家零售商，我们将代表您与他们联系。"
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "劳动节"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "语言服务"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "语言"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "最后"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "末班车%{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "之后"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "领导"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "了解更多关于查理卡的信息"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "了解更多关于MBTA票价的信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "了解有关地铁方便的更多信息"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "了解更多关于地铁站自行车停车的信息"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "了解有关该车站自行车存放处的更多信息。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "了解更多关于通勤铁路自行车的信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "了解有关巴士无障碍的更多信息"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "了解更多关于地铁票价、通票类型以及如何支付车费的信息。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "了解更多票价信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "了解更多关于渡轮无障碍设施的信息"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "了解更多关于投诉流程的信息"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "了解更多关于地铁站停车的信息"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "了解有关减价票和资格的更多信息"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "了解更多座位供应趋势"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "了解更多关于无障碍功能的信息，请访问%{place} 。"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "了解更多关于此项目的信息"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "了解提交投诉后会发生什么。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "步行最少"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "离开"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "出发时间为%{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "左边"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "请告知我们"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "线路和路线"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "列表视图"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "针对所有 MBTA 交通方式的实时服务警报，包括地铁、巴士、通勤铁路和渡轮。 睡眠、建筑施工、电梯停运等方面的最新情况。"
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "加载更多"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "正在加载到货信息……"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "正在加载所选服务的时刻表"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "正在加载行程详情"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "正在加载即将进行的出发航班"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Back Bay车站内的大堂"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "当地巴士"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "本地巴士单程票"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "地点"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "位置距离任何公交站点都不够近。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "位置不可使用"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "洛根快线"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "长坡道"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "失物招领"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "失物招领"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type}车站和时刻表，包括地图、实时更新、停车和无障碍信息以及换乘信息。"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{route_name} %{station_name}和时刻表，包括时刻表、地图、票价、实时更新、停车和无障碍信息以及换乘信息。"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "MBTA %{text}站点和时刻表，包括地图、停车和无障碍信息以及票价。"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{type}路线%{name}的站点和时刻表，包括地图、实时更新、停车和无障碍信息以及换乘信息。"
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - 麻省湾交通管理局"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "MBTA Facebook"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "MBTA票价"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "MBTA礼品店"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA Green Line电车车站和时刻表，包括地图、实时更新、停车和无障碍信息以及换乘。"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "MBTA主页"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "MBTA主页"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "MBTA Instagram"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "MBTA 辅助客运系统计划"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "MBTA项目/计划"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "MBTA车站"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "MBTA线程"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "MBTA交通警察"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "MBTA行程规划器"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "MBTA 推特"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "MBTA 用户指南"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "MBTA YouTube"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA 自动售票机"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "MBTA 乘客可以在大波士顿和Providence地区的零售商处购买 CharlieTickets 并充值并购买巴士、地铁、通火车站和渡轮的%{charlie_card} 。"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "MBTA.com 最新消息"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "MBTA.com 菜单"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "主要的"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "总热线"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "主菜单"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "维护"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "维护投诉"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "掉头"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "由……管理"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "座位充足"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "地图"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "马丁·路德·金纪念日"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "马萨诸塞湾交通管理局"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "麻省海湾交通管理局，版权所有。"
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport 摆渡巴士"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport 摆渡巴士%{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "第18场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "第30场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "第45场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "第五场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "第61场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "第74场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "第97场比赛"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "需要匹配车票 "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "可能不太方便"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "媒体联系信息"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "媒体关系"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "会议信息"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "媒体成员可以通过发送电子邮件申请加入我们的媒体名单。 "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "除某些例外情况外，公众有权索取 MBTA 文件的副本。需支付费用，费用可能因具体申请而异。"
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "纪念日"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "菜单"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "军队"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "迷你高站台为列车组中的某些车厢提供平整的登车通道。"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "分钟"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "移动应用"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "手机车票"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "模式"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "交通方式"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "星期一"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "周一至周五"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "周一至周五"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "周一至周五"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "月票"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "月票LinkPass"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "月票 本地巴士 通票"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "月票 通票"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mTicket App 上的月票 通票"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "更多指南"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "更多信息"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "更多内容 "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "最直接"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "最受欢迎的票价"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "大多数（但不是全部）MBTA 码头都易于通过残障进行上升。 根据潮汐水位和航行所用船只的类型，即使在无障碍码头，您也可能会遇到较大的坡度和狭窄的通道。在所有码头，请等待船员告知您可以安全通行后再继续前进。"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "导航菜单"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "新"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "元旦"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "消息"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "下一步"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "下周"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "下一站"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "没有%{group}警报"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "无计划服务"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "无服务"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "这里没有警报。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "未来7天内无任何变更发布"
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "无事件"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "禁止停车"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "今天暂停服务"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "在此日期和时间，始发地和目的地之间未找到换乘。"
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "未选择任何交通方式"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "在%{time_on_date}周围 2 小时内未找到任何交通路线。其他时间可能也有路线可供选择。"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "未找到行程"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "没有即将进行的假期"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "正常服务"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "北行"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "不方便"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "无法使用"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "不拥挤。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "备注"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "注意："
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "笔记"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "注意"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "现在"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "现在在"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "观察到"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "MBTA 官方网站 -- 大波士顿公共交通系统的时刻表、地图和票价信息，包括地铁、通勤铁路、巴士路线和船线。"
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "MBTA官方网站——规划您在大波士顿地区的公共交通出行"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "糟糕！我们这边出现延误了。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "准时"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "每辆巴士前门都设有登车坡道。"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "一日通票"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "单程票"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "正在进行"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "只允许携带钱包或小型透明袋。登机前必须丢弃违禁物品。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "或者，"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "或者，前往 "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "订购月票 通票"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "出发地距离任何公交站点都太远。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "始发地位于我们的服务区域之外"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "出发地或目的地超出我们的服务区域。"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "其他"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "其他时刻"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "我们的工作"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "我们的用户指南可以帮助您学习如何导航系统、参加本地活动、使用无障碍功能等等。"
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "故障"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "出站列车取消"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "户外自行车架"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "户外自行车架可用"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "过夜"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "概述"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF表时刻"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF即将进行"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "页面未找到 | MBTA - 麻省湾交通管理局"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "找不到网页"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "页"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "辅助客运系统 ( The RIDE )"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "停車處"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "停车场关闭"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "停车问题"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "停车收费标准"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "停车场位于%{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "提供停车位"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "乘客必须告知 "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "过去的变化"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "爱国者日"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "支付车费"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "支付方式"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "人们"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "人们在North Station内等候橙线列车进站。"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "人们在North Station内步行经过上车出发线。"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "在North Station内，人们正走向Green Line列车。"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "表现"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "规划您的旅程"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "计划一次旅行"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "计划一次无障碍旅行"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "计划您的行程"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "计划服务警报"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "计划工作"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "请输入评论以继续。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "请输入有效的电子邮件地址。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "请输入有效的车辆号码，仅限数字。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "请输入距离 MBTA 服务区域 100 英里以内的地址。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "请输入您的名字以继续。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "请输入您的末班车名称以继续。"
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "请选择与出发地不同的目的地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "请选择目的地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "请选择出发地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "请至少选择一种出行方式。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "请选择问题类型。"
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "请指定未来的日期和时间，或选择“立即”。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "请重试或通过 mbta.com/customer-support 向我们发送反馈。"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "政策与公民权利"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "政策变更"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "便携式登机升降机"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "发布于"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "预计出发时间尚未公布，但会在首班航班出发前在此处显示。"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "优先选择方便路线"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "高级乘车"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "高级乘车费用"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "新闻稿"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "预览版"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "以前的"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "隐私权政策"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "项目"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "拟定销售地点"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "公众会议"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "大波士顿地区的公共交通。路线、时刻表、旅行计划、票价、服务警报、实时更新和一般信息。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "购买查理票"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "购买查理卡或为现有查理卡充值"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "在自动售票机购买车票。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "请在附近的零售售票点购买车票。"
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "质量、合规与监管"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "四分之一决赛"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "问题"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "铁路"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "阅读我们的%{world_cup_link}"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "通过电子邮件或短信接收 MBTA 服务警报通知。"
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "地铁最新消息"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "最近访问时刻表"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "优惠票价"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "注册您的查理卡（CharlieCard）即可享受自行车停车服务"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "相关文件"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "相关服务警报"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "举报欺诈、浪费或滥用行为"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "报告铁路道口闸门问题"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "报告无障碍问题"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "报告电梯故障"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "报告自动扶梯故障"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "举报任何涉嫌欺诈、浪费或滥用行为"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "申请公开记录"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "零售销售地点"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "包含往返机票"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "乘坐%{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "乘坐%{route}列车%{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "没有匹配车票的乘客将不被允许上车Boston Stadium Trains。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "正确的"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "往返"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "32强"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "路线%{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "路线%{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "路线"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "高优先级警报路线"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "安全"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "周六"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "时刻表和地图"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "时刻表变更"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "时刻表"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "大波士顿地区 MBTA 通勤铁路线路的时刻表信息，包括实时更新和到站预测。"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "大波士顿地区 MBTA 公交线路时刻表信息，包括实时更新和到站预测。"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "提供马萨诸塞湾地区 MBTA 渡轮航线的时刻表信息，包括可下载的 PDF 文件。"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "大波士顿地区 MBTA 地铁线路时刻表信息，包括实时更新和到站预测。"
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "大波士顿地区 MBTA 地铁、巴士、通勤铁路 和 渡轮 的时刻表信息，包括实时更新和抵达预测。"
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "时刻表将很快在MBTA网站上公布。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "已安排"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "计划服务持续至%{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "计划出发"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "时刻表"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "时刻表和地图"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "时刻表和地图"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "仅上学日运营"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "搜索"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "搜索 MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "查找站点或车站"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "搜索路线、地点、信息等"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "搜索结果"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "搜索 MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "季节性"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "季节性服务"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "座位供应情况"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "State官方网站"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "提供安全停车位，但需提前注册查理卡。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "查看警报"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "发现异常，立即报告"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "查看所有新闻稿"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "查看所有公开会议和活动"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "查看所有服务警报"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "查看所有用户指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "看看你可以携带哪些物品乘坐Boston Stadium列车。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "选择"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "请向我们发送反馈"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "老年人查理卡或TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "老年人身份证"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "老年人"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "服务器问题"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "服务"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "服务警报"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "服务变更"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "服务投诉"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "服务查询"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "服务警报或间歇"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "服务变更将于 6 月 6 日至 7 月 12 日生效。请查看您线路的%{timetable_link}以获取最新的时刻表。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "服务已结束"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "服务运行正常"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "为世界杯服务"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "最短行程"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "展示"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "显示详情"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "减少停靠次数"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "显示更多站点"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "显示全部"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "显示主要站点。"
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "摆渡巴士"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "摆渡巴士"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "注册服务"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "登入"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "注册自动付款"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "注册接收 T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "订阅警报通知"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "类似行程到达%{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "类似行程于%{time}出发"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "类似行程到达%{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "类似行程于%{times}出发"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "单轨"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "转向主要内容"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "绕行"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "略微偏左"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "略微偏右"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "智能卡"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "雪道"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "铲雪"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "部分座位尚有空位"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "有些拥挤"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "我们这边出了点问题。"
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "对不起！我们错过了您的站点。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "对不起。出问题了。请重试。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "对不起。上传您的图片时遇到问题。请重试。"
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "南行"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "特别活动车票"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "需要特殊车票"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "车站及服务警报"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "车站无障碍设施"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "车站关闭"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "车站特色"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "车站问题"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "服务于 MBTA %{lines}条线路%{location}的车站。"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "车站"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "车站和停车场"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "车站和站点"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "地位"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "停止%{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "站点关闭"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "站点迁移"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "停止 绕行"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "停止"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "停止 绕行"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "学生"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "学生卡"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "提交"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "向MBTA提交公共记录申请。"
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "地铁"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "地铁新手指南"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "地铁票价"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "地铁线路图"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "单地铁程票"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "地铁状态"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "推荐零售商"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "概括"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "星期日"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "暂停"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "可持续性"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "交换始发地和目的地"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "全系统"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "提醒/倒计时/应用"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "TTY电话"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "乘坐地铁去投票"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "乘电梯"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "坐火车去看世界杯比赛？"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "请告诉我们您的想法"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "告诉我们您的日常出行情况，我们会根据您的需要，在您需要的时间向您发送相关的短信或电子邮件提醒。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "暂时不可使用"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "暂时已关闭"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "临时发行"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "临时问题"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "使用条款"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "感谢您提交反馈意见。我们的客户支持团队将尽快查看您的评论。"
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "感恩节"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "这 "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "The RIDE的全系统无障碍和无障碍联络中的无障碍参与协调员负责在收到 ADA/无障碍投诉后协调解决方案。"
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "Foxboro特别活动专线仅用于偶尔服务。"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "监察长办公室内部特别审计部门负责监督马萨诸塞州交通部各项计划的质量、效率和诚信。"
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "旅程"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "交互式时间表"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "目前没有实时出发信息。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "目前没有实时出发信息。以下显示的是预定出发时间。"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "没有"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "没有 "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "没有额外的无障碍功能，但巴士总是无障碍上车。"
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "没有警报。"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "没有高优先级事项"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "目前没有其他通勤铁路警报。"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "目前没有其他地铁警报。"
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "%{date}上没有安排%{direction}行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "目前没有安排%{direction}次行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "%{date}上没有预定的行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "没有预定的行程。"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "目前暂无更新信息。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "目前没有已安排的%{route_name} 。"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "目前还没有计划工作信息。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "此时间段内， %{stop}没有安排%{route}服务。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "加载到达数据时出现问题"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "加载时刻表时出现问题"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "加载行程详情时出现问题"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "加载即将进行的出发航班时出现问题"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "此%{place}不方便。"
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "本星期"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "此列表不包含MBTA目前的零售商。要查看当前的零售店位置，请使用我们的"
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "此页面已停止使用。"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "该车站没有自行车存放处。"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "这个车站没有电梯。"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "这家商店没有自动扶梯。"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "这家商店没有停车场。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "本站没有自动售票机，但您可以在车站购买车票。"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "这趟列车通常有<br /> <strong>%{seats}座位可用</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "星期四"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "时间表"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "到"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "如需报告铁路道口的问题或紧急情况，请致电"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "如需提交 ADA/无障碍投诉或反馈，请致电"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "今天"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "今天"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "免费电话"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "轨道登机变更"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "轨道变换"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "赛道待定"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "使用<strong>MBTA Go</strong>应用程序实时追踪您的%{route_type_text}行程"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "火车"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "列车%{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "计划从%{platform}开往上车的列车将于%{station}时刻从"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "转移"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "转会"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "交通"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "交通警察"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "乘坐Blue 、 Orange 、 Red和Green线，票价相同。"
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "旅行"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Trip planner"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "旅行类型"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "从%{from}到%{to}行程"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "请尝试在下方搜索您要查找的内容。"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "星期二"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "周二，11月5日是2024年大选投票的末日。 乘坐地铁前往投票站。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "通常只有不到 33% 的座位可用，而且不太可能保持社交距离（每排约 3 人以上）。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "通常情况下，超过 33% 的座位仍然空着，可以保持社交距离（每排约 2-3 人）。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "通常情况下，超过 66% 的座位可用，并且可以保持社交距离（每排约 0-2 人）。"
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "未知"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "非计划赛道"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "直到%{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "即将进行"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "即将进行变更"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "即将进行 出发"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "即将进行假期"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "即将进行公开会议和活动"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "更新于"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "更新： "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "更新"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "使用"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "用户指南"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "退伍军人节"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "通过"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "看法"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "查看%{timetable_link}以获取出发信息。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "查看警报"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "查看所有联系电话"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "查看所有选项"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "查看个人简介"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "查看%{name}的个人简介"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "查看PDF时间表"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "请在MBTA网站上查看PDF格式的时刻表。"
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "查看上一页"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "查看全部"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "查看所有巴士路线"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "查看所有活动"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "查看所有指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "查看所有比赛"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "查看所有新闻"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "查看所有项目更新"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "查看所有项目"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "查看可用电梯。"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "查看可用的自动扶梯。"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "查看 MBTA 巴士、地铁、通勤铁路、渡轮和The RIDE的常见票价信息。 在线查找 CharlieCard 服务并了解批量订购计划。"
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "查看晚间时刻表"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "查看票价概览"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "查看更多付款信息"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "查看早晨时刻表"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "在谷歌地图上查看"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "在 MBTA 行程规划器上查看"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "查看停车费率、设施信息等。"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "查看电话号码"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "访问"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "参观行动中心"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "投票"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "等待结果"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "等待出发"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "走"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "仅步行路线"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "华盛顿诞辰"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "我们只能提供%{rating}时刻表的行程数据，有效期至%{end_date} 。"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "提交您的反馈时出现问题——请拨打下面的主要热线电话，或稍后再试。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "我们希望确保我们构建的零售网络能够为您服务。您可以使用下面的表格分享您的反馈意见。"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "我们未能找到您所在地址的投票站。您也可以访问"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "我们将直接向您发送 MBTA 的新闻稿和媒体通告。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "在未来几年推行票价改革项目的过程中，我们希望公众能够帮助我们做出正确的决定。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "我们正在扩大乘客可以办理或充值 CharlieCard 以及购买通票的地点网络。"
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "网站"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "星期三"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "周末通票"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "周末"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "西行"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "MBTA 发生了什么？"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "什么时候"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "加入我们"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "加入我们"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "在职的"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "世界杯指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "世界杯比赛"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "请写信给我们"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "全年"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "您也可以通过电子邮件联系我。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "大多数车票申请会在 5 个工作日内得到回复。 某些投诉可能需要更长时间的调查，最长可达 30 天。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "您可以使用以下方式支付车费："
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "您必须同意我们的隐私政策才能提交反馈。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "您必须先完成 reCAPTCHA 验证才能提交反馈。"
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "世界杯将影响您的通勤铁路行程。"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "您的投票站"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "区"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "区域%{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "1A-10区"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "一名船员"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "无障碍设施"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "此时发出警报"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "和"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "到达"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "抵达"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "此时"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "介于%{first}和%{last}之间"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "船"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "巴士"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "巴士站"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "现金"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "改变"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "变化"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "非接触式支付"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "当前的"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "已离开"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "码头"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "东方"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "很少"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "为了"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "来自%{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "已离开"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "进站"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "信息"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "由于服务变更，暂时无法使用。"
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "线"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "地点"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "mTicket App"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "许多"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "附近零售店"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "北"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "超过30分钟"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "超过一个小时"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "到"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "或"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "或 "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "或者填写此页面上的反馈表。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "或在任何巴士上用现金支付"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "出站"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "纸质渡轮车票"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "计划"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "减价票卡"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "提前注册"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "报告问题"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "需要"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "零售店位置查找器"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "路线"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "查看所有拟定销售地点的地图"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "服务"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "一些"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "南"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "车站"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "车站"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "停止"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "停止"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "MBTA主页"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "指挥家"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "第二天早上"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "通过"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "时间表"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "到"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "至%{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "找到你的投票地点，然后使用"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "计划您的行程"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "停车位总数"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "向"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "追踪 "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "火车"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "今日行程"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "最多 10 分钟"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "最多 15 分钟"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "最多 20 分钟"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "最多 25 分钟"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "最多 30 分钟"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "网站"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "西方"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "和"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "满足您的要求。"
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " 警报"
 msgid " at "
 msgstr " 在 "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " 在%{address}"
@@ -128,7 +128,7 @@ msgstr " 在 "
 msgid " on track "
 msgstr " 进展顺利 "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y}的%{x}工作"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -326,7 +327,7 @@ msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "今天又去了%{count}趟"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "1日通票"
@@ -344,8 +345,8 @@ msgstr "每周 7 天，每天 24 小时"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "7天通票"
@@ -356,12 +357,12 @@ msgstr "7天通票"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "TTY用户请拨打711；ASL用户请拨打VRS。"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA乘车"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "ADA乘车费用"
@@ -441,7 +442,7 @@ msgstr "添加到日历"
 msgid "Admins Only"
 msgstr "仅限管理员"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "成人"
@@ -525,7 +526,7 @@ msgstr "所有列车取消"
 msgid "All Updates"
 msgstr "所有更新"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "所有渡轮航线"
@@ -939,7 +940,7 @@ msgstr "改变行程方向。"
 msgid "Changes"
 msgstr "变化"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -955,7 +956,7 @@ msgid "Charlie Service Center"
 msgstr "Charlie 服务中心"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "查理卡"
@@ -972,8 +973,8 @@ msgstr "CharlieCard"
 msgid "CharlieCards & Tickets"
 msgstr "查理卡和车票"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -988,12 +989,12 @@ msgstr "查看"
 msgid "Check-In at South Station"
 msgstr "在South Station办理登机手续"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "孩子"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "3岁以下儿童"
@@ -1049,7 +1050,7 @@ msgstr "哥伦布日"
 msgid "Comment"
 msgstr "评论"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "通勤渡轮到洛根Airport"
@@ -1067,7 +1068,7 @@ msgstr "通勤渡轮到洛根Airport"
 msgid "Commuter Rail"
 msgstr "通勤火车"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "通勤火车 "
@@ -1184,7 +1185,7 @@ msgstr "信用卡/借记卡"
 msgid "Credit/debit cards"
 msgstr "信用卡/借记卡"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "跨港渡轮"
@@ -1255,7 +1256,7 @@ msgstr "日期"
 msgid "Date and Time"
 msgstr "日期和时间"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "日通票"
@@ -1396,7 +1397,7 @@ msgstr "提前出发"
 msgid "Early Departure Stop"
 msgstr "提前出发停靠站"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1636,7 +1637,7 @@ msgstr "预计延误"
 msgid "Explore stations by mode"
 msgstr "按模式探索车站"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "快速巴士"
@@ -1668,7 +1669,7 @@ msgstr "设施信息"
 msgid "Facility Issue"
 msgstr "设施问题"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "家庭四人套餐（2 位成人，2 位儿童）"
@@ -1766,7 +1767,7 @@ msgstr "MBTA 最新动态和项目"
 msgid "Ferry"
 msgstr "渡轮"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "渡轮 "
@@ -1909,7 +1910,7 @@ msgstr "如有任何关于此新闻稿的问题或意见，请联系我们。"
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "如需前往Foxboro定期工作日服务，请访问： "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Foxboro特别活动"
@@ -1932,7 +1933,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "免费踏板和停车安全停车场"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "免费服务"
@@ -1952,7 +1953,7 @@ msgstr "从"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "全高站台，为列车组中的每节车厢提供平缓的登车通道。"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2033,7 +2034,7 @@ msgstr "Green Line %{branch}支线"
 msgid "Group Name"
 msgstr "组名"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "港口环线渡轮"
@@ -2059,7 +2060,7 @@ msgstr "隐藏"
 msgid "Hide Details"
 msgstr "隐藏详情"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2160,17 +2161,17 @@ msgstr "机构销售"
 msgid "Intended Audience"
 msgstr "目标受众"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "区域间%{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "无效持续时间"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "无效票价"
@@ -2408,7 +2409,7 @@ msgstr "正在加载即将进行的出发航班"
 msgid "Lobby inside Back Bay station"
 msgstr "Back Bay车站内的大堂"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "当地巴士"
@@ -2436,7 +2437,7 @@ msgstr "位置不可使用"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "洛根快线"
@@ -2457,7 +2458,7 @@ msgstr "失物招领"
 msgid "Lost and Found"
 msgstr "失物招领"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2675,8 +2676,8 @@ msgstr "麻省海湾交通管理局，版权所有。"
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport 摆渡巴士"
@@ -2776,7 +2777,7 @@ msgstr "纪念日"
 msgid "Menu"
 msgstr "菜单"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "军队"
@@ -2839,23 +2840,23 @@ msgstr "月票"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "月票LinkPass"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "月票 本地巴士 通票"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "月票 通票"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mTicket App 上的月票 通票"
@@ -3058,7 +3059,7 @@ msgstr "笔记"
 msgid "Notice"
 msgstr "注意"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3101,12 +3102,12 @@ msgstr "准时"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "每辆巴士前门都设有登车坡道。"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "一日通票"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "单程票"
@@ -3460,12 +3461,12 @@ msgstr "预计出发时间尚未公布，但会在首班航班出发前在此处
 msgid "Prefer accessible routes"
 msgstr "优先选择方便路线"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "高级乘车"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "高级乘车费用"
@@ -3671,7 +3672,7 @@ msgstr "没有匹配车票的乘客将不被允许上车Boston Stadium Trains。
 msgid "Right"
 msgstr "正确的"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "往返"
@@ -3909,7 +3910,7 @@ msgstr "选择"
 msgid "Send Us Feedback"
 msgstr "请向我们发送反馈"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "老年人查理卡或TAP ID"
@@ -3919,7 +3920,7 @@ msgstr "老年人查理卡或TAP ID"
 msgid "Senior ID Cards"
 msgstr "老年人身份证"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "老年人"
@@ -4019,8 +4020,8 @@ msgid "Showing major stops."
 msgstr "显示主要站点。"
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "摆渡巴士"
@@ -4157,7 +4158,7 @@ msgstr "对不起。上传您的图片时遇到问题。请重试。"
 msgid "Southbound"
 msgstr "南行"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "特别活动车票"
@@ -4192,13 +4193,13 @@ msgstr "车站特色"
 msgid "Station Issue"
 msgstr "车站问题"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "服务于 MBTA %{lines}条线路%{location}的车站。"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4260,12 +4261,12 @@ msgstr "停止"
 msgid "Stops Skipped"
 msgstr "停止 绕行"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "学生"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "学生卡"
@@ -4288,7 +4289,7 @@ msgstr "向MBTA提交公共记录申请。"
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "地铁"
@@ -5113,8 +5114,8 @@ msgstr "网站"
 msgid "Wednesday"
 msgstr "星期三"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "周末通票"
@@ -5140,11 +5141,6 @@ msgstr "MBTA 发生了什么？"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "什么时候"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5223,12 +5219,12 @@ msgid "Zone"
 msgstr "区"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "区域%{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "1A-10区"
@@ -5293,7 +5289,7 @@ msgstr "巴士"
 msgid "bus stop"
 msgstr "巴士站"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "现金"
@@ -5308,7 +5304,7 @@ msgstr "改变"
 msgid "changes"
 msgstr "变化"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "非接触式支付"
@@ -5380,7 +5376,7 @@ msgid "location"
 msgstr "地点"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "mTicket App"
@@ -5420,7 +5416,7 @@ msgstr "到"
 msgid "or"
 msgstr "或"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "或 "
@@ -5440,7 +5436,7 @@ msgstr "或在任何巴士上用现金支付"
 msgid "outbound"
 msgstr "出站"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "纸质渡轮车票"
@@ -5630,8 +5626,8 @@ msgstr "网站"
 msgid "west"
 msgstr "西方"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5641,3 +5637,13 @@ msgstr "和"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "满足您的要求。"
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5519,9 +5519,9 @@ msgstr "滿足您的要求。"
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
-msgstr ""
+msgstr "內港區 1A"
 
 #: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
-msgstr ""
+msgstr "Winthrop和Quincy Ferry"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -62,7 +62,7 @@ msgstr " 警報"
 msgid " at "
 msgstr " 在 "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:447
+#: lib/dotcom_web/controllers/stop_controller.ex:406
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " 在%{address}"
@@ -128,7 +128,7 @@ msgstr " 在 "
 msgid " on track "
 msgstr " 進展順利 "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:47
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
 #: lib/dotcom_web/templates/error/error_layout.html.heex:26
 #, elixir-autogen, elixir-format
 msgid " or "
@@ -270,6 +270,7 @@ msgstr "%{y}的%{x}工作"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
 #: lib/vehicle_helpers.ex:166
 #, elixir-autogen, elixir-format
 msgid ", "
@@ -326,7 +327,7 @@ msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "今天又去了%{count}趟"
 
-#: lib/fares/format.ex:117
+#: lib/fares/format.ex:120
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "1日通票"
@@ -344,8 +345,8 @@ msgstr "每週 7 天，每天 24 小時"
 
 #: lib/dotcom_web/views/fare_view.ex:50
 #: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:64
-#: lib/fares/format.ex:116
+#: lib/fares/format.ex:66
+#: lib/fares/format.ex:119
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "7天通票"
@@ -356,12 +357,12 @@ msgstr "7天通票"
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "TTY用戶請撥打711；ASL用戶請撥打VRS。"
 
-#: lib/fares/format.ex:104
+#: lib/fares/format.ex:107
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA乘車"
 
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex:121
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "ADA乘車費用"
@@ -441,7 +442,7 @@ msgstr "新增到日曆"
 msgid "Admins Only"
 msgstr "限管理員"
 
-#: lib/fares/fare_info.ex:845
+#: lib/fares/fare_info.ex:906
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "成人"
@@ -525,7 +526,7 @@ msgstr "所有列車取消"
 msgid "All Updates"
 msgstr "所有更新"
 
-#: lib/fares/format.ex:187
+#: lib/fares/format.ex:190
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "所有渡輪航線"
@@ -939,7 +940,7 @@ msgstr "改變行程方向。"
 msgid "Changes"
 msgstr "變化"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex:91
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
@@ -955,7 +956,7 @@ msgid "Charlie Service Center"
 msgstr "Charlie 服務中心"
 
 #: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:35
+#: lib/fares/format.ex:37
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "查理卡"
@@ -972,8 +973,8 @@ msgstr "CharlieCard"
 msgid "CharlieCards & Tickets"
 msgstr "查理卡和車票"
 
-#: lib/fares/format.ex:36
-#: lib/fares/format.ex:37
+#: lib/fares/format.ex:38
+#: lib/fares/format.ex:39
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
@@ -988,12 +989,12 @@ msgstr "查看"
 msgid "Check-In at South Station"
 msgstr "在South Station辦理登機手續"
 
-#: lib/fares/fare_info.ex:846
+#: lib/fares/fare_info.ex:907
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "孩子"
 
-#: lib/fares/fare_info.ex:847
+#: lib/fares/fare_info.ex:908
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "3歲以下兒童"
@@ -1049,7 +1050,7 @@ msgstr "哥倫布日"
 msgid "Comment"
 msgstr "評論"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex:100
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "通勤渡輪到洛根Airport"
@@ -1067,7 +1068,7 @@ msgstr "通勤渡輪到洛根Airport"
 msgid "Commuter Rail"
 msgstr "通勤火車"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex:192
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "通勤火車 "
@@ -1184,7 +1185,7 @@ msgstr "信用卡/金融卡"
 msgid "Credit/debit cards"
 msgstr "信用卡/金融卡"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "跨港渡輪"
@@ -1255,7 +1256,7 @@ msgstr "日期"
 msgid "Date and Time"
 msgstr "日期和時間"
 
-#: lib/fares/format.ex:60
+#: lib/fares/format.ex:62
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "日通票"
@@ -1396,7 +1397,7 @@ msgstr "提前出發"
 msgid "Early Departure Stop"
 msgstr "提前出發停靠站"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex:94
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
@@ -1636,7 +1637,7 @@ msgstr "預計延誤"
 msgid "Explore stations by mode"
 msgstr "按模式探索車站"
 
-#: lib/fares/format.ex:88
+#: lib/fares/format.ex:90
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "快速巴士"
@@ -1668,7 +1669,7 @@ msgstr "設施資訊"
 msgid "Facility Issue"
 msgstr "設施問題"
 
-#: lib/fares/fare_info.ex:851
+#: lib/fares/fare_info.ex:912
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "家庭四人套餐（2 位成人，2 位兒童）"
@@ -1766,7 +1767,7 @@ msgstr "MBTA 最新動態和項目"
 msgid "Ferry"
 msgstr "渡輪"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex:193
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "渡輪 "
@@ -1909,7 +1910,7 @@ msgstr "如有任何關於此新聞稿的問題或意見，請與我們聯絡。
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "如需前往Foxboro定期工作日服務，請造訪： "
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex:103
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Foxboro特別活動"
@@ -1932,7 +1933,7 @@ msgid "Free Pedal and Park secured parking"
 msgstr "免費踏板和停車安全停車場"
 
 #: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex:105
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "免費服務"
@@ -1952,7 +1953,7 @@ msgstr "從"
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "全高月臺為列車組內的每節車廂提供平整的登車通道"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex:97
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
@@ -2033,7 +2034,7 @@ msgstr "Green Line %{branch}支線"
 msgid "Group Name"
 msgstr "組名"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex:93
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "港口環線渡輪"
@@ -2059,7 +2060,7 @@ msgstr "隱藏"
 msgid "Hide Details"
 msgstr "隱藏詳情"
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex:99
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
@@ -2160,17 +2161,17 @@ msgstr "機構銷售"
 msgid "Intended Audience"
 msgstr "目標受眾"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex:102
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "區域間%{zone}"
 
-#: lib/fares/format.ex:80
+#: lib/fares/format.ex:82
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "無效持續時間"
 
-#: lib/fares/format.ex:106
+#: lib/fares/format.ex:109
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "無效票價"
@@ -2408,7 +2409,7 @@ msgstr "正在加載即將進行的出發航班"
 msgid "Lobby inside Back Bay station"
 msgstr "Back Bay車站內大廳"
 
-#: lib/fares/format.ex:87
+#: lib/fares/format.ex:89
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "當地巴士"
@@ -2436,7 +2437,7 @@ msgstr "位置不可用"
 
 #: lib/dotcom_web/components/route_symbols.ex:250
 #: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex:111
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "洛根快線"
@@ -2457,7 +2458,7 @@ msgstr "失物招領"
 msgid "Lost and Found"
 msgstr "失物招領"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
@@ -2675,8 +2676,8 @@ msgstr "麻省海灣交通管理局，版權所有。"
 
 #: lib/dotcom_web/views/helpers.ex:245
 #: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:107
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex:110
+#: lib/fares/format.ex:112
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport 擺渡巴士"
@@ -2776,7 +2777,7 @@ msgstr "紀念日"
 msgid "Menu"
 msgstr "功能表"
 
-#: lib/fares/fare_info.ex:869
+#: lib/fares/fare_info.ex:930
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "軍隊"
@@ -2839,23 +2840,23 @@ msgstr "月票"
 
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
 #: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:113
+#: lib/fares/format.ex:116
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "月票LinkPass"
 
 #: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:114
+#: lib/fares/format.ex:117
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "月票 本地巴士 通票"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "月票 通票"
 
-#: lib/fares/format.ex:73
+#: lib/fares/format.ex:75
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mTicket App 上的月票 通票"
@@ -3058,7 +3059,7 @@ msgstr "筆記"
 msgid "Notice"
 msgstr "注意"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:314
+#: lib/dotcom_web/components/system_status/subway_status.ex:324
 #: lib/dotcom_web/components/trip_planner/input_form.ex:73
 #: lib/dotcom_web/live/schedule_finder_live.ex:418
 #: lib/dotcom_web/live/upcoming_departures_live.ex:720
@@ -3101,12 +3102,12 @@ msgstr "準時"
 msgid "Onboard ramps at the front door of each bus"
 msgstr "每輛巴士前門都設有登車坡道。"
 
-#: lib/fares/format.ex:56
+#: lib/fares/format.ex:58
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "一日通票"
 
-#: lib/fares/format.ex:48
+#: lib/fares/format.ex:50
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "單程票"
@@ -3460,12 +3461,12 @@ msgstr "預計出發時間尚未公佈，但會在首班航班出發前在此顯
 msgid "Prefer accessible routes"
 msgstr "優先選擇方便路線"
 
-#: lib/fares/format.ex:105
+#: lib/fares/format.ex:108
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "高級乘車"
 
-#: lib/fares/format.ex:119
+#: lib/fares/format.ex:122
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "高級乘車費用"
@@ -3671,7 +3672,7 @@ msgstr "沒有配對車票的乘客將不被允許上車Boston Stadium Trains。
 msgid "Right"
 msgstr "正確的"
 
-#: lib/fares/format.ex:52
+#: lib/fares/format.ex:54
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "往返"
@@ -3909,7 +3910,7 @@ msgstr "選擇"
 msgid "Send Us Feedback"
 msgstr "請向我們發送反饋"
 
-#: lib/fares/format.ex:41
+#: lib/fares/format.ex:43
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "老年人查理卡或TAP ID"
@@ -3919,7 +3920,7 @@ msgstr "老年人查理卡或TAP ID"
 msgid "Senior ID Cards"
 msgstr "老年人身分證"
 
-#: lib/fares/fare_info.ex:863
+#: lib/fares/fare_info.ex:924
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "老年人"
@@ -4019,8 +4020,8 @@ msgid "Showing major stops."
 msgstr "顯示主要站點。"
 
 #: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:103
-#: lib/fares/format.ex:112
+#: lib/fares/format.ex:106
+#: lib/fares/format.ex:115
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "擺渡巴士"
@@ -4157,7 +4158,7 @@ msgstr "對不起。上傳您的圖片時遇到問題。請重試。"
 msgid "Southbound"
 msgstr "南行"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex:44
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "特別活動車票"
@@ -4192,13 +4193,13 @@ msgstr "車站特色"
 msgid "Station Issue"
 msgstr "車站問題"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:429
+#: lib/dotcom_web/controllers/stop_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "服務於 MBTA %{lines}條線路%{location}的車站。"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:52
-#: lib/dotcom_web/controllers/stop_controller.ex:414
+#: lib/dotcom_web/controllers/stop_controller.ex:51
+#: lib/dotcom_web/controllers/stop_controller.ex:373
 #: lib/dotcom_web/templates/stop/index.html.heex:21
 #: lib/dotcom_web/templates/stop/index.html.heex:41
 #: lib/dotcom_web/views/page_view.ex:181
@@ -4260,12 +4261,12 @@ msgstr "停止"
 msgid "Stops Skipped"
 msgstr "停止 繞行"
 
-#: lib/fares/fare_info.ex:857
+#: lib/fares/fare_info.ex:918
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "學生"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex:45
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "學生卡"
@@ -4288,7 +4289,7 @@ msgstr "向MBTA提交公共記錄申請。"
 #: lib/dotcom_web/views/helpers.ex:236
 #: lib/dotcom_web/views/layout_view.ex:89
 #: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:86
+#: lib/fares/format.ex:88
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "地鐵"
@@ -5113,8 +5114,8 @@ msgstr "網站"
 msgid "Wednesday"
 msgstr "星期三"
 
-#: lib/fares/format.ex:68
-#: lib/fares/format.ex:115
+#: lib/fares/format.ex:70
+#: lib/fares/format.ex:118
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "週末通票"
@@ -5140,11 +5141,6 @@ msgstr "MBTA 發生了什麼事？"
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "什麼時候"
-
-#: lib/fares/format.ex:94
-#, elixir-autogen, elixir-format
-msgid "Winthrop/Quincy Ferry"
-msgstr "Winthrop/Quincy Ferry"
 
 #: lib/dotcom_web/templates/layout/_footer.html.heex:73
 #, elixir-autogen, elixir-format
@@ -5223,12 +5219,12 @@ msgid "Zone"
 msgstr "區"
 
 #: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex:101
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "區域%{zone}"
 
-#: lib/fares/format.ex:186
+#: lib/fares/format.ex:189
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "1A-10區"
@@ -5293,7 +5289,7 @@ msgstr "巴士"
 msgid "bus stop"
 msgstr "巴士站"
 
-#: lib/fares/format.ex:34
+#: lib/fares/format.ex:36
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "現金"
@@ -5308,7 +5304,7 @@ msgstr "改變"
 msgid "changes"
 msgstr "變化"
 
-#: lib/fares/format.ex:38
+#: lib/fares/format.ex:40
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "非接觸式支付"
@@ -5380,7 +5376,7 @@ msgid "location"
 msgstr "地點"
 
 #: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex:41
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "mTicket App"
@@ -5420,7 +5416,7 @@ msgstr "到"
 msgid "or"
 msgstr "或"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:42
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "或 "
@@ -5440,7 +5436,7 @@ msgstr "或在任何巴士上用現金支付"
 msgid "outbound"
 msgstr "出站"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex:42
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "紙質渡輪車票"
@@ -5630,8 +5626,8 @@ msgstr "網站"
 msgid "west"
 msgstr "西方"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:91
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:117
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
 #: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "with"
@@ -5641,3 +5637,13 @@ msgstr "和"
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "滿足您的要求。"
+
+#: lib/fares/format.ex:98
+#, elixir-autogen, elixir-format
+msgid "Inner Harbor Zone 1A"
+msgstr ""
+
+#: lib/fares/format.ex:96
+#, elixir-autogen, elixir-format
+msgid "Winthrop and Quincy Ferry"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -11,5639 +11,5517 @@ msgstr ""
 "Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/dotcom_web/views/page_view.ex:182
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " & Stops"
 msgstr " 和站點"
 
-#: lib/dotcom_web/views/schedule_view.ex:415
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Additional service between Boston, Hingham, and Hull is available via the %{link}"
 msgstr " 波士頓、 Hingham和Hull之間可透過%{link}列車提供額外服務。"
 
-#: lib/dotcom/schedule_note.ex:100
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid " It travels along limited stops between Foxboro and either Providence or Downtown Boston (South Station)"
 msgstr " 它沿途停靠站點有限，往返Foxboro和Providence或波士頓Downtown （ South Station ）之間。"
 
-#: lib/dotcom_web/views/page_view.ex:197
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Lines"
 msgstr " 線條"
 
-#: lib/dotcom_web/views/page_view.ex:208
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid " Routes"
 msgstr " 路線"
 
-#: lib/dotcom_web/views/schedule_view.ex:438
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service continues later in the day in the opposite direction. %{link}"
 msgstr " 當天晚些時候，該服務將繼續以相反的方向運行。%{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:460
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Service is available earlier in the day in the opposite direction. %{link}"
 msgstr " 當天早些時候，反方向的服務也已開通。%{link}"
 
-#: lib/dotcom_web/views/schedule_view.ex:404
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " 活動結束後30分鐘，列車將從Foxboro出發。"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:110
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " alerts"
 msgstr " 警報"
 
-#: lib/dotcom_web/views/alert_view.ex:79
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at "
 msgstr " 在 "
 
-#: lib/dotcom_web/controllers/stop_controller.ex:406
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid " at %{address}"
 msgstr " 在%{address}"
 
-#: lib/dotcom_web/views/alert_view.ex:104
-#: lib/dotcom_web/views/alert_view.ex:112
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " at this time."
 msgstr " 此時。"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:20
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid " depend on the distance traveled (zones). Refer to the information below:"
 msgstr " 取決於行駛距離（區域）。請參考以下資訊："
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:129
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " for real-time track changes."
 msgstr " 用於即時追蹤更改。"
 
-#: lib/dotcom_web/views/alert_view.ex:70
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " for the "
 msgstr " 為了 "
 
-#: lib/vehicle_helpers.ex:143
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " has arrived at "
 msgstr " 已到達 "
 
-#: lib/vehicle_helpers.ex:142
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is arriving at "
 msgstr " 正在到達 "
 
-#: lib/vehicle_helpers.ex:144
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " is on the way to "
 msgstr " 正在前往 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " may leave ahead of schedule at these stops."
 msgstr " 可能會在時刻表之前在這些站點出發。"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:107
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid " minute walk"
 msgstr " 步行幾分鐘"
 
-#: lib/journey.ex:233
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid " on "
 msgstr " 在 "
 
-#: lib/dotcom_web/views/alert_view.ex:83
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid " on the "
 msgstr " 在 "
 
-#: lib/vehicle_helpers.ex:107
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid " on track "
 msgstr " 進展順利 "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:49
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid " or "
 msgstr " 或 "
 
-#: lib/dotcom_web/views/schedule_view.ex:179
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule"
 msgstr " 時刻表"
 
-#: lib/dotcom_web/views/schedule_view.ex:180
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid " schedule and map"
 msgstr " 時刻表和地圖"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:127
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " symbol. Check "
 msgstr " 象徵。查看 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:22
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " that they wish to leave. Passengers waiting to board must be visible on the platform for the "
 msgstr " 他們想離開。等待上車的乘客必須在月台上可見 "
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:23
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid " to stop."
 msgstr " 停止。"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:86
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "\"Walking distance\""
 msgstr "步行距離"
 
-#: lib/dotcom/schedule_note.ex:130
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{avg} minutes"
 msgstr "%{avg}分鐘"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:211
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:220
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} Stops"
 msgstr "%{count}停止"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:28
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} alerts"
 msgstr "%{count}警報"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:57
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "%{count} later %{change_text}"
 msgstr "%{count}稍後%{change_text}"
 
-#: lib/dotcom_web/views/cms_view.ex:57
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{start_time} - %{end_time}"
 msgstr "%{date}在%{start_time} - %{end_time}"
 
-#: lib/dotcom_web/components/world_cup_timetable/match_link.ex:56
-#: lib/dotcom_web/views/cms_view.ex:50
+#: lib/dotcom_web/components/world_cup_timetable/match_link.ex
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} at %{time}"
 msgstr "%{date}在%{time}"
 
-#: lib/dotcom_web/views/schedule_view.ex:73
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} is outside of our current schedule."
 msgstr "%{date}不在我們當下的時間表之內。"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:117
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "%{date} until further notice"
 msgstr "%{date}直至另行通知"
 
-#: lib/dotcom/schedule_note.ex:136
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "%{min} – %{max} minutes"
 msgstr "%{min} – %{max}分鐘"
 
-#: lib/dotcom/trip_plan/input_form.ex:249
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode1} and %{mode2}"
 msgstr "%{mode1}和%{mode2}"
 
-#: lib/dotcom/trip_plan/input_form.ex:232
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "%{mode_label} Only"
 msgstr "%{mode_label}僅"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:62
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "%{name} Commuter Rail"
 msgstr "%{name}通勤鐵路"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:41
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{place} Information"
 msgstr "%{place}訊息"
 
-#: lib/dotcom/service_patterns.ex:215
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Planned Work"
 msgstr "%{rating}計劃工作"
 
-#: lib/dotcom/service_patterns.ex:234
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, ends %{date}"
 msgstr "%{rating}時刻表，結束%{date}"
 
-#: lib/dotcom/service_patterns.ex:239
-#: lib/dotcom/service_patterns.ex:249
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "%{rating} Schedules, starts %{date}"
 msgstr "%{rating}時刻表，開始於%{date}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:237
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "%{route_name} to %{headsign}"
 msgstr "%{route_name}到%{headsign}"
 
-#: lib/dotcom_web/views/cms_view.ex:65
+#: lib/dotcom_web/views/cms_view.ex
 #, elixir-autogen, elixir-format
 msgid "%{sdate} %{stime} - %{edate} %{etime}"
 msgstr "%{sdate} %{stime} - %{edate} %{etime}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:163
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "%{time} on %{date}"
 msgstr "%{time}在%{date}"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:11
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "%{y} of %{x} working"
 msgstr "%{y}的%{x}工作"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:39
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:41
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:43
-#: lib/vehicle_helpers.ex:166
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid ", "
 msgstr "， "
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:34
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid ", cash, or "
 msgstr "現金，或 "
 
-#: lib/dotcom_web/views/alert_view.ex:101
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "."
 msgstr "。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:130
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Accessible Route"
 msgid_plural "%{count} Accessible Routes"
 msgstr[0] "%{count}條無障礙路線"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:136
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Inaccessible Route"
 msgid_plural "%{count} Inaccessible Routes"
 msgstr[0] "%{count}條無法通行的路線"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:119
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "1 Unavailable Route"
 msgid_plural "%{count} Unavailable Routes"
 msgstr[0] "%{count}條不可使用路線"
 
-#: lib/dotcom_web/views/helpers/alert_helpers.ex:27
+#: lib/dotcom_web/views/helpers/alert_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "1 alert"
 msgstr "1 則警報"
 
-#: lib/dotcom_web/components/search_results_live.ex:89
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 result"
 msgid_plural "%{count} results"
 msgstr[0] "共 %{count} 個結果"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:223
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "1 stop"
 msgid_plural "%{count} stops"
 msgstr[0] "%{count}站"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:845
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "1 trip later today"
 msgid_plural "%{count} trips later today"
 msgstr[0] "今天又去了%{count}趟"
 
-#: lib/fares/format.ex:120
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "1-Day Pass"
 msgstr "1日通票"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:70
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "2 areas where wheeled mobility devices can be secured"
 msgstr "2 個可以保護輪式助行裝置的區域"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:13
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:31
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
 #, elixir-autogen, elixir-format
 msgid "24 hours, 7 days a week"
 msgstr "每週 7 天，每天 24 小時"
 
-#: lib/dotcom_web/views/fare_view.ex:50
-#: lib/dotcom_web/views/fare_view.ex:73
-#: lib/fares/format.ex:66
-#: lib/fares/format.ex:119
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "7-Day Pass"
 msgstr "7天通票"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:8
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:8
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "711 for TTY callers;  VRS for ASL callers"
 msgstr "TTY用戶請撥打711；ASL用戶請撥打VRS。"
 
-#: lib/fares/format.ex:107
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride"
 msgstr "ADA乘車"
 
-#: lib/fares/format.ex:121
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "ADA Ride Fare"
 msgstr "ADA乘車費用"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:23
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "ADA/Accessibility Complaints"
 msgstr "ADA/無障礙投訴"
 
-#: lib/dotcom_web/views/layout_view.ex:188
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "關於"
 
-#: lib/dotcom_web/views/helpers.ex:249
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Access"
 msgstr "使用權"
 
-#: lib/alerts/alert.ex:227
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
 msgstr "訪問問題"
 
-#: lib/alerts/accessibility.ex:16
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Access Issues"
 msgstr "訪問問題"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:9
-#: lib/dotcom_web/templates/page/_important_links.html.heex:7
-#: lib/dotcom_web/views/layout_view.ex:108
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Accessibility"
 msgstr "無障礙"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility Resources"
 msgstr "無障礙資源"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Accessibility at %{name}"
 msgstr "無障礙存取%{name}"
 
-#: lib/dotcom_web/components/timetable.ex:281
-#: lib/dotcom_web/components/transit_icons.ex:15
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:78
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Accessible"
 msgstr "無障礙"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:6
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "添加"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add %{title} to calendar"
 msgstr "將%{title}加入到日曆"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:3
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add event to calendar"
 msgstr "將事件新增至日曆"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:14
-#: lib/dotcom_web/templates/event/show.html.heex:114
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Add to Calendar"
 msgstr "新增到日曆"
 
-#: lib/dotcom_web/templates/layout/admin.html.heex:6
+#: lib/dotcom_web/templates/layout/admin.html.heex
 #, elixir-autogen, elixir-format
 msgid "Admins Only"
 msgstr "限管理員"
 
-#: lib/fares/fare_info.ex:906
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Adult"
 msgstr "成人"
 
-#: lib/dotcom_web/templates/event/show.html.heex:70
-#: lib/dotcom_web/templates/event/show.html.heex:131
-#: lib/dotcom_web/templates/event/show.html.heex:151
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Agenda"
 msgstr "議程"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:185
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Alert"
 msgstr "警報"
 
-#: lib/dotcom_web/components/layouts/alerts_layout.html.heex:3
-#: lib/dotcom_web/controllers/alert_controller.ex:96
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:33
-#: lib/dotcom_web/live/subway_alerts_live.ex:31
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:49
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:15
-#: lib/dotcom_web/views/schedule_view.ex:300
+#: lib/dotcom_web/components/layouts/alerts_layout.html.heex
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "警報"
 
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:42
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Alerts for MBTA %{description}"
 msgstr "MBTA %{description}的警報"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:12
-#: lib/dotcom_web/views/partial_view.ex:191
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Alerts"
 msgstr "所有警報"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:131
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Boston Stadium Train tickets include a return trip after the match. Trains will start leaving Foxboro Station 30 minutes after the final whistle. Return trains will leave the stadium roughly every 15 minutes until all trains have departed."
 msgstr "所有Boston Stadium火車票均包含賽後回程車票。 列車將在終場哨響後 30 分鐘開始從Foxboro車站出發。 回程列車大約每 15 分鐘一班從體育場出發，直到所有列車都出發為止。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:160
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Inbound Trains"
 msgstr "所有進站列車"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Location Types"
 msgstr "所有位置類型"
 
-#: lib/dotcom_web/views/layout_view.ex:226
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All MBTA Improvement Projects"
 msgstr "所有MBTA改善項目"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Outbound Trains"
 msgstr "所有出站列車"
 
-#: lib/dotcom_web/views/layout_view.ex:94
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "All Schedules & Maps"
 msgstr "所有時刻表和地圖"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:166
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains"
 msgstr "所有列車"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:151
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "All Trains Cancelled"
 msgstr "所有列車取消"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:5
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "All Updates"
 msgstr "所有更新"
 
-#: lib/fares/format.ex:190
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "All ferry routes"
 msgstr "所有渡輪航線"
 
-#: lib/dotcom_web/views/customer_support_view.ex:46
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "All fields with an asterisk* are required."
 msgstr "標有星號*的欄位均為必填項。"
 
-#: lib/dotcom/trip_plan/input_form.ex:229
-#: lib/dotcom/trip_plan/input_form.ex:238
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "All modes"
 msgstr "所有模式"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "All proposed locations are subject to site suitability, permitting, and retail availability."
 msgstr "所有擬定地點均需視場地適宜性、許可證辦理情況及零售供應情況而定。"
 
-#: lib/alerts/alert.ex:228
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
 msgstr "安珀警報"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:9
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "An exterior shot of the Downtown Crossing Station entrance. US Flags line the street, and skyscrapers are visible in the background. Many pedestrians are walking by."
 msgstr "Downtown Crossing車站入口的外部照片。 街道兩旁飄揚著美國國旗，遠處可見摩天大樓。許多行人正從旁邊經過。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Apple Pay"
 msgstr "Apple Pay"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:541
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Approaching"
 msgstr "即將進站"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:75
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Arrive by"
 msgstr "到達時間"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:718
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving"
 msgstr "到達"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:77
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Arriving by %{time}"
 msgstr "到達時間： %{time}"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "At fare vending machines, you can"
 msgstr "在自動售票機上，您可以"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:122
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "At stations with multiple tracks outside of North, South, Back Bay, and Ruggles Stations, inbound trains board from Track 2, and outbound trains board from Track 1 unless otherwise specified. Scheduled track changes will be denoted by the "
 msgstr "在北行、南行、 Back Bay和Ruggles車站外有多條軌道的車站，進站列車從 2 號軌道上車，出站列車從 1 號軌道上車，除非另有說明。 計劃中的軌道變更將以以下方式標示： "
 
-#: lib/dotcom_web/templates/event/show.html.heex:118
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "與會者"
 
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:72
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bad grouped fare card data"
 msgstr "錯誤的團體票價卡數據"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:133
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bag Policy & Prohibited Items"
 msgstr "背包政策及違禁物品"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:127
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Be at South Station at the time shown for your boarding group. Your boarding group is on your Boston Stadium Train ticket."
 msgstr "請依照您所在登車組別的指定時間到South Station 。 您的登車組號在您的Boston Stadium火車票上。"
 
-#: lib/dotcom/utils/service_date_time.ex:85
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Before Today"
 msgstr "今天之前"
 
-#: lib/dotcom_web/views/layout_view.ex:225
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Better Bus Project"
 msgstr "更好的巴士項目"
 
-#: lib/dotcom_web/components/timetable.ex:82
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles Allowed?"
 msgstr "允許騎自行車嗎？"
 
-#: lib/dotcom_web/components/timetable.ex:101
-#: lib/dotcom_web/components/timetable.ex:105
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles allowed"
 msgstr "允許騎自行車"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:4
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bicycles are allowed on trains with the bicycle symbol below the train number, subject to restrictions."
 msgstr "列車車次下方有自行車標誌的列車允許攜帶自行車上車，但需遵守相關限制。"
 
-#: lib/dotcom_web/components/timetable.ex:107
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Bicycles not allowed"
 msgstr "禁止騎自行車"
 
-#: lib/dotcom/alerts/commuter_rail.ex:17
-#: lib/dotcom/alerts/subway.ex:16
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Bike"
 msgstr "自行車"
 
-#: lib/alerts/alert.ex:229
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
 msgstr "自行車問題"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage"
 msgstr "自行車存放處"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:30
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bike Storage at %{name}"
 msgstr "自行車存放處%{name}"
 
-#: lib/dotcom_web/views/layout_view.ex:105
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bikes"
 msgstr "自行車"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:94
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes Allowed"
 msgstr "允許騎自行車"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:160
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bikes are allowed on all ferry boats"
 msgstr "所有渡輪都允許攜帶自行車。"
 
-#: lib/dotcom_web/views/helpers.ex:250
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line"
 msgstr "Blue Line"
 
-#: lib/hub_stops.ex:41
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line subway platform inside State Street"
 msgstr "Blue Line地鐵月台State Street 內"
 
-#: lib/hub_stops.ex:43
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Blue Line train departing Airport station"
 msgstr "Blue Line火車從Airport車站出發"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:719
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding"
 msgstr "登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:26
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:40
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:54
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:68
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:82
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:96
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:110
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group A"
 msgstr "A組登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:27
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:41
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:55
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:69
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:83
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:97
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:111
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group B"
 msgstr "B組登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:28
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:42
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:56
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:70
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:84
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:98
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group C"
 msgstr "C組登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:29
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:43
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:57
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:71
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:85
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:99
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group D"
 msgstr "D組登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:30
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:44
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:58
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:72
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:86
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:100
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:114
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Boarding Group E"
 msgstr "E組登機"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:76
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boarding Groups"
 msgstr "登船組"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:113
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train Ticket Required"
 msgstr "Boston Stadium需要火車票"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:115
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket app. For more information, read our %{world_cup_link}"
 msgstr "Boston Stadium火車票必須提前在mTicket應用程式上購買。 欲了解更多信息，請閱讀我們的%{world_cup_link}"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:25
-#: lib/dotcom_web/views/page_view.ex:202
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium專列"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:10
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Boston Visitor's Guide to The T"
 msgstr "波士頓地鐵遊客指南"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:226
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Both Directions"
 msgstr "雙向"
 
-#: lib/dotcom_web/templates/stop/show.html.heex:49
+#: lib/dotcom_web/templates/stop/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bringing your car or bike"
 msgstr "開車或騎自行車"
 
-#: lib/dotcom/trip_plan/input_form.ex:201
-#: lib/dotcom_web/controllers/mode/bus.ex:14
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:33
-#: lib/dotcom_web/views/helpers.ex:238
-#: lib/dotcom_web/views/layout_view.ex:90
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "巴士"
 
-#: lib/dotcom/upcoming_departures/processor.ex:219
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Bus %{trip_name}"
 msgstr "巴士%{trip_name}"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:20
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
 msgstr "巴士初學者指南"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:28
-#: lib/dotcom_web/views/layout_view.ex:138
+#: lib/dotcom_web/controllers/mode/bus.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Fares"
 msgstr "巴士票價"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Features"
 msgstr "巴士特色"
 
-#: lib/dotcom_web/views/mode_view.ex:191
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Map"
 msgstr "巴士地圖"
 
-#: lib/dotcom_web/views/customer_support_view.ex:110
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Other"
 msgstr "巴士其他"
 
-#: lib/dotcom_web/views/schedule_view.ex:280
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"
 msgstr "巴士路線"
 
-#: lib/feedback/message.ex:19
-#: lib/feedback/message.ex:32
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop"
 msgstr "巴士站"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:16
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Stop Changes"
 msgstr "巴士站變更"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:68
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Buses that can be lowered for easier boarding and exiting"
 msgstr "可降低車身高度以便乘客上下車的巴士"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:55
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "商業"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:83
-#: lib/dotcom_web/views/layout_view.ex:212
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Business Opportunities"
 msgstr "商業機會"
 
-#: lib/dotcom_web/templates/event/index.html.heex:17
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Calendar view"
 msgstr "日曆視圖"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:82
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call"
 msgstr "稱呼"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:18
-#: lib/dotcom_web/templates/layout/_footer.html.heex:6
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Call Us"
 msgstr "致電我們"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:95
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "取消"
 
-#: lib/alerts/alert.ex:230
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:124
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
 msgstr "取消"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:127
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Cancellations"
 msgstr "取消"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:775
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "已取消"
 
-#: lib/dotcom_web/views/layout_view.ex:221
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Capital Transformation"
 msgstr "資本轉型"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:74
-#: lib/dotcom_web/templates/page/_important_links.html.heex:31
-#: lib/dotcom_web/views/layout_view.ex:210
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Careers"
 msgstr "職業生涯"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:45
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:56
-#: lib/fares/retail_locations_data.ex:91
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Cash"
 msgstr "現金"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "改變"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Date"
 msgstr "更改日期"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:17
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Change Direction of Trip."
 msgstr "改變行程方向。"
 
-#: lib/dotcom_web/views/schedule_view.ex:561
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Changes"
 msgstr "變化"
 
-#: lib/fares/format.ex:91
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Charlestown Ferry"
 msgstr "Charlestown Ferry"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Charlie Retailer"
 msgstr "查理零售商"
 
-#: lib/dotcom_web/views/layout_view.ex:146
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Charlie Service Center"
 msgstr "Charlie 服務中心"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:69
-#: lib/fares/format.ex:37
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCard"
 msgstr "查理卡"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards"
 msgstr "CharlieCard"
 
-#: lib/feedback/message.ex:20
-#: lib/feedback/message.ex:33
-#: lib/feedback/message.ex:45
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieCards & Tickets"
 msgstr "查理卡和車票"
 
-#: lib/fares/format.ex:38
-#: lib/fares/format.ex:39
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "CharlieTicket"
 msgstr "CharlieTicket"
 
-#: lib/fares/retail_locations_data.ex:92
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Check"
 msgstr "查看"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:86
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Check-In at South Station"
 msgstr "在South Station辦理登機手續"
 
-#: lib/fares/fare_info.ex:907
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "孩子"
 
-#: lib/fares/fare_info.ex:908
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Child under 3"
 msgstr "3歲以下兒童"
 
-#: lib/dotcom_web/views/layout_view.ex:247
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Choose Your Language"
 msgstr "選擇您的語言"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:408
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Choose a schedule type from the available options"
 msgstr "從可用選項中選擇一種時間表類型"
 
-#: lib/holiday/repo.ex:78
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Christmas Day"
 msgstr "聖誕節"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:39
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Civil Rights"
 msgstr "民權"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:76
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clickable graphic for User Guides"
 msgstr "使用者指南中的可點擊圖形"
 
-#: lib/dotcom_web/components/components.ex:309
-#: lib/dotcom_web/live/search_page_live.html.heex:43
+#: lib/dotcom_web/components/components.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "關閉"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:18
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Close dialog"
 msgstr "關閉對話框"
 
-#: lib/fares/retail_locations_data.ex:93
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Coin"
 msgstr "硬幣"
 
-#: lib/holiday/repo.ex:75
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Columbus Day"
 msgstr "哥倫布日"
 
-#: lib/feedback/message.ex:30
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "評論"
 
-#: lib/fares/format.ex:100
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Ferry to Logan Airport"
 msgstr "通勤渡輪到洛根Airport"
 
-#: lib/dotcom/trip_plan/input_form.ex:198
-#: lib/dotcom_web/components/route_symbols.ex:248
-#: lib/dotcom_web/controllers/mode/commuter.ex:13
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:29
-#: lib/dotcom_web/hooks/breadcrumbs.ex:24
-#: lib/dotcom_web/views/customer_support_view.ex:109
-#: lib/dotcom_web/views/helpers.ex:237
-#: lib/dotcom_web/views/layout_view.ex:91
-#: lib/dotcom_web/views/page_view.ex:191
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail"
 msgstr "通勤火車"
 
-#: lib/fares/format.ex:192
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail "
 msgstr "通勤火車 "
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:31
-#: lib/dotcom_web/views/layout_view.ex:139
+#: lib/dotcom_web/controllers/mode/commuter.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Fares"
 msgstr "通勤鐵路票價"
 
-#: lib/dotcom_web/views/mode_view.ex:189
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Map"
 msgstr "通勤鐵路地圖"
 
-#: lib/dotcom_web/views/fare_view.ex:84
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Monthly Pass"
 msgstr "通勤鐵路月票 通票"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:11
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail One-Way"
 msgstr "通勤鐵路單程票"
 
-#: lib/dotcom_web/views/layout_view.ex:223
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Positive Train Control"
 msgstr "通勤鐵路正線控制系統"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:38
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Status"
 msgstr "通勤鐵路狀況"
 
-#: lib/dotcom_web/views/mode_view.ex:188
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail Zones Map"
 msgstr "通勤鐵路區域地圖"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:26
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Commuter Rail seat availability is regularly updated to reflect a trip's typical ridership based on automated and conductor data from the past 14-30 days."
 msgstr "通勤鐵路座位可用性會定期更新，以反映過去 14-30 天的自動和乘務員資料所顯示的典型客流量。"
 
-#: lib/feedback/message.ex:17
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Complaint"
 msgstr "投訴"
 
-#: lib/feedback/message.ex:58
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Compliment"
 msgstr "讚揚"
 
-#: lib/dotcom_web/views/layout_view.ex:158
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "聯繫"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:4
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "聯絡我們"
 
-#: lib/dotcom_web/views/layout_view.ex:184
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
 msgstr "聯絡電話"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:500
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Contact the MBTA customer support team and view additional contact numbers for the Transit Police, lost and found, and accessibility."
 msgstr "聯絡 MBTA 客戶支援團隊，並查看交通警察、失物招領處和無障礙設施的更多聯絡電話。"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Contact the Transit Police"
 msgstr "請聯絡交通警察"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:204
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "繼續"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Cost"
 msgstr "成本"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks"
 msgstr "有頂棚的自行車架"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Covered bike racks are available"
 msgstr "有頂棚的自行車架。"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:12
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Create an Account"
 msgstr "建立一個帳戶"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:54
-#: lib/fares/retail_locations_data.ex:94
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Credit/Debit Card"
 msgstr "信用卡/金融卡"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Credit/debit cards"
 msgstr "信用卡/金融卡"
 
-#: lib/fares/format.ex:92
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Cross Harbor Ferry"
 msgstr "跨港渡輪"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:9
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
 #, elixir-autogen, elixir-format
 msgid "Crosstown"
 msgstr "克羅斯敦"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:584
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Crowded"
 msgstr "擠"
 
-#: lib/dotcom_web/views/schedule_view.ex:172
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current"
 msgstr "目前的"
 
-#: lib/dotcom_web/views/partial_view.ex:192
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Alerts"
 msgstr "目前警報"
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:75
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Current Changes"
 msgstr "目前變化"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:23
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "Current Status"
 msgstr "目前狀態"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:27
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Current seat availability thresholds are:"
 msgstr "目前座位可用閾值為："
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:107
-#: lib/dotcom_web/controllers/customer_support_controller.ex:234
-#: lib/dotcom_web/controllers/customer_support_controller.ex:247
-#: lib/dotcom_web/controllers/customer_support_controller.ex:257
-#: lib/dotcom_web/templates/customer_support/index.html.heex:3
-#: lib/dotcom_web/templates/layout/_footer.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:162
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/customer_support/index.html.heex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Customer Support"
 msgstr "客戶支援"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Daily"
 msgstr "日常的"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:129
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Daily Schedules"
 msgstr "每日表時刻"
 
-#: lib/dotcom_web/templates/event/show.html.heex:107
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "日期"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:3
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Date and Time"
 msgstr "日期和時間"
 
-#: lib/fares/format.ex:62
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Day Pass"
 msgstr "日通票"
 
-#: lib/alerts/alert.ex:231
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:130
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Delay"
 msgstr "延誤"
 
-#: lib/journey.ex:251
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "Delayed %{minutes}"
 msgstr "延遲%{minutes}"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:133
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:136
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:141
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:154
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Delays"
 msgstr "延誤"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:197
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Depart"
 msgstr "出發"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:157
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Depart at"
 msgstr "出發"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Departures"
 msgstr "出港"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:73
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is not close enough to any transit stops"
 msgstr "目的地距離任何公車站點都太遠。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:59
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Destination location is outside of our service area"
 msgstr "目的地位於我們的服務區域之外"
 
-#: lib/dotcom_web/views/layout_view.ex:115
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr "目的地"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:287
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr "細節"
 
-#: lib/alerts/alert.ex:232
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Detour"
 msgstr "繞行"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:91
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "開發者"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:72
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Digital displays and automated announcements that share key route and stop info"
 msgstr "數位顯示器和自動廣播系統會發布主要線路和站點訊息"
 
-#: lib/dotcom_web/templates/schedule/_direction_select.html.heex:19
+#: lib/dotcom_web/templates/schedule/_direction_select.html.heex
 #, elixir-autogen, elixir-format
 msgid "Direction of your trip"
 msgstr "您的旅行方向"
 
-#: lib/feedback/message.ex:46
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Disability ID Cards"
 msgstr "殘障人士身分證"
 
-#: lib/alerts/alert.ex:233
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
 msgstr "碼頭關閉"
 
-#: lib/alerts/alert.ex:234
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
 msgstr "碼頭問題"
 
-#: lib/dotcom_web/live/search_page_live.ex:87
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Documents"
 msgstr "文件"
 
-#: lib/dotcom_web/components/timetable.ex:370
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Does not stop at"
 msgstr "並未就此止步"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:127
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Due to Single Tracking"
 msgstr "由於單軌"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "EBT card"
 msgstr "EBT卡"
 
-#: lib/fares/retail_locations_data.ex:95
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ 通票"
 
-#: lib/dotcom_web/components/timetable.ex:33
-#: lib/dotcom_web/components/timetable.ex:179
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier"
 msgstr "早些時候"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:241
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Earliest Arrival"
 msgstr "最早到達"
 
-#: lib/dotcom_web/components/timetable.ex:358
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure"
 msgstr "提前出發"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:108
-#: lib/dotcom_web/views/schedule/timetable.ex:46
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Early Departure Stop"
 msgstr "提前出發停靠站"
 
-#: lib/fares/format.ex:94
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "East Boston Ferry"
 msgstr "East Boston Ferry"
 
-#: lib/routes/parser.ex:69
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
 msgstr "東行"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:52
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator"
 msgstr "電梯"
 
-#: lib/dotcom/alerts/commuter_rail.ex:16
-#: lib/dotcom/alerts/subway.ex:15
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator & Escalator"
 msgstr "電梯和電扶梯"
 
-#: lib/alerts/alert.ex:235
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
 msgstr "電梯關閉"
 
-#: lib/alerts/accessibility.ex:17
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Elevator Closures"
 msgstr "電梯關閉"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:12
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevator/Escalator Hotline"
 msgstr "電梯/電扶梯熱線"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators"
 msgstr "電梯"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Elevators at %{name}"
 msgstr "電梯位於%{name}"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "Emergency"
 msgstr "緊急情況"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:12
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:30
-#: lib/dotcom_web/views/layout_view.ex:183
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "緊急情況 聯絡方式"
 
-#: lib/feedback/message.ex:60
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee"
 msgstr "員工"
 
-#: lib/feedback/message.ex:21
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Employee Complaint"
 msgstr "員工投訴"
 
-#: lib/dotcom_web/templates/event/_add_button.html.heex:12
+#: lib/dotcom_web/templates/event/_add_button.html.heex
 #, elixir-autogen, elixir-format
 msgid "Ended"
 msgstr "結束"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:87
-#: lib/dotcom_web/views/layout_view.ex:213
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Engineering Design Standards"
 msgstr "工程設計標準"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:62
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:22
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a destination location"
 msgstr "輸入目的地"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:139
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:29
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:26
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter a location"
 msgstr "輸入位置"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:43
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:17
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter an origin location"
 msgstr "輸入起始位置"
 
-#: lib/dotcom_web/templates/project/index.html.heex:26
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter keyword(s)"
 msgstr "輸入關鍵字"
 
-#: lib/dotcom_web/templates/project/index.html.heex:27
+#: lib/dotcom_web/templates/project/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter project keywords"
 msgstr "輸入項目關鍵字"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:210
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the station"
 msgstr "進入車站"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:205
-#: lib/dotcom_web/components/trip_planner/helpers.ex:206
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Enter the traffic circle"
 msgstr "進入交通圈"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:29
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Enter your registered address"
 msgstr "請輸入您的註冊地址"
 
-#: lib/hub_stops.ex:31
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Blue and Green Lines outside Government Center"
 msgstr "Government Center外的Blue和Green線入口"
 
-#: lib/hub_stops.ex:21
-#: lib/hub_stops.ex:29
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Green and Red Lines outside Park Street"
 msgstr "Park Street外的Green和Red入口"
 
-#: lib/hub_stops.ex:23
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Orange and Red Lines outside Downtown Crossing"
 msgstr "Downtown Crossing外的Orange和Red入口"
 
-#: lib/hub_stops.ex:37
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrance to Ruggles station"
 msgstr "進入Ruggles車站"
 
-#: lib/hub_stops.ex:12
-#: lib/hub_stops.ex:19
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Entrances to Red Line and Commuter Rail outside South Station"
 msgstr "South Station外進入Red Line並通勤鐵路"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:3
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "錯誤"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:32
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator"
 msgstr "電扶梯"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (down only)"
 msgstr "扶梯（僅下）"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:44
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up and down)"
 msgstr "手扶梯（上下）"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalator (up only)"
 msgstr "扶梯（僅上排）"
 
-#: lib/alerts/alert.ex:236
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
 msgstr "電扶梯關閉"
 
-#: lib/alerts/accessibility.ex:18
+#: lib/alerts/accessibility.ex
 #, elixir-autogen, elixir-format
 msgid "Escalator Closures"
 msgstr "電扶梯關閉"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:4
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators"
 msgstr "電扶梯"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:22
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Escalators at %{name}"
 msgstr "扶梯位於%{name}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:89
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Estimated Arrival at Foxboro Station"
 msgstr "預計抵達Foxboro車站"
 
-#: lib/dotcom_web/templates/event/show.html.heex:27
-#: lib/dotcom_web/templates/event/show.html.heex:123
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event Description"
 msgstr "活動描述"
 
-#: lib/dotcom_web/templates/event/_popup.html.heex:9
+#: lib/dotcom_web/templates/event/_popup.html.heex
 #, elixir-autogen, elixir-format
 msgid "Event summary for "
 msgstr "活動摘要 "
 
-#: lib/dotcom_web/controllers/event_controller.ex:28
-#: lib/dotcom_web/controllers/event_controller.ex:94
-#: lib/dotcom_web/live/search_page_live.ex:88
-#: lib/dotcom_web/templates/event/_month.html.heex:13
-#: lib/dotcom_web/templates/event/index.html.heex:3
+#: lib/dotcom_web/controllers/event_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/event/_month.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr "活動"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:211
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Exit the station"
 msgstr "離開車站"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:153
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Expect Delays"
 msgstr "預計延誤"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:13
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Explore stations by mode"
 msgstr "按模式探索車站"
 
-#: lib/fares/format.ex:90
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus"
 msgstr "快速巴士"
 
-#: lib/dotcom_web/views/fare_view.ex:65
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Express Bus One-Way"
 msgstr "快速巴士單程票"
 
-#: lib/hub_stops.ex:42
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Exterior of Wonderland station"
 msgstr "Wonderland車站外觀"
 
-#: lib/alerts/alert.ex:237
-#: lib/dotcom/service_patterns.ex:212
+#: lib/alerts/alert.ex
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
 msgstr "額外服務"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:63
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Facility Information"
 msgstr "設施資訊"
 
-#: lib/alerts/alert.ex:238
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
 msgstr "設施問題"
 
-#: lib/fares/fare_info.ex:912
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Family 4-pack (2 adults, 2 children)"
 msgstr "家庭四人套餐（2 位成人，2 位兒童）"
 
-#: lib/feedback/message.ex:22
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Evasion"
 msgstr "逃票"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:8
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options"
 msgstr "票價選項"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Options at %{name}"
 msgstr "%{name}處的票價選項"
 
-#: lib/feedback/message.ex:34
-#: lib/feedback/message.ex:47
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Policy"
 msgstr "票價政策"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:48
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Retail Locations"
 msgstr "票價零售地點"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:106
-#: lib/dotcom_web/views/layout_view.ex:131
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fare Transformation"
 msgstr "票價轉換"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Types"
 msgstr "票價類型"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:1
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machine"
 msgstr "自動售票機"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:28
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fare Vending Machines"
 msgstr "自動售票機"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:117
-#: lib/dotcom_web/templates/mode/hub.html.heex:35
-#: lib/dotcom_web/templates/mode/index.html.heex:37
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:122
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares"
 msgstr "票價"
 
-#: lib/dotcom_web/views/layout_view.ex:126
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Info"
 msgstr "票價資訊"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:128
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares Overview"
 msgstr "票價概覽"
 
-#: lib/dotcom_web/views/layout_view.ex:135
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Fares by Mode"
 msgstr "各交通方式票價"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:15
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Fares differ between Hingham/Hull Ferries & Charlestown Ferries. Refer to the information below:"
 msgstr "Hingham / Hull渡輪和Charlestown渡輪之間的票價有所不同。 請參考以下資訊："
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:11
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "Featured MBTA Updates and Projects"
 msgstr "MBTA 最新動態和項目"
 
-#: lib/dotcom/trip_plan/input_form.ex:202
-#: lib/dotcom_web/components/route_symbols.ex:249
-#: lib/dotcom_web/controllers/mode/ferry.ex:10
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:37
-#: lib/dotcom_web/views/customer_support_view.ex:111
-#: lib/dotcom_web/views/helpers.ex:239
-#: lib/dotcom_web/views/layout_view.ex:92
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/controllers/mode/ferry.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry"
 msgstr "渡輪"
 
-#: lib/fares/format.ex:193
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry "
 msgstr "渡輪 "
 
-#: lib/dotcom_web/views/layout_view.ex:140
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Fares"
 msgstr "渡輪票價"
 
-#: lib/dotcom_web/views/mode_view.ex:192
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Map"
 msgstr "渡輪地圖"
 
-#: lib/dotcom_web/views/fare_view.ex:95
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "Ferry Monthly Pass"
 msgstr "渡輪 月票 通票"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:72
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Few Seats Available"
 msgstr "座位有限"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:28
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "File a Discrimination Complaint"
 msgstr "提交歧視投訴"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:81
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:62
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Fill out the form"
 msgstr "填寫表格"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:37
-#: lib/dotcom_web/live/search_page_live.html.heex:41
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:19
-#: lib/dotcom_web/views/partial_view.ex:154
+#: lib/dotcom_web/live/search_page_live.html.heex
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Filter by type"
 msgstr "按類型篩選"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:49
-#: lib/dotcom_web/views/layout_view.ex:197
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Financials"
 msgstr "財務"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:24
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Proposed Locations Near You"
 msgstr "尋找您附近的擬建地點"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:23
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find Your Polling Place"
 msgstr "尋找您的投票地點"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:112
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Find a Location"
 msgstr "尋找位置"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:21
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find a Store Near You"
 msgstr "尋找您附近的門市"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:70
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Find out how to get involved"
 msgstr "了解如何參與"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:544
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Finishing another trip"
 msgstr "又一次旅行結束了"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:474
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "First %{vehicle}"
 msgstr "第一%{vehicle}"
 
-#: lib/dotcom_web/components/timetable.ex:354
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:101
-#: lib/dotcom_web/views/schedule/timetable.ex:50
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Flag Stop"
 msgstr "旗停"
 
-#: lib/dotcom_web/views/schedule_view.ex:500
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Flag the bus in any safe place along the route"
 msgstr "在沿途任何安全地點攔下巴士"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA on Twitter"
 msgstr "請在 Twitter 上關注 @MBTA"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:14
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow @MBTA_CR on Twitter"
 msgstr "請在推特上關注@MBTA_CR"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:212
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Follow signs"
 msgstr "遵循指示牌"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "Follow the link below to find the number associated with the mode or route where you lost your item."
 msgstr "請點選以下連結尋找與您遺失物品的交通方式或路線相關的編號。"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:19
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "For Express Bus fares, read the complete %{link} page."
 msgstr "有關快速巴士票價，請閱讀完整的%{link}頁面。"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:18
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "For all information about World Cup train service, read our %{world_cup_link}"
 msgstr "有關世界盃列車服務的全部信息，請閱讀我們的%{world_cup_link}"
 
-#: lib/dotcom_web/components/alerts.ex:48
+#: lib/dotcom_web/components/alerts.ex
 #, elixir-autogen, elixir-format
 msgid "For more information"
 msgstr "更多資訊"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:27
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "For questions or comments about this press release, please contact"
 msgstr "如有任何關於此新聞稿的問題或意見，請與我們聯絡。"
 
-#: lib/dotcom/schedule_note.ex:109
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "For regular weekday service to Foxboro please visit: "
 msgstr "如需前往Foxboro定期工作日服務，請造訪： "
 
-#: lib/fares/format.ex:103
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Foxboro Special Event"
 msgstr "Foxboro特別活動"
 
-#: lib/dotcom/schedule_note.ex:112
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "Franklin Line"
 msgstr "Franklin線"
 
-#: lib/dotcom_web/views/schedule_view.ex:360
-#: lib/fares/format.ex:17
-#: lib/fares/format.ex:20
+#: lib/dotcom_web/views/schedule_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "免費"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Free Pedal and Park secured parking"
 msgstr "免費踏板和停車安全停車場"
 
-#: lib/dotcom_web/views/helpers.ex:251
-#: lib/fares/format.ex:105
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Free Service"
 msgstr "免費服務"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:69
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Friday"
 msgstr "星期五"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:144
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "從"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Full high level platform to provide level boarding to every car in a train set"
 msgstr "全高月臺為列車組內的每節車廂提供平整的登車通道"
 
-#: lib/fares/format.ex:97
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Georges Island"
 msgstr "Georges Island"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:40
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Directions"
 msgstr "獲取路線"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:66
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get Involved"
 msgstr "介入"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:38
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Get Service Updates"
 msgstr "取得服務更新"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:2
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get T-Alerts"
 msgstr "取得T-Alerts"
 
-#: lib/dotcom_web/views/layout_view.ex:149
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get a CharlieCard"
 msgstr "辦理一張查理卡"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:58
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get an invoice in the mail for a $1 fee"
 msgstr "您將收到一張郵寄的發票，費用為 1 美元。"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:92
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get directions to this parking facility"
 msgstr "前往此停車場的路線"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:38
-#: lib/dotcom_web/views/layout_view.ex:192
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Get to Know Us"
 msgstr "了解我們"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:26
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Get trip suggestions"
 msgstr "獲取旅行建議"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:213
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Go"
 msgstr "去"
 
-#: lib/dotcom_web/components/components.ex:372
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Going to a World Cup match at Boston Stadium?"
 msgstr "打算去Boston Stadium看世界盃比賽嗎？"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:41
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
 msgstr "Google Pay"
 
-#: lib/dotcom_web/views/helpers.ex:252
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line"
 msgstr "Green Line"
 
-#: lib/dotcom_web/components/route_symbols.ex:253
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Green Line %{branch} Branch"
 msgstr "Green Line %{branch}支線"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:82
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Group Name"
 msgstr "組名"
 
-#: lib/fares/format.ex:93
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Harbor Loop Ferry"
 msgstr "港口環線渡輪"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:200
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard left"
 msgstr "極左"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:203
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Hard right"
 msgstr "極右翼"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:856
-#: lib/dotcom_web/templates/stop/index.html.heex:75
+#: lib/dotcom_web/live/upcoming_departures_live.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "隱藏"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:193
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Hide Details"
 msgstr "隱藏詳情"
 
-#: lib/fares/format.ex:99
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull Ferry"
 msgstr "Hingham/Hull Ferry"
 
-#: lib/dotcom_web/views/schedule_view.ex:419
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Hingham/Hull ferry"
 msgstr "Hingham / Hull渡輪"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:44
-#: lib/dotcom_web/views/layout_view.ex:196
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "歷史"
 
-#: lib/dotcom/service_patterns.ex:209
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Holiday Schedules"
 msgstr "假期表時刻"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:29
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:89
-#: lib/dotcom_web/views/layout_view.ex:107
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Holidays"
 msgstr "假期"
 
-#: lib/cms/breadcrumbs.ex:19
-#: lib/util/breadcrumb_html.ex:74
-#: lib/util/breadcrumb_html.ex:113
+#: lib/cms/breadcrumbs.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "家"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:25
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "家庭住址"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:135
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Icon Key"
 msgstr "圖示圖例"
 
-#: lib/dotcom_web/views/customer_support_view.ex:61
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
 msgstr "如有需要，請務必註明事件發生的時間和日期、路線以及車輛編號。"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:15
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "If you provided your contact info, check your email for a confirmation with an incident number. If you don't receive a confirmation within 10 minutes, try submitting your feedback again or call us at"
 msgstr "如果您提供了聯絡方式，請查看您的電子郵件，您會收到一封包含事件編號的確認郵件。如果您在 10 分鐘內沒有收到確認訊息，請嘗試再次提交回饋或致電我們。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:74
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "If you'd like us to give you a call, please give us the best number where we can reach you."
 msgstr "如果您希望我們給您打電話，請提供我們能聯絡到您的最佳電話號碼。"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights."
 msgstr "如果您的公民權利受到侵犯，您可以向 MBTA 多元化和公民權利辦公室提出投訴。"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:112
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Information"
 msgstr "重要訊息"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:3
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Important Links"
 msgstr "重要連結"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:148
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Inbound Trains Cancelled"
 msgstr "進站列車取消"
 
-#: lib/holiday/repo.ex:73
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Independence Day"
 msgstr "獨立日"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:2
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Information & Support"
 msgstr "資訊與支援"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:79
-#: lib/dotcom_web/views/layout_view.ex:211
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Institutional Sales"
 msgstr "機構銷售"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:25
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Intended Audience"
 msgstr "目標受眾"
 
-#: lib/fares/format.ex:102
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Interzone %{zone}"
 msgstr "區域間%{zone}"
 
-#: lib/fares/format.ex:82
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Duration"
 msgstr "無效持續時間"
 
-#: lib/fares/format.ex:109
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Invalid Fare"
 msgstr "無效票價"
 
-#: lib/fares/retail_locations_data.ex:96
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Invoice"
 msgstr "發票"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:252
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Is this helpful? Send us feedback"
 msgstr "這樣有幫助嗎？請向我們發送反饋"
 
-#: lib/dotcom_web/templates/event/_month_select.html.heex:2
-#: lib/dotcom_web/templates/event/_year_select.html.heex:2
-#: lib/dotcom_web/templates/event/index.html.heex:32
-#: lib/dotcom_web/templates/schedule/_alerts.html.heex:6
+#: lib/dotcom_web/templates/event/_month_select.html.heex
+#: lib/dotcom_web/templates/event/_year_select.html.heex
+#: lib/dotcom_web/templates/event/index.html.heex
+#: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Jump to"
 msgstr "跳轉至"
 
-#: lib/holiday/repo.ex:72
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Juneteenth Independence Day"
 msgstr "六月節獨立日"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:125
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know Your Boarding Group"
 msgstr "了解你的登船組"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:79
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:60
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Know a local store owner who might be interested in joining our retail network? Suggest a retailer and we'll reach out to them on your behalf."
 msgstr "您認識有興趣加入我們零售網絡的本地店主嗎？請推薦一家零售商，我們將代表您與他們聯繫。"
 
-#: lib/holiday/repo.ex:74
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Labor Day"
 msgstr "勞動節"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:32
-#: lib/dotcom_web/views/layout_view.ex:171
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Language Services"
 msgstr "語言服務"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:105
-#: lib/dotcom_web/views/layout_view.ex:243
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "語言"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:382
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last"
 msgstr "最後"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:480
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Last %{vehicle}"
 msgstr "末班車%{vehicle}"
 
-#: lib/dotcom/utils/service_date_time.ex:89
-#: lib/dotcom_web/components/timetable.ex:41
-#: lib/dotcom_web/components/timetable.ex:187
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "之後"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:39
-#: lib/dotcom_web/templates/page/_important_links.html.heex:15
-#: lib/dotcom_web/views/layout_view.ex:195
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Leadership"
 msgstr "領導"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:71
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about CharlieCard"
 msgstr "了解更多關於查理卡的信息"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about MBTA fares"
 msgstr "了解更多關於MBTA票價的信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:88
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about accessibility on the T"
 msgstr "了解有關地鐵方便的更多信息"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike parking at the T"
 msgstr "了解更多關於地鐵站自行車停車的信息"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:15
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bike storage at this station."
 msgstr "了解有關該車站自行車存放處的更多資訊。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:8
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bikes on Commuter Rail"
 msgstr "了解更多關於通勤鐵路自行車的信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:93
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about bus accessibility"
 msgstr "了解有關巴士無障礙的更多信息"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:49
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fare prices, pass types, and how to pay your fare on the T."
 msgstr "了解更多關於票價、通票類型以及如何在地鐵上支付票價的資訊。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:59
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about fares"
 msgstr "了解更多票價信息"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:83
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about ferry accessibility"
 msgstr "了解更多關於渡輪無障礙設施的信息"
 
-#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about filing a complaint"
 msgstr "了解更多關於投訴流程的信息"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:96
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about parking at the T"
 msgstr "了解更多關於地鐵站停車的信息"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:62
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about reduced fares and eligibility"
 msgstr "了解有關減價票和資格的更多信息"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:84
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about seat availability trends"
 msgstr "了解更多座位供應趨勢"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about the accessibility features at this %{place}."
 msgstr "了解更多關於無障礙功能的信息，請訪問%{place} 。"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:50
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn more about this project"
 msgstr "了解更多關於此項目的信息"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:9
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "Learn what happens after you file a complaint"
 msgstr "了解提交投訴後會發生什麼。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:242
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Least Walking"
 msgstr "步行最少"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:74
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Leave at"
 msgstr "離開"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:79
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Leaving at %{time}"
 msgstr "出發時間為%{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:199
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Left"
 msgstr "左邊"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:57
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Let us know"
 msgstr "請告知我們"
 
-#: lib/dotcom_web/live/search_page_live.ex:84
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Lines and Routes"
 msgstr "線路和路線"
 
-#: lib/dotcom_web/templates/event/index.html.heex:12
+#: lib/dotcom_web/templates/event/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "List view"
 msgstr "清單視圖"
 
-#: lib/dotcom_web/controllers/alert_controller.ex:90
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:20
-#: lib/dotcom_web/live/subway_alerts_live.ex:29
+#: lib/dotcom_web/controllers/alert_controller.ex
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
 msgstr "針對所有 MBTA 交通方式的即時服務警報，包括地鐵、巴士、通勤鐵路和渡輪。 睡眠、建築施工、電梯停駛等的最新資訊。"
 
-#: lib/dotcom_web/components/search_results_live.ex:113
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "加載更多"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:543
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading arrivals..."
 msgstr "正在加載到貨資訊…"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:138
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading schedules for selected service"
 msgstr "正在載入所選服務的時刻表"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:423
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading trip details"
 msgstr "正在加載行程詳情"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:66
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Loading upcoming departures"
 msgstr "正在加載即將進行的出發航班"
 
-#: lib/hub_stops.ex:15
-#: lib/hub_stops.ex:36
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "Lobby inside Back Bay station"
 msgstr "Back Bay車站內大廳"
 
-#: lib/fares/format.ex:89
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Local Bus"
 msgstr "當地巴士"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:6
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Local Bus One-Way"
 msgstr "本地巴士單程票"
 
-#: lib/dotcom_web/templates/event/_address.html.heex:2
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:17
+#: lib/dotcom_web/templates/event/_address.html.heex
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "地點"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:76
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Location is not close enough to any transit stops"
 msgstr "位置距離任何公車站點都不夠近。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:543
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Location unavailable"
 msgstr "位置不可用"
 
-#: lib/dotcom_web/components/route_symbols.ex:250
-#: lib/dotcom_web/views/helpers.ex:242
-#: lib/fares/format.ex:111
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Logan Express"
 msgstr "洛根快線"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:47
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Long ramp"
 msgstr "長坡道"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:21
-#: lib/dotcom_web/views/layout_view.ex:170
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Lost & Found"
 msgstr "失物招領"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:33
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Lost and Found"
 msgstr "失物招領"
 
-#: lib/fares/format.ex:95
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Lynn Ferry"
 msgstr "Lynn Ferry"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:265
-#: lib/util/breadcrumb_html.ex:77
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA"
 msgstr "MBTA"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:266
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{name} %{type} stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{name} %{type}車站和時刻表，包括地圖、即時更新、停車和無障礙資訊以及轉乘。"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:45
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{route_name} %{station_name} and schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{route_name} %{station_name}和時刻，包括時間表、地圖、票價、即時更新、停車和無障礙資訊以及轉乘。"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:250
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{text} stops and schedules, including maps, parking and accessibility information, and fares."
 msgstr "MBTA %{text}站點和時刻表，包括地圖、停車和無障礙資訊以及票價。"
 
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:258
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA %{type} route %{name} stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA %{type}路線%{name}站點和時刻表，包括地圖、即時更新、停車和無障礙資訊以及轉乘。"
 
-#: lib/util/breadcrumb_html.ex:82
+#: lib/util/breadcrumb_html.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA - Massachusetts Bay Transportation Authority"
 msgstr "MBTA - 麻省灣交通管理局"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:124
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Facebook"
 msgstr "MBTA Facebook"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:47
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Fares"
 msgstr "MBTA票價"
 
-#: lib/dotcom_web/views/layout_view.ex:200
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Gift Shop"
 msgstr "MBTA禮品店"
 
-#: lib/dotcom_web/controllers/schedule/green.ex:59
+#: lib/dotcom_web/controllers/schedule/green.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Green Line trolley stations and schedules, including maps, real-time updates, parking and accessibility information, and connections."
 msgstr "MBTA Green Line電車車站和時刻表，包括地圖、即時更新、停車和無障礙資訊以及轉乘。"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:22
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Home Page"
 msgstr "MBTA首頁"
 
-#: lib/dotcom_web/templates/page/index.html.heex:2
+#: lib/dotcom_web/templates/page/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Homepage"
 msgstr "MBTA首頁"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:131
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Instagram"
 msgstr "MBTA Instagram"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:145
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA LinkedIn"
 msgstr "MBTA LinkedIn"
 
-#: lib/dotcom_web/views/mode_view.ex:22
-#: lib/dotcom_web/views/mode_view.ex:132
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Paratransit Program"
 msgstr "MBTA 輔助客運系統計劃"
 
-#: lib/feedback/message.ex:36
-#: lib/feedback/message.ex:62
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Projects/Programs"
 msgstr "MBTA項目/計劃"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:5
-#: lib/dotcom_web/views/layout_view.ex:114
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Stations"
 msgstr "MBTA車站"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:138
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Threads"
 msgstr "MBTA線程"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:162
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA TikTok"
 msgstr "MBTA TikTok"
 
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:177
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "MBTA Transit Police"
 msgstr "MBTA交通警察"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:60
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Trip Planner"
 msgstr "MBTA行程規劃器"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:156
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA Twitter"
 msgstr "MBTA 推特"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:4
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA User Guides"
 msgstr "MBTA 使用者指南"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:152
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA YouTube"
 msgstr "MBTA YouTube"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:31
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA fare vending machines"
 msgstr "MBTA自動售票機"
 
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:6
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase %{charlie_card} for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
 msgstr "MBTA 乘客可以在大波士頓和Providence地區的零售商處購買 CharlieTickets 並充值併購買巴士、地鐵、通火車站和渡輪的%{charlie_card} 。"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:57
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Latest News"
 msgstr "MBTA.com 最新消息"
 
-#: lib/dotcom_web/templates/page/menu.html.heex:2
+#: lib/dotcom_web/templates/page/menu.html.heex
 #, elixir-autogen, elixir-format
 msgid "MBTA.com Menu"
 msgstr "MBTA.com 選單"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:5
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "主要的"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Hotline"
 msgstr "總熱線"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Main Menu"
 msgstr "主選單"
 
-#: lib/feedback/message.ex:35
-#: lib/feedback/message.ex:48
-#: lib/feedback/message.ex:61
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
 msgstr "維護"
 
-#: lib/feedback/message.ex:23
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Maintenance Complaint"
 msgstr "維護投訴"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:208
-#: lib/dotcom_web/components/trip_planner/helpers.ex:209
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Make a U-turn"
 msgstr "掉頭"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:73
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Managed by"
 msgstr "由…管理"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:36
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Many Seats Available"
 msgstr "座位充足"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:29
-#: lib/dotcom_web/templates/mode/index.html.heex:34
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:116
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "地圖"
 
-#: lib/holiday/repo.ex:68
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Martin Luther King, Jr. Day"
 msgstr "馬丁路德金恩紀念日"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:20
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority"
 msgstr "馬薩諸塞灣交通管理局"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:169
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Massachusetts Bay Transportation Authority, all rights reserved."
 msgstr "麻省海灣交通管理局，版權所有。"
 
-#: lib/dotcom_web/views/helpers.ex:245
-#: lib/dotcom_web/views/helpers.ex:247
-#: lib/fares/format.ex:110
-#: lib/fares/format.ex:112
+#: lib/dotcom_web/views/helpers.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle"
 msgstr "Massport 擺渡巴士"
 
-#: lib/dotcom_web/components/route_symbols.ex:261
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Massport Shuttle %{route_number}"
 msgstr "Massport 擺渡巴士%{route_number}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:36
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 18"
 msgstr "第18場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:50
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 30"
 msgstr "第30場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:64
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 45"
 msgstr "第45場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:22
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 5"
 msgstr "第五場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:78
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 61"
 msgstr "第61場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:92
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 74"
 msgstr "第74場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:106
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Match 97"
 msgstr "第97場比賽"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:121
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Match Ticket Required "
 msgstr "需要匹配車票 "
 
-#: lib/dotcom_web/components/route_symbols.ex:255
-#: lib/dotcom_web/views/helpers.ex:253
-#: lib/dotcom_web/views/helpers.ex:254
+#: lib/dotcom_web/components/route_symbols.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/timetable.ex:293
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "可能不太方便"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:26
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Media Contact Information"
 msgstr "媒體聯絡訊息"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:59
-#: lib/dotcom_web/views/layout_view.ex:199
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Media Relations"
 msgstr "媒體關係"
 
-#: lib/dotcom_web/templates/event/_meeting_info.html.heex:2
-#: lib/dotcom_web/templates/event/show.html.heex:105
+#: lib/dotcom_web/templates/event/_meeting_info.html.heex
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Meeting Info"
 msgstr "會議資訊"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the press can request to join our media list by emailing "
 msgstr "媒體成員可以透過發送電子郵件申請加入我們的媒體名單。 "
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request."
 msgstr "除某些例外情況外，公眾有權索取 MBTA 文件的副本。需支付費用，費用可能因具體申請而異。"
 
-#: lib/holiday/repo.ex:71
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Memorial Day"
 msgstr "紀念日"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:10
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:19
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Menu"
 msgstr "功能表"
 
-#: lib/fares/fare_info.ex:930
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Military"
 msgstr "軍隊"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Mini high level platform to provide level boarding to certain cars in a train set"
 msgstr "迷你高月臺為列車組內的某些車廂提供平整的登車通道"
 
-#: lib/dotcom_web/templates/event/show.html.heex:165
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Minutes"
 msgstr "分分鐘"
 
-#: lib/fares/retail_locations_data.ex:97
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile App"
 msgstr "行動應用"
 
-#: lib/feedback/message.ex:24
-#: lib/feedback/message.ex:49
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Mobile Ticketing"
 msgstr "手機車票"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:96
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Modes"
 msgstr "模式"
 
-#: lib/dotcom_web/views/layout_view.ex:87
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Modes of Transit"
 msgstr "交通方式"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:65
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday"
 msgstr "星期一"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday - Friday"
 msgstr "週一至週五"
 
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:3
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monday thru Friday"
 msgstr "週一至週五"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:34
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "Monday to Friday"
 msgstr "週一至週五"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:39
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr "月票"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:8
-#: lib/dotcom_web/views/fare_view.ex:54
-#: lib/fares/format.ex:116
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly LinkPass"
 msgstr "月票LinkPass"
 
-#: lib/dotcom_web/views/fare_view.ex:69
-#: lib/fares/format.ex:117
+#: lib/dotcom_web/views/fare_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Local Bus Pass"
 msgstr "月票 本地巴士 通票"
 
-#: lib/fares/format.ex:77
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass"
 msgstr "月票 通票"
 
-#: lib/fares/format.ex:75
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Monthly Pass on mTicket App"
 msgstr "mTicket App 上的月票 通票"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:69
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Guides"
 msgstr "更多指南"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:18
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "More Information"
 msgstr "更多資訊"
 
-#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex:3
+#: lib/dotcom_web/templates/cms/_sidebar_left.html.heex
 #, elixir-autogen, elixir-format
 msgid "More from "
 msgstr "更多內容 "
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:243
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Most Direct"
 msgstr "最直接"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:3
-#: lib/dotcom_web/views/layout_view.ex:154
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Most popular fares"
 msgstr "最受歡迎的票價"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "大多數（但不是全部）MBTA 碼頭都易於透過殘障進行上升。 根據潮汐水位和航行所用船隻的類型，即使在無障礙碼頭，您也可能會遇到較大的坡度和狹窄的通道。在所有碼頭，請等待船員告知您可以安全通行後再繼續前進。"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex:1
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "導航選單"
 
-#: lib/alerts/alert.ex:265
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "新"
 
-#: lib/holiday/repo.ex:67
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "New Year’s Day"
 msgstr "元旦"
 
-#: lib/dotcom_web/controllers/news_entry_controller.ex:92
-#: lib/dotcom_web/controllers/news_entry_controller.ex:97
-#: lib/dotcom_web/live/search_page_live.ex:89
-#: lib/dotcom_web/templates/mode/hub.html.heex:60
-#: lib/dotcom_web/templates/news_entry/index.html.heex:5
-#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex:4
+#: lib/dotcom_web/controllers/news_entry_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/dotcom_web/templates/news_entry/index.html.heex
+#: lib/dotcom_web/templates/schedule/_cms_teasers.html.heex
 #, elixir-autogen, elixir-format
 msgid "News"
 msgstr "訊息"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:26
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "下一步"
 
-#: lib/dotcom/utils/service_date_time.ex:88
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "Next Week"
 msgstr "下週"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:540
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Next stop"
 msgstr "下一站"
 
-#: lib/dotcom_web/components/alerts/grouped.ex:40
+#: lib/dotcom_web/components/alerts/grouped.ex
 #, elixir-autogen, elixir-format
 msgid "No %{group} alerts"
 msgstr "沒有%{group}警報"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:40
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:52
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:239
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "No Scheduled Service"
 msgstr "無計劃服務"
 
-#: lib/dotcom_web/views/schedule/stop_list.ex:15
-#: lib/dotcom_web/views/schedule/stop_list.ex:19
+#: lib/dotcom_web/views/schedule/stop_list.ex
 #, elixir-autogen, elixir-format
 msgid "No Service"
 msgstr "無服務"
 
-#: lib/dotcom_web/templates/bus_stop_change/index.html.heex:24
+#: lib/dotcom_web/templates/bus_stop_change/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "No alerts here."
 msgstr "這裡沒有警報。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:71
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
 #, elixir-autogen, elixir-format
 msgid "No changes posted for the next 7 days"
 msgstr "未來7天內無任何變更發布"
 
-#: lib/dotcom_web/templates/event/_event_list.html.heex:35
+#: lib/dotcom_web/templates/event/_event_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "No events"
 msgstr "無事件"
 
-#: lib/dotcom_web/components/timetable.ex:277
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "禁止停車"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:125
-#: lib/dotcom_web/live/upcoming_departures_live.ex:286
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "No service today"
 msgstr "今天暫停服務"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:34
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit connection was found between the origin and destination on this date and time"
 msgstr "在此日期和時間，起點和終點之間未找到任何轉機行程。"
 
-#: lib/dotcom/trip_plan/input_form.ex:246
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "No transit modes selected"
 msgstr "未選擇任何交通方式"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:44
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "No transit routes found within 2 hours of %{time_on_date}. Routes may be available at other times."
 msgstr "在%{time_on_date}周圍 2 小時內未找到任何交通路線。其他時間可能也有路線可供選擇。"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:57
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "No trips found"
 msgstr "未找到行程"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:5
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "No upcoming holidays"
 msgstr "沒有即將進行的假期"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:32
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:48
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:236
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:146
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Normal Service"
 msgstr "正常服務"
 
-#: lib/routes/parser.ex:67
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Northbound"
 msgstr "北行"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:10
-#: lib/dotcom_web/components/timetable.ex:291
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:81
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
 msgstr "不方便"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:6
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:7
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr "無法使用"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:582
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Not crowded"
 msgstr "不擁擠。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "備註"
 
-#: lib/dotcom_web/views/schedule_view.ex:403
-#: lib/dotcom_web/views/schedule_view.ex:414
-#: lib/dotcom_web/views/schedule_view.ex:437
-#: lib/dotcom_web/views/schedule_view.ex:459
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "注意："
 
-#: lib/dotcom_web/templates/event/show.html.heex:81
-#: lib/dotcom_web/templates/event/show.html.heex:140
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "筆記"
 
-#: lib/alerts/alert.ex:239
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Notice"
 msgstr "注意"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:324
-#: lib/dotcom_web/components/trip_planner/input_form.ex:73
-#: lib/dotcom_web/live/schedule_finder_live.ex:418
-#: lib/dotcom_web/live/upcoming_departures_live.ex:720
+#: lib/dotcom_web/components/system_status/subway_status.ex
+#: lib/dotcom_web/components/trip_planner/input_form.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "現在"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:542
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Now at"
 msgstr "現在在"
 
-#: lib/holiday/repo.ex:42
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Observed"
 msgstr "觀察到"
 
-#: lib/dotcom_web/views/layout_view.ex:316
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines."
 msgstr "MBTA 官方網站 -- 大波士頓公共交通系統的時間表、地圖和票價信息，包括地鐵、通勤鐵路、巴士路線和船線。"
 
-#: lib/dotcom_web/live/trip_planner_live.ex:21
+#: lib/dotcom_web/live/trip_planner_live.ex
 #, elixir-autogen, elixir-format
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
 msgstr "MBTA官方網站－規劃您在大波士頓地區的大眾運輸工具出發"
 
-#: lib/dotcom_web/views/error_view.ex:25
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Oh no! We're experiencing delays."
 msgstr "糟糕！我們這邊出現延誤了。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:773
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "On Time"
 msgstr "準時"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Onboard ramps at the front door of each bus"
 msgstr "每輛巴士前門都設有登車坡道。"
 
-#: lib/fares/format.ex:58
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Day Pass"
 msgstr "一日通票"
 
-#: lib/fares/format.ex:50
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "One-Way"
 msgstr "單程票"
 
-#: lib/alerts/alert.ex:268
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Ongoing"
 msgstr "正在進行"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:135
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Only wallets or small clear bags are permitted. Prohibited items must be discarded before boarding."
 msgstr "只允許攜帶錢包或小型透明袋。登機前必須丟棄違禁物品。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or,"
 msgstr "或者，"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Or, go to "
 msgstr "或者，前往 "
 
-#: lib/dotcom_web/views/helpers.ex:255
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Orange Line"
 msgstr "Orange Line"
 
-#: lib/dotcom_web/views/layout_view.ex:148
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Order Monthly Passes"
 msgstr "訂購月票 通票"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:70
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is not close enough to any transit stops"
 msgstr "出發地距離任何公車站點都太遠。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:56
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin location is outside of our service area"
 msgstr "始發地位於我們的服務區域之外"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:62
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Origin or destination location is outside of our service area"
 msgstr "出發地或目的地超出我們的服務區域。"
 
-#: lib/alerts/alert.ex:215
-#: lib/dotcom/alerts/commuter_rail.ex:19
-#: lib/dotcom/alerts/subway.ex:18
-#: lib/feedback/message.ex:28
-#: lib/feedback/message.ex:41
-#: lib/feedback/message.ex:56
-#: lib/feedback/message.ex:64
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "其他"
 
-#: lib/dotcom/service_patterns.ex:256
+#: lib/dotcom/service_patterns.ex
 #, elixir-autogen, elixir-format
 msgid "Other Schedules"
 msgstr "其他時刻"
 
-#: lib/dotcom_web/views/layout_view.ex:218
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Our Work"
 msgstr "我們的工作"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:83
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Our user guides can help you learn how to navigate the system, get to local events, use accessibility features, and more."
 msgstr "我們的使用者指南可以幫助您學習如何導航系統、參加本地活動、使用無障礙功能等等。"
 
-#: lib/dotcom_web/components/stops.ex:78
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Out of Order"
 msgstr "故障"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:145
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
 #, elixir-autogen, elixir-format
 msgid "Outbound Trains Cancelled"
 msgstr "出站列車取消"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:45
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks"
 msgstr "戶外自行車架"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Outdoor bike racks are available"
 msgstr "戶外自行車架可用"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Overnight"
 msgstr "過夜"
 
-#: lib/dotcom_web/views/layout_view.ex:194
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "概述"
 
-#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex:8
+#: lib/dotcom_web/templates/schedule/_pdf_schedules.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Schedules"
 msgstr "PDF表時刻"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:7
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "PDF Upcoming"
 msgstr "PDF即將進行"
 
-#: lib/dotcom_web/views/layout_view.ex:333
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "頁面找不到 | MBTA - 麻省灣交通管理局"
 
-#: lib/dotcom_web/views/error_view.ex:10
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr "找不到網頁"
 
-#: lib/dotcom_web/live/search_page_live.ex:85
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "頁"
 
-#: lib/dotcom_web/views/layout_view.ex:93
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Paratransit (The RIDE)"
 msgstr "輔助客運系統 ( The RIDE )"
 
-#: lib/dotcom/alerts/commuter_rail.ex:18
-#: lib/dotcom/alerts/subway.ex:17
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:4
-#: lib/dotcom_web/components/transit_icons.ex:25
-#: lib/dotcom_web/templates/page/_important_links.html.heex:63
-#: lib/dotcom_web/views/layout_view.ex:104
-#: lib/feedback/message.ex:25
-#: lib/feedback/message.ex:37
-#: lib/feedback/message.ex:50
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Parking"
 msgstr "停車處"
 
-#: lib/alerts/alert.ex:240
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
 msgstr "停車場關閉"
 
-#: lib/alerts/alert.ex:241
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
 msgstr "停車問題"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:33
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking Rates"
 msgstr "停車收費標準"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:24
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Parking at %{name}"
 msgstr "停車場位於%{name}"
 
-#: lib/dotcom_web/components/timetable.ex:269
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "提供停車位"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:20
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Passengers must tell "
 msgstr "乘客必須告知 "
 
-#: lib/dotcom_web/views/bus_stop_change_view.ex:74
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Past Changes"
 msgstr "過去的變化"
 
-#: lib/holiday/repo.ex:70
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Patriots’ Day"
 msgstr "愛國者日"
 
-#: lib/dotcom_web/views/layout_view.ex:144
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Pay Your Fare"
 msgstr "支付車費"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:46
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "支付方式"
 
-#: lib/dotcom_web/controllers/cms_controller.ex:169
+#: lib/dotcom_web/controllers/cms_controller.ex
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "人們"
 
-#: lib/hub_stops.ex:35
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People waiting as orange line train arrives inside North Station"
 msgstr "人們在North Station內等候橘線列車進站。"
 
-#: lib/hub_stops.ex:14
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking by train departure board inside North Station"
 msgstr "人們正從North Station內的上車候車點走過。"
 
-#: lib/hub_stops.ex:27
+#: lib/hub_stops.ex
 #, elixir-autogen, elixir-format
 msgid "People walking towards Green Line train inside North Station"
 msgstr "在North Station內，人們正走向Green Line列車。"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:70
-#: lib/dotcom_web/templates/page/_important_links.html.heex:23
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_important_links.html.heex
 #, elixir-autogen, elixir-format
 msgid "Performance"
 msgstr "表現"
 
-#: lib/dotcom_web/views/layout_view.ex:98
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Plan Your Journey"
 msgstr "規劃您的旅程"
 
-#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex:4
+#: lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan a trip"
 msgstr "計劃一次旅行"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:99
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:37
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:37
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan an accessible trip"
 msgstr "計劃一次無障礙旅行"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:47
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Plan your trip"
 msgstr "規劃您的行程"
 
-#: lib/dotcom_web/views/partial_view.ex:193
+#: lib/dotcom_web/views/partial_view.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Service Alerts"
 msgstr "計劃服務警報"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:39
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Planned Work"
 msgstr "計劃工作"
 
-#: lib/dotcom_web/views/customer_support_view.ex:127
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a comment to continue."
 msgstr "請輸入評論以繼續。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:133
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email."
 msgstr "請輸入有效的電子郵件地址。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:131
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid vehicle number with numeric characters only."
 msgstr "請輸入有效的車輛號碼，僅限數字。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:36
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:33
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Please enter an address that is within 100 miles of an MBTA service area."
 msgstr "請輸入距離 MBTA 服務區域 100 英里以內的地址。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:134
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your first name to continue."
 msgstr "請輸入您的名字以繼續。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:135
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please enter your last name to continue."
 msgstr "請輸入您的姓名以繼續。"
 
-#: lib/dotcom/trip_plan/input_form.ex:103
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination at a different location from the origin."
 msgstr "請選擇與出發地不同的目的地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:110
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select a destination location."
 msgstr "請選擇目的地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:100
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select an origin location."
 msgstr "請選擇出發地。"
 
-#: lib/dotcom/trip_plan/input_form.ex:105
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please select at least one mode of transit."
 msgstr "請至少選擇一種出行方式。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:126
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Please select the type of concern."
 msgstr "請選擇問題類型。"
 
-#: lib/dotcom/trip_plan/input_form.ex:108
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Please specify a date and time in the future or select 'Now'."
 msgstr "請指定未來的日期和時間，或選擇「立即」。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:85
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Please try again or send us feedback at mbta.com/customer-support"
 msgstr "請重試或透過 mbta.com/customer-support 向我們發送回饋。"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:64
-#: lib/dotcom_web/views/layout_view.ex:201
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Policies & Civil Rights"
 msgstr "政策與公民權利"
 
-#: lib/alerts/alert.ex:242
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
 msgstr "政策變更"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:53
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Portable boarding lift"
 msgstr "手提式登機升降機"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:6
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Posted on"
 msgstr "發佈於"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:273
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Predicted departure times aren’t available yet, but they’ll appear here before the scheduled first trip."
 msgstr "預計出發時間尚未公佈，但會在首班航班出發前在此顯示。"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:121
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Prefer accessible routes"
 msgstr "優先選擇方便路線"
 
-#: lib/fares/format.ex:108
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride"
 msgstr "高級乘車"
 
-#: lib/fares/format.ex:122
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Premium Ride Fare"
 msgstr "高級乘車費用"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:5
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
 msgstr "新聞稿"
 
-#: lib/dotcom_web/templates/layout/preview.html.heex:2
-#: lib/dotcom_web/templates/layout/preview.html.heex:6
+#: lib/dotcom_web/templates/layout/preview.html.heex
 #, elixir-autogen, elixir-format
 msgid "Preview Version"
 msgstr "預覽版"
 
-#: lib/dotcom_web/templates/news_entry/index.html.heex:20
+#: lib/dotcom_web/templates/news_entry/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "以前的"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:172
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "隱私權政策"
 
-#: lib/dotcom_web/controllers/project_controller.ex:13
-#: lib/dotcom_web/live/search_page_live.ex:86
+#: lib/dotcom_web/controllers/project_controller.ex
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr "專案"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:109
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:6
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Proposed Sales Locations"
 msgstr "擬定銷售地點"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:54
-#: lib/dotcom_web/views/layout_view.ex:198
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Public Meetings"
 msgstr "公眾會議"
 
-#: lib/dotcom_web/controllers/page_controller.ex:35
+#: lib/dotcom_web/controllers/page_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
 msgstr "大波士頓地區的公共交通。路線、時刻表、旅行計劃、票價、服務警報、即時更新和一般資訊。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase CharlieTickets"
 msgstr "購買查理票"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:35
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase a CharlieCard or reload an existing one"
 msgstr "購買查理卡或為現有查理卡儲值"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at fare vending machines."
 msgstr "在自動售票機購買車票。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:13
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Purchase fares at nearby retail sales locations."
 msgstr "在附近的零售售票點購買車票。"
 
-#: lib/dotcom_web/views/layout_view.ex:203
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Quality, Compliance & Oversight"
 msgstr "品質、合規與監管"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:108
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Quarter Finals"
 msgstr "四分之一決賽"
 
-#: lib/feedback/message.ex:43
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Question"
 msgstr "問題"
 
-#: lib/dotcom_web/views/alert_view.ex:247
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "鐵路"
 
-#: lib/dotcom_web/components/components.ex:375
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Read our %{world_cup_link}"
 msgstr "閱讀我們的%{world_cup_link}"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:1
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Receive notifications of MBTA service alerts by email or text."
 msgstr "透過電子郵件或簡訊接收 MBTA 服務警報通知。"
 
-#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex:2
+#: lib/dotcom_web/templates/news_entry/_recent_news.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recent News on the T"
 msgstr "捷運最新消息"
 
-#: lib/dotcom_web/templates/partial/_recently_visited.html.heex:3
+#: lib/dotcom_web/templates/partial/_recently_visited.html.heex
 #, elixir-autogen, elixir-format
 msgid "Recently Visited Schedules"
 msgstr "最近造訪時刻表"
 
-#: lib/dotcom_web/views/helpers.ex:256
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Red Line"
 msgstr "Red Line"
 
-#: lib/dotcom_web/templates/page/_fares_passes.html.heex:24
-#: lib/dotcom_web/views/layout_view.ex:129
+#: lib/dotcom_web/templates/page/_fares_passes.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Reduced Fares"
 msgstr "優惠票價"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Register your CharlieCard for bike parking"
 msgstr "註冊您的查理卡（CharlieCard）即可享受自行車停車服務"
 
-#: lib/dotcom_web/templates/event/show.html.heex:33
-#: lib/dotcom_web/templates/event/show.html.heex:179
+#: lib/dotcom_web/templates/event/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Files"
 msgstr "相關文件"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Related Service Alerts"
 msgstr "相關服務警報"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:58
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Report Fraud, Waste, or Abuse"
 msgstr "舉報詐欺、浪費或濫用行為"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:63
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:22
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "報告鐵路道口閘門問題"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an accessibility issue"
 msgstr "報告無障礙問題"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an elevator issue"
 msgstr "報告電梯故障"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report an escalator issue"
 msgstr "報告自動扶梯故障"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "Report suspected fraud, waste, or abuse"
 msgstr "舉報任何涉嫌詐欺、浪費或濫用行為"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:48
-#: lib/dotcom_web/templates/layout/_footer.html.heex:26
-#: lib/dotcom_web/views/layout_view.ex:167
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Request Public Records"
 msgstr "申請公開記錄"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:118
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:4
-#: lib/dotcom_web/views/layout_view.ex:150
+#: lib/dotcom_web/controllers/fare_controller.ex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Retail Sales Locations"
 msgstr "零售銷售地點"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:129
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Return Trip Included"
 msgstr "包含來回機票"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:258
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} %{vehicle}"
 msgstr "乘坐%{route} %{vehicle}"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:256
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Ride the %{route} Train %{train}"
 msgstr "搭乘%{route}列車%{train}"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:123
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Riders without match tickets will not be permitted to board Boston Stadium Trains."
 msgstr "沒有配對車票的乘客將不被允許上車Boston Stadium Trains。"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:202
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Right"
 msgstr "正確的"
 
-#: lib/fares/format.ex:54
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Round Trip"
 msgstr "往返"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.ex:94
+#: lib/dotcom_web/live/world_cup_timetable_live.ex
 #, elixir-autogen, elixir-format
 msgid "Round of 32"
 msgstr "32強"
 
-#: lib/dotcom_web/components/route_symbols.ex:270
+#: lib/dotcom_web/components/route_symbols.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{name}"
 msgstr "路線%{name}"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:587
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Route %{route}"
 msgstr "路線%{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:17
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "路線"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:4
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes With High Priority Alerts"
 msgstr "高優先警報路線"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:69
-#: lib/dotcom_web/views/layout_view.ex:202
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "安全"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Samsung Pay"
 msgstr "Samsung Pay"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:70
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Saturday"
 msgstr "週六"
 
-#: lib/dotcom_web/views/schedule_view.ex:311
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
 msgstr "時刻表和地圖"
 
-#: lib/alerts/alert.ex:243
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
 msgstr "時刻表變更"
 
-#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex:9
+#: lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedule for"
 msgstr "時刻表"
 
-#: lib/dotcom_web/controllers/mode/commuter.ex:9
+#: lib/dotcom_web/controllers/mode/commuter.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA Commuter Rail lines in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "大波士頓地區 MBTA 通勤鐵路線的時刻表信息，包括即時更新和到站預測。"
 
-#: lib/dotcom_web/controllers/mode/bus.ex:10
+#: lib/dotcom_web/controllers/mode/bus.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA bus routes in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "提供大波士頓地區 MBTA 公車線路的即時訊息，包括即時更新和到站預測。"
 
-#: lib/dotcom_web/controllers/mode/ferry.ex:6
+#: lib/dotcom_web/controllers/mode/ferry.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA ferry routes operating in Massachusetts Bay, including downloadable PDFs."
 msgstr "提供馬薩諸塞灣地區 MBTA 渡輪航線的時刻表信息，包括可下載的 PDF 文件。"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:8
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway lines in Greater Boston, including real-time updates and arrival predictions."
 msgstr "大波士頓地區 MBTA 地鐵線路時刻表信息，包括即時更新和到站預測。"
 
-#: lib/dotcom_web/controllers/mode_controller.ex:34
+#: lib/dotcom_web/controllers/mode_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule information for MBTA subway, bus, Commuter Rail, and ferry in the Greater Boston region, including real-time updates and arrival predictions."
 msgstr "大波士頓地區 MBTA 地鐵、巴士、通勤鐵路 和 渡輪 的時刻表信息，包括即時更新和抵達預測。"
 
-#: lib/dotcom/timetable_blocking.ex:12
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule will be available soon on the MBTA website."
 msgstr "時刻表將很快在MBTA網站上公佈。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:760
-#: lib/dotcom_web/live/upcoming_departures_live.ex:774
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "已安排"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:823
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled service continues until %{end_of_service}"
 msgstr "計劃服務持續至%{end_of_service}"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:538
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Scheduled to depart"
 msgstr "計劃出發"
 
-#: lib/dotcom_web/templates/mode/hub.html.heex:21
-#: lib/feedback/message.ex:38
-#: lib/feedback/message.ex:51
+#: lib/dotcom_web/templates/mode/hub.html.heex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules"
 msgstr "時刻表"
 
-#: lib/dotcom_web/controllers/mode/hub.ex:51
-#: lib/dotcom_web/controllers/mode_controller.ex:29
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:18
-#: lib/dotcom_web/hooks/breadcrumbs.ex:23
-#: lib/dotcom_web/views/schedule_view.ex:316
+#: lib/dotcom_web/controllers/mode/hub.ex
+#: lib/dotcom_web/controllers/mode_controller.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
 msgstr "時刻表和地圖"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:9
+#: lib/dotcom_web/templates/mode/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Schedules and Maps"
 msgstr "時刻表和地圖"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:525
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "School days only"
 msgstr "僅上學日營運"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:13
-#: lib/dotcom_web/live/search_page_live.html.heex:3
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "搜索"
 
-#: lib/dotcom_web/templates/layout/_new_header.html.heex:42
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search MBTA.com"
 msgstr "搜尋 MBTA.com"
 
-#: lib/dotcom_web/templates/stop/_search_bar.html.heex:5
+#: lib/dotcom_web/templates/stop/_search_bar.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for a stop or station"
 msgstr "尋找站點或車站"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:19
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search for routes, places, information, and more"
 msgstr "搜尋路線、地點、資訊等"
 
-#: lib/dotcom_web/components/search_results_live.ex:86
+#: lib/dotcom_web/components/search_results_live.ex
 #, elixir-autogen, elixir-format
 msgid "Search results for"
 msgstr "搜尋結果"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:23
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Search the MBTA"
 msgstr "搜尋 MBTA"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:18
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seasonal"
 msgstr "季節性"
 
-#: lib/dotcom_web/views/schedule_view.ex:514
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Seasonal Service"
 msgstr "季節性服務"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:116
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Seat Availability"
 msgstr "座位供應情況"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:56
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secretary of State's official site"
 msgstr "State官方網站"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:19
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Secured parking is available but requires Charlie Card registration in advance."
 msgstr "提供安全停車位，但需提前註冊查理卡。"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:154
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:147
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "See Alerts"
 msgstr "查看警報"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:12
-#: lib/dotcom_web/views/layout_view.ex:178
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "See Something, Say Something"
 msgstr "發現異常，立即報告"
 
-#: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
+#: lib/dotcom_web/templates/page/_news_and_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all press releases"
 msgstr "看所有新聞稿"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:10
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all public meetings and events"
 msgstr "查看所有公開會議和活動"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:68
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all service alerts"
 msgstr "查看所有服務警報"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:5
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "See all user guides"
 msgstr "查看所有使用者指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:136
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "See what you can bring on Boston Stadium Trains"
 msgstr "看看你可以攜帶哪些物品來搭乘Boston Stadium列車。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:114
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "選擇"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:16
-#: lib/dotcom_web/templates/page/_contact_us.html.heex:14
-#: lib/dotcom_web/views/layout_view.ex:164
+#: lib/dotcom_web/templates/layout/_footer.html.heex
+#: lib/dotcom_web/templates/page/_contact_us.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Send Us Feedback"
 msgstr "請向我們發送反饋"
 
-#: lib/fares/format.ex:43
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Senior CharlieCard or TAP ID"
 msgstr "老年人查理卡或TAP ID"
 
-#: lib/feedback/message.ex:52
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Senior ID Cards"
 msgstr "老年人身分證"
 
-#: lib/fares/fare_info.ex:924
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Seniors"
 msgstr "老年人"
 
-#: lib/dotcom_web/views/error_view.ex:24
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Server issue"
 msgstr "伺服器問題"
 
-#: lib/dotcom/alerts/commuter_rail.ex:14
-#: lib/dotcom/alerts/subway.ex:14
-#: lib/feedback/message.ex:63
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom/alerts/subway.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service"
 msgstr "服務"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:175
-#: lib/dotcom_web/views/layout_view.ex:102
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service Alerts"
 msgstr "服務警報"
 
-#: lib/alerts/alert.ex:244
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Service Change"
 msgstr "服務變更"
 
-#: lib/feedback/message.ex:26
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Complaint"
 msgstr "服務投訴"
 
-#: lib/feedback/message.ex:39
-#: lib/feedback/message.ex:53
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Service Inquiry"
 msgstr "服務查詢"
 
-#: lib/dotcom_web/components/timetable.ex:299
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Service alert or delay"
 msgstr "服務警報或間歇"
 
-#: lib/dotcom_web/components/components.ex:427
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
 msgstr "服務變更於 6 月 6 日至 7 月 12 日生效。檢查您線路的每一天的%{timetable_link}以獲取最新的時間表。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:280
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
 msgstr "服務已結束"
 
-#: lib/dotcom_web/views/alert_view.ex:62
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Service is running as expected"
 msgstr "服務運作正常"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:12
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Service to the World Cup"
 msgstr "為世界盃服務"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:244
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Shortest Trip"
 msgstr "最短行程"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:853
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "展示"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:190
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Show Details"
 msgstr "顯示詳情"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:484
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show fewer stops"
 msgstr "減少停靠次數"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:469
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Show more stops"
 msgstr "顯示更多站點"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing all"
 msgstr "顯示全部"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:64
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Showing major stops."
 msgstr "顯示主要站點。"
 
-#: lib/alerts/alert.ex:245
-#: lib/fares/format.ex:106
-#: lib/fares/format.ex:115
+#: lib/alerts/alert.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
 msgstr "擺渡巴士"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:155
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Shuttles"
 msgstr "擺渡巴士"
 
-#: lib/dotcom_web/views/layout_view.ex:103
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign Up for Service Alerts"
 msgstr "註冊服務"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:18
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign in"
 msgstr "登入"
 
-#: lib/dotcom_web/views/layout_view.ex:147
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sign up for Auto-pay"
 msgstr "註冊自動付款"
 
-#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for T-Alerts"
 msgstr "註冊接收 T-Alerts"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:65
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sign up for alert notifications"
 msgstr "訂閱警報通知"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex:2
-#: lib/dotcom_web/views/helpers.ex:257
+#: lib/dotcom_web/templates/mode/_grid_buttons_bus.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Silver Line"
 msgstr "Silver Line"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:113
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip arrives at %{time}"
 msgstr "類似行程到達%{time}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:110
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trip departs at %{time}"
 msgstr "類似行程於%{time}出發"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:119
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips arrive at %{times}"
 msgstr "類似行程到達%{times}"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:116
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Similar trips depart at %{times}"
 msgstr "類似行程於%{times}出發"
 
-#: lib/alerts/alert.ex:246
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
 msgstr "單軌"
 
-#: lib/dotcom_web/templates/layout/root.html.heex:118
+#: lib/dotcom_web/templates/layout/root.html.heex
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr "轉向主要內容"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:203
-#: lib/dotcom_web/live/upcoming_departures_live.ex:620
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr "繞行"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:198
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly left"
 msgstr "略微偏左"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:201
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Slightly right"
 msgstr "略微偏右"
 
-#: lib/fares/retail_locations_data.ex:98
+#: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "Smart Card"
 msgstr "智慧卡"
 
-#: lib/alerts/alert.ex:247
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
 msgstr "雪道"
 
-#: lib/alerts/alert.ex:252
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Snow Shoveling"
 msgstr "鏟雪"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:54
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Some Seats Available"
 msgstr "部分座位可用"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:583
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Some crowding"
 msgstr "有些擁擠"
 
-#: lib/dotcom_web/views/error_view.ex:26
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Something went wrong on our end."
 msgstr "我們這邊出了點問題。"
 
-#: lib/dotcom_web/views/error_view.ex:11
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry! We missed your stop."
 msgstr "對不起！我們錯過了您的站點。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:143
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. Something went wrong. Please try again."
 msgstr "對不起。出問題了。請重試。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:128
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sorry. We had trouble uploading your image. Please try again."
 msgstr "對不起。上傳您的圖片時遇到問題。請重試。"
 
-#: lib/routes/parser.ex:68
+#: lib/routes/parser.ex
 #, elixir-autogen, elixir-format
 msgid "Southbound"
 msgstr "南行"
 
-#: lib/fares/format.ex:44
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special Event Ticket"
 msgstr "特別活動車票"
 
-#: lib/fares/format.ex:18
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Special ticket required"
 msgstr "需要特殊車票"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:81
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "Station & Service Alerts"
 msgstr "車站及服務警報"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:38
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Accessibility"
 msgstr "車站無障礙設施"
 
-#: lib/alerts/alert.ex:248
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
 msgstr "車站關閉"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:36
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Station Features"
 msgstr "車站特色"
 
-#: lib/alerts/alert.ex:249
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
 msgstr "車站問題"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:388
+#: lib/dotcom_web/controllers/stop_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Station serving MBTA %{lines} lines%{location}."
 msgstr "服務於 MBTA %{lines}條線路%{location}的車站。"
 
-#: lib/dotcom_web/controllers/stop_controller.ex:51
-#: lib/dotcom_web/controllers/stop_controller.ex:373
-#: lib/dotcom_web/templates/stop/index.html.heex:21
-#: lib/dotcom_web/templates/stop/index.html.heex:41
-#: lib/dotcom_web/views/page_view.ex:181
+#: lib/dotcom_web/controllers/stop_controller.ex
+#: lib/dotcom_web/templates/stop/index.html.heex
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Stations"
 msgstr "車站"
 
-#: lib/dotcom_web/templates/page/_find_a_location.html.heex:14
+#: lib/dotcom_web/templates/page/_find_a_location.html.heex
 #, elixir-autogen, elixir-format
 msgid "Stations and Parking"
 msgstr "車站和停車場"
 
-#: lib/dotcom_web/live/search_page_live.ex:83
+#: lib/dotcom_web/live/search_page_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stations and Stops"
 msgstr "車站和站點"
 
-#: lib/dotcom_web/components/stops.ex:75
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "地位"
 
-#: lib/dotcom_web/components/stops/header.ex:39
+#: lib/dotcom_web/components/stops/header.ex
 #, elixir-autogen, elixir-format
 msgid "Stop %{id}"
 msgstr "停止%{id}"
 
-#: lib/alerts/alert.ex:250
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
 msgstr "網站關閉"
 
-#: lib/alerts/alert.ex:251
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Move"
 msgstr "網站遷移"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:82
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:192
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:156
-#: lib/dotcom_web/live/upcoming_departures_live.ex:776
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Stop Skipped"
 msgstr "停止 繞行"
 
-#: lib/dotcom/alerts/endpoint_stops.ex:107
-#: lib/dotcom/alerts/endpoint_stops.ex:110
-#: lib/dotcom/alerts/endpoint_stops.ex:114
-#: lib/dotcom/alerts/endpoint_stops.ex:115
-#: lib/dotcom_web/components/timetable.ex:59
-#: lib/dotcom_web/components/timetable.ex:205
+#: lib/dotcom/alerts/endpoint_stops.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Stops"
 msgstr "停止"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_status.ex:197
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:157
+#: lib/dotcom_web/components/system_status/commuter_rail_status.ex
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "Stops Skipped"
 msgstr "停止 繞行"
 
-#: lib/fares/fare_info.ex:918
+#: lib/fares/fare_info.ex
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "學生"
 
-#: lib/fares/format.ex:45
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Student CharlieCard"
 msgstr "學生卡"
 
-#: lib/dotcom_web/live/search_page_live.html.heex:26
+#: lib/dotcom_web/live/search_page_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit"
 msgstr "提交"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "Submit a public records request to the MBTA"
 msgstr "向MBTA提交公共記錄申請。"
 
-#: lib/dotcom/trip_plan/input_form.ex:199
-#: lib/dotcom/trip_plan/input_form.ex:200
-#: lib/dotcom_web/controllers/mode/subway.ex:22
-#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex:25
-#: lib/dotcom_web/views/customer_support_view.ex:108
-#: lib/dotcom_web/views/helpers.ex:236
-#: lib/dotcom_web/views/layout_view.ex:89
-#: lib/dotcom_web/views/page_view.ex:196
-#: lib/fares/format.ex:88
+#: lib/dotcom/trip_plan/input_form.ex
+#: lib/dotcom_web/controllers/mode/subway.ex
+#: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/views/customer_support_view.ex
+#: lib/dotcom_web/views/helpers.ex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/dotcom_web/views/page_view.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Subway"
 msgstr "地鐵"
 
-#: lib/dotcom_web/templates/page/_user_guides.html.heex:15
+#: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
 msgstr "地鐵新手指南"
 
-#: lib/dotcom_web/views/layout_view.ex:137
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Fares"
 msgstr "地鐵票價"
 
-#: lib/dotcom_web/views/mode_view.ex:190
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Map"
 msgstr "地鐵線路圖"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:4
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway One-Way"
 msgstr "單地鐵程票"
 
-#: lib/dotcom_web/components/system_status/subway_status.ex:28
-#: lib/dotcom_web/components/system_status/subway_status.ex:59
+#: lib/dotcom_web/components/system_status/subway_status.ex
 #, elixir-autogen, elixir-format
 msgid "Subway Status"
 msgstr "地鐵狀態"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:77
-#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex:58
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+#: lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Suggest a Retailer"
 msgstr "推薦零售商"
 
-#: lib/alerts/alert.ex:253
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "概括"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:64
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Sunday"
 msgstr "星期日"
 
-#: lib/alerts/alert.ex:254
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Suspension"
 msgstr "暫停"
 
-#: lib/dotcom_web/templates/page/_important_links.html.heex:47
-#: lib/dotcom_web/views/layout_view.ex:220
+#: lib/dotcom_web/templates/page/_important_links.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "永續性"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:55
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Swap origin and destination locations"
 msgstr "交換始發地和目的地"
 
-#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex:7
+#: lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "Systemwide"
 msgstr "全系統"
 
-#: lib/feedback/message.ex:27
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "TAlerts/Countdowns/Apps"
 msgstr "提醒/倒數計時/應用"
 
-#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_transit_police.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY"
 msgstr "TTY"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:43
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "TTY Phone"
 msgstr "TTY電話"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:56
-#: lib/dotcom_web/templates/vote/show.html.heex:4
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Take the T to Vote"
 msgstr "搭乘地鐵去投票"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:207
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "搭乘電梯"
 
-#: lib/dotcom_web/components/components.ex:398
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Taking the train to a World Cup match?"
 msgstr "坐火車去看世界盃比賽？"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:53
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell Us What You Think"
 msgstr "請告訴我們您的想法"
 
-#: lib/dotcom_web/templates/alert/_t-alerts.html.heex:6
+#: lib/dotcom_web/templates/alert/_t-alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
 msgstr "告訴我們您的日常出行情況，我們會按照您希望的時間，透過簡訊或電子郵件向您發送與您相關的警訊。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:233
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Temporarily Unavailable"
 msgstr "暫時不可用"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:9
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:9
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporarily closed"
 msgstr "暫時已關閉"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:12
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary Issue"
 msgstr "臨時發行"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:11
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Temporary issue"
 msgstr "臨時問題"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:173
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Terms of Use"
 msgstr "使用條款"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:12
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thank you for submitting your feedback. Our Customer Support team will review your comments soon."
 msgstr "感謝您提交回饋意見。我們的客戶支援團隊將盡快查看您的評論。"
 
-#: lib/holiday/repo.ex:77
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Thanksgiving Day"
 msgstr "感恩節"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:17
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "The "
 msgstr "這 "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:5
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received."
 msgstr "The RIDE的全系統無障礙和無障礙聯絡中的無障礙參與協調員負責在收到 ADA/無障礙投訴後協調解決方案。"
 
-#: lib/dotcom/schedule_note.ex:98
+#: lib/dotcom/schedule_note.ex
 #, elixir-autogen, elixir-format
 msgid "The Foxboro Special Events line is only for occasional service."
 msgstr "Foxboro特別活動專線僅用於偶爾服務。"
 
-#: lib/dotcom_web/templates/customer_support/_report.html.heex:3
+#: lib/dotcom_web/templates/customer_support/_report.html.heex
 #, elixir-autogen, elixir-format
 msgid "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs."
 msgstr "監察長辦公室內部特別審計部門負責監督麻州交通部各項計畫的品質、效率和誠信。"
 
-#: lib/dotcom_web/views/page_view.ex:187
+#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "The RIDE"
 msgstr "The RIDE"
 
-#: lib/dotcom_web/views/helpers.ex:258
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "The Ride"
 msgstr "旅程"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "The interactive timetable for"
 msgstr "互動式時間表"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:292
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available."
 msgstr "目前沒有即時出發資訊。"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:303
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are currently no realtime departures available. Scheduled departures are shown below."
 msgstr "目前沒有即時出發資訊。以下列出預定出發時間。"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no"
 msgstr "沒有"
 
-#: lib/dotcom_web/views/alert_view.ex:101
-#: lib/dotcom_web/views/alert_view.ex:108
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no "
 msgstr "沒有 "
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:60
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no additional accessibility features, but buses are always accessible to board."
 msgstr "沒有額外的無障礙功能，但巴士總是無障礙上車。"
 
-#: lib/dotcom_web/views/alert_view.ex:104
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no alerts"
 msgstr "沒有警報。"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no high priority"
 msgstr "沒有高優先事項"
 
-#: lib/dotcom_web/live/commuter_rail_alerts_live.ex:79
+#: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other commuter rail alerts at this time."
 msgstr "目前沒有其他通勤鐵路警報。"
 
-#: lib/dotcom_web/live/subway_alerts_live.ex:78
+#: lib/dotcom_web/live/subway_alerts_live.ex
 #, elixir-autogen, elixir-format
 msgid "There are no other subway alerts at this time."
 msgstr "目前沒有其他地鐵警報。"
 
-#: lib/dotcom_web/views/schedule_view.ex:87
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips on %{date}."
 msgstr "%{date}上沒有安排%{direction}行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:94
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled %{direction} trips."
 msgstr "目前沒有安排%{direction}次行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:105
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips on %{date}."
 msgstr "%{date}上沒有預定行程。"
 
-#: lib/dotcom_web/views/schedule_view.ex:108
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "There are no scheduled trips."
 msgstr "沒有預定的行程。"
 
-#: lib/dotcom_web/templates/project/updates.html.heex:44
+#: lib/dotcom_web/templates/project/updates.html.heex
 #, elixir-autogen, elixir-format
 msgid "There are no updates at this time."
 msgstr "目前暫無更新資料。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:592
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is currently no scheduled %{route_name}."
 msgstr "目前沒有已安排的%{route_name} 。"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:43
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "There is no planned work information at this time."
 msgstr "目前還沒有計劃工作資訊。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:594
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There is no scheduled %{route} service at %{stop} for this time period."
 msgstr "此時間段內， %{stop}沒有安排%{route}服務。"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:547
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading arrivals"
 msgstr "載入到達資料時出現問題"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:143
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading schedules"
 msgstr "載入時刻表時出現問題"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:427
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading trip details"
 msgstr "加載行程詳情時出現問題"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:59
-#: lib/dotcom_web/live/upcoming_departures_live.ex:71
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "There was a problem loading upcoming departures"
 msgstr "加載即將進行的出發航班時出現問題"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:21
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This %{place} is not accessible."
 msgstr "此%{place}不方便。"
 
-#: lib/dotcom/utils/service_date_time.ex:87
+#: lib/dotcom/utils/service_date_time.ex
 #, elixir-autogen, elixir-format
 msgid "This Week"
 msgstr "本星期"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:18
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "This list does not include current MBTA retailers. To see current retail locations, use our"
 msgstr "此清單不包含MBTA目前的零售商。要查看目前的零售店位置，請使用我們的"
 
-#: lib/dotcom_web/views/error_view.ex:12
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "This page is no longer in service."
 msgstr "此頁面已停止使用。"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:25
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have bike storage."
 msgstr "該車站沒有自行車存放處。"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have elevators."
 msgstr "這個車站沒有電梯。"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:17
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have escalators."
 msgstr "這個車站沒有自動扶梯。"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This station does not have parking."
 msgstr "這個車站沒有停車位。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:50
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "This stop does not have fare vending machines, but you can purchase fares at a"
 msgstr "本站沒有自動售票機，但您可以在車站購買車票。"
 
-#: lib/dotcom_web/views/schedule_view.ex:548
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "This train typically has<br /><strong>%{seats} seats available</strong>"
 msgstr "這列列車通常有<br /> <strong>%{seats}座位可用</strong>"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:68
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Thursday"
 msgstr "星期四"
 
-#: lib/dotcom_web/views/schedule_view.ex:310
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
 msgstr "時間表"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:145
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "到"
 
-#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex:2
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:25
+#: lib/dotcom_web/templates/customer_support/_rail_road.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
 #, elixir-autogen, elixir-format
 msgid "To report a problem or emergency with a railroad crossing, call"
 msgstr "如需通報鐵路道口的問題或緊急情況，請致電"
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:2
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
 msgstr "如需提交 ADA/無障礙投訴或回饋，請致電"
 
-#: lib/dotcom/utils/service_date_time.ex:86
-#: lib/dotcom_web/components/planned_disruptions.ex:158
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:33
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:92
-#: lib/dotcom_web/views/helpers.ex:550
+#: lib/dotcom/utils/service_date_time.ex
+#: lib/dotcom_web/components/planned_disruptions.ex
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "今天"
 
-#: lib/dotcom_web/views/alert_view.ex:163
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Today at"
 msgstr "今天"
 
-#: lib/dotcom_web/templates/customer_support/_call_us.html.heex:7
+#: lib/dotcom_web/templates/customer_support/_call_us.html.heex
 #, elixir-autogen, elixir-format
 msgid "Toll Free"
 msgstr "免費電話"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:131
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Track Boarding Change"
 msgstr "軌道登機變更"
 
-#: lib/alerts/alert.ex:255
-#: lib/dotcom/alerts/commuter_rail.ex:15
-#: lib/dotcom_web/components/timetable.ex:346
+#: lib/alerts/alert.ex
+#: lib/dotcom/alerts/commuter_rail.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Track Change"
 msgstr "軌道變換"
 
-#: lib/dotcom/schedule_finder.ex:225
+#: lib/dotcom/schedule_finder.ex
 #, elixir-autogen, elixir-format
 msgid "Track TBA"
 msgstr "賽道待定"
 
-#: lib/dotcom_web/components/components.ex:486
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong> app"
 msgstr "使用<strong>MBTA Go</strong>應用程式即時追蹤您的%{route_type_text}行程"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:531
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "火車"
 
-#: lib/dotcom/upcoming_departures/processor.ex:223
+#: lib/dotcom/upcoming_departures/processor.ex
 #, elixir-autogen, elixir-format
 msgid "Train %{trip_name}"
 msgstr "列車%{trip_name}"
 
-#: lib/dotcom_web/views/schedule/timetable.ex:59
+#: lib/dotcom_web/views/schedule/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Train scheduled to board from %{platform} at %{station}"
 msgstr "計畫從%{platform}開往上車的列車將於%{station}時刻從"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:184
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Transfer"
 msgstr "轉移"
 
-#: lib/dotcom_web/views/layout_view.ex:130
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transfers"
 msgstr "轉會"
 
-#: lib/dotcom_web/views/layout_view.ex:83
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit"
 msgstr "交通"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:43
-#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex:15
-#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:175
+#: lib/dotcom_web/controllers/customer_support_controller.ex
+#: lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Transit Police"
 msgstr "交通警察"
 
-#: lib/dotcom_web/controllers/mode/subway.ex:27
+#: lib/dotcom_web/controllers/mode/subway.ex
 #, elixir-autogen, elixir-format
 msgid "Travel anywhere on the Blue, Orange, Red, and Green lines for the same price."
 msgstr "搭乘Blue 、 Orange 、 Red和Green線，票價相同。"
 
-#: lib/dotcom_web/components/timetable.ex:70
-#: lib/dotcom_web/components/timetable.ex:216
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Trip"
 msgstr "旅行"
 
-#: lib/dotcom_web/hooks/breadcrumbs.ex:17
-#: lib/dotcom_web/live/trip_planner_live.ex:115
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:33
-#: lib/dotcom_web/views/layout_view.ex:101
-#: lib/feedback/message.ex:54
+#: lib/dotcom_web/hooks/breadcrumbs.ex
+#: lib/dotcom_web/live/trip_planner_live.ex
+#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/views/layout_view.ex
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Trip Planner"
 msgstr "Trip planner"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:23
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Trip Type"
 msgstr "旅行類型"
 
-#: lib/dotcom_web/components/trip_planner/results_summary.ex:65
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Trips from %{from} to %{to}"
 msgstr "從%{from}到%{to}行程"
 
-#: lib/dotcom_web/views/error_view.ex:13
-#: lib/dotcom_web/views/error_view.ex:27
+#: lib/dotcom_web/views/error_view.ex
 #, elixir-autogen, elixir-format
 msgid "Try searching for what you're looking for below."
 msgstr "請嘗試在下方搜尋您要找的內容。"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:66
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday"
 msgstr "星期二"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:73
-#: lib/dotcom_web/templates/vote/show.html.heex:14
+#: lib/dotcom_web/controllers/vote_controller.ex
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Tuesday, November 5 is the last day to vote in the 2024 general election. Use the T to get to your polling location."
 msgstr "週二，11月5日是2024年大選投票的末日。 搭乘地鐵前往投票站。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:76
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically fewer than 33% of seats available and distancing is unlikely (~3+ people per row)"
 msgstr "通常只有不到 33% 的座位可用，而且不太可能保持社交距離（每排約 3 人以上）。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:58
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 33% of seats remain available and distancing may be possible (~2-3 people per row)"
 msgstr "通常情況下，超過 33% 的座位仍然空著，可以保持社交距離（每排約 2-3 人）。"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:40
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "Typically more than 66% of seats are available and distancing is possible (~0-2 people per row)"
 msgstr "通常情況下，超過 66% 的座位可用，並且可以保持社交距離（每排約 0-2 人）。"
 
-#: lib/alerts/alert.ex:256
-#: lib/alerts/alert.ex:269
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "未知"
 
-#: lib/dotcom_web/views/schedule_view.ex:573
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Unscheduled Track"
 msgstr "非計劃賽道"
 
-#: lib/dotcom_web/components/planned_disruptions.ex:114
+#: lib/dotcom_web/components/planned_disruptions.ex
 #, elixir-autogen, elixir-format
 msgid "Until %{date}"
 msgstr "直到%{date}"
 
-#: lib/alerts/alert.ex:266
-#: lib/alerts/alert.ex:267
-#: lib/dotcom_web/views/schedule_view.ex:173
+#: lib/alerts/alert.ex
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming"
 msgstr "即將進行"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex:36
-#: lib/dotcom_web/views/bus_stop_change_view.ex:76
+#: lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+#: lib/dotcom_web/views/bus_stop_change_view.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Changes"
 msgstr "即將進行變更"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:114
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Departures"
 msgstr "即將進行 出發"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:2
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Holidays"
 msgstr "即將進行假期"
 
-#: lib/dotcom_web/templates/page/_homepage-events.html.heex:5
+#: lib/dotcom_web/templates/page/_homepage-events.html.heex
 #, elixir-autogen, elixir-format
 msgid "Upcoming Public Meetings and Events"
 msgstr "即將進行公開會議和活動"
 
-#: lib/dotcom_web/templates/cms/page/_project_update.html.heex:2
-#: lib/dotcom_web/templates/project/update.html.heex:6
+#: lib/dotcom_web/templates/cms/page/_project_update.html.heex
+#: lib/dotcom_web/templates/project/update.html.heex
 #, elixir-autogen, elixir-format
 msgid "Updated on"
 msgstr "更新於"
 
-#: lib/dotcom_web/views/alert_view.ex:170
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Updated: "
 msgstr "更新： "
 
-#: lib/dotcom_web/controllers/cms_controller.ex:129
-#: lib/dotcom_web/controllers/project_controller.ex:105
-#: lib/dotcom_web/controllers/project_controller.ex:146
+#: lib/dotcom_web/controllers/cms_controller.ex
+#: lib/dotcom_web/controllers/project_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Updates"
 msgstr "更新"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:49
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Use"
 msgstr "使用"
 
-#: lib/dotcom_web/views/layout_view.ex:106
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "User Guides"
 msgstr "使用者指南"
 
-#: lib/holiday/repo.ex:76
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Veterans Day"
 msgstr "退伍軍人節"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:517
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:520
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Via"
 msgstr "透過"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "看法"
 
-#: lib/dotcom_web/components/components.ex:401
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "View %{timetable_link} for departure information."
 msgstr "查看%{timetable_link}以獲取出發資訊。"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:237
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
 msgstr "查看警報"
 
-#: lib/dotcom_web/views/layout_view.ex:165
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "View All Contact Numbers"
 msgstr "查看所有聯絡電話"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:40
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View All Options"
 msgstr "查看所有選項"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:9
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio"
 msgstr "查看個人簡介"
 
-#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex:11
+#: lib/dotcom_web/templates/cms/paragraph/_person.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Bio for %{name}"
 msgstr "看看%{name}的個人簡介"
 
-#: lib/dotcom_web/templates/alert/_summary_content.html.heex:19
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:5
-#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex:4
+#: lib/dotcom_web/templates/alert/_summary_content.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
+#: lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable"
 msgstr "查看PDF時間表"
 
-#: lib/dotcom/timetable_blocking.ex:11
+#: lib/dotcom/timetable_blocking.ex
 #, elixir-autogen, elixir-format
 msgid "View PDF Timetable on the MBTA website."
 msgstr "請在MBTA網站上查看PDF格式的時間表。"
 
-#: lib/dotcom_web/templates/event/_month.html.heex:13
+#: lib/dotcom_web/templates/event/_month.html.heex
 #, elixir-autogen, elixir-format
 msgid "View Previous"
 msgstr "查看上一頁"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:66
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "看全部"
 
-#: lib/dotcom_web/views/mode_view.ex:83
+#: lib/dotcom_web/views/mode_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all bus routes"
 msgstr "查看所有巴士路線"
 
-#: lib/dotcom_web/views/paragraph_view.ex:206
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all events"
 msgstr "查看所有活動"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:85
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all guides"
 msgstr "查看所有指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:43
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "View all matches"
 msgstr "查看所有比賽"
 
-#: lib/dotcom_web/views/paragraph_view.ex:213
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all news"
 msgstr "查看所有新聞"
 
-#: lib/dotcom_web/views/paragraph_view.ex:199
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all project updates"
 msgstr "查看所有項目更新"
 
-#: lib/dotcom_web/views/paragraph_view.ex:220
+#: lib/dotcom_web/views/paragraph_view.ex
 #, elixir-autogen, elixir-format
 msgid "View all projects"
 msgstr "查看所有項目"
 
-#: lib/dotcom_web/components/stops/elevator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/elevator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available elevators."
 msgstr "查看可用電梯。"
 
-#: lib/dotcom_web/components/stops/escalator_amenity.html.heex:18
+#: lib/dotcom_web/components/stops/escalator_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View available escalators."
 msgstr "查看可用的自動扶梯。"
 
-#: lib/dotcom_web/controllers/fare_controller.ex:127
+#: lib/dotcom_web/controllers/fare_controller.ex
 #, elixir-autogen, elixir-format
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "查看 MBTA 巴士、地鐵、通勤鐵路、渡輪和The RIDE的常見票價資訊。 在線查找 CharlieCard 服務並了解大量訂購計劃。"
 
-#: lib/dotcom_web/views/schedule_view.ex:442
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View evening timetable"
 msgstr "查看晚間時刻表"
 
-#: lib/dotcom_web/templates/mode/index.html.heex:43
-#: lib/dotcom_web/views/fare_view.ex:112
+#: lib/dotcom_web/templates/mode/index.html.heex
+#: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
 msgid "View fares overview"
 msgstr "查看票價概覽"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:95
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "查看更多付款信息"
 
-#: lib/dotcom_web/views/schedule_view.ex:464
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "View morning timetable"
 msgstr "查看早晨時刻表"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:51
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on Google Maps"
 msgstr "在谷歌地圖上查看"
 
-#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex:44
+#: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "View on MBTA Trip Planner"
 msgstr "在 MBTA 行程規劃器上查看"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:20
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View parking rates, facility information, and more."
 msgstr "查看停車費率、設施資訊等。"
 
-#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex:6
+#: lib/dotcom_web/templates/customer_support/_lost_and_found.html.heex
 #, elixir-autogen, elixir-format
 msgid "View phone numbers"
 msgstr "查看電話號碼"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:76
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "訪問"
 
-#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex:104
+#: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Visit the Mobility Center"
 msgstr "參觀行動中心"
 
-#: lib/dotcom_web/controllers/vote_controller.ex:64
+#: lib/dotcom_web/controllers/vote_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "投票"
 
-#: lib/dotcom_web/components/trip_planner/results.ex:62
+#: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting for results"
 msgstr "等待結果"
 
-#: lib/dotcom_web/live/upcoming_departures_live.ex:539
+#: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Waiting to depart"
 msgstr "等待出發"
 
-#: lib/dotcom_web/components/trip_planner/walking_leg.ex:34
+#: lib/dotcom_web/components/trip_planner/walking_leg.ex
 #, elixir-autogen, elixir-format
 msgid "Walk"
 msgstr "走"
 
-#: lib/dotcom/trip_plan/input_form.ex:231
-#: lib/dotcom/trip_plan/input_form.ex:234
+#: lib/dotcom/trip_plan/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "Walking directions only"
 msgstr "僅提供步行路線"
 
-#: lib/holiday/repo.ex:69
+#: lib/holiday/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Washington’s Birthday"
 msgstr "華盛頓誕辰"
 
-#: lib/dotcom_web/views/schedule_view.ex:77
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "We can only provide trip data for the %{rating} schedule, valid until %{end_date}."
 msgstr "我們只能提供%{rating}時刻表的行程數據，有效期限至%{end_date} 。"
 
-#: lib/dotcom_web/templates/customer_support/index.html.heex:23
+#: lib/dotcom_web/templates/customer_support/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes."
 msgstr "提交您的回饋時出現問題—請撥打下面的主要熱線電話，或稍後再試。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:55
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We want to make sure we're building a retail network that works for you. You can share your feedback using the form below."
 msgstr "我們希望確保我們建立的零售網路能夠為您服務。您可以使用下面的表格分享您的回饋意見。"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:54
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We weren't able to find a polling place for your address. You can also visit the"
 msgstr "我們未能找到您所在地址的投票站。您也可以參觀"
 
-#: lib/dotcom_web/templates/news_entry/show.html.heex:43
+#: lib/dotcom_web/templates/news_entry/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "We'll send you MBTA press releases and media advisories directly."
 msgstr "我們將直接向您發送 MBTA 的新聞稿和媒體通告。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:68
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're asking the public to help guide our decisions as we roll out the Fare Transformation project over the next several years."
 msgstr "在未來幾年推行票價改革計畫的過程中，我們希望大眾能幫助我們做出正確的決定。"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:8
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
 msgstr "我們正在擴大乘客可以辦理或充值 CharlieCard 以及購買通票的地點網路。"
 
-#: lib/feedback/message.ex:40
-#: lib/feedback/message.ex:55
+#: lib/feedback/message.ex
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "網站"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:67
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Wednesday"
 msgstr "星期三"
 
-#: lib/fares/format.ex:70
-#: lib/fares/format.ex:118
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Weekend Pass"
 msgstr "週末通票"
 
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:24
-#: lib/dotcom_web/templates/schedule/_date_picker.html.heex:86
+#: lib/dotcom_web/templates/schedule/_date_picker.html.heex
 #, elixir-autogen, elixir-format
 msgid "Weekends"
 msgstr "週末"
 
-#: lib/routes/parser.ex:70
-#: lib/routes/repo.ex:193
+#: lib/routes/parser.ex
+#: lib/routes/repo.ex
 #, elixir-autogen, elixir-format
 msgid "Westbound"
 msgstr "西行"
 
-#: lib/dotcom_web/templates/page/_whats_happening.html.heex:14
+#: lib/dotcom_web/templates/page/_whats_happening.html.heex
 #, elixir-autogen, elixir-format
 msgid "What's Happening at the MBTA"
 msgstr "MBTA 發生了什麼事？"
 
-#: lib/dotcom_web/components/trip_planner/input_form.ex:69
+#: lib/dotcom_web/components/trip_planner/input_form.ex
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr "什麼時候"
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:73
+#: lib/dotcom_web/templates/layout/_footer.html.heex
 #, elixir-autogen, elixir-format
 msgid "Work With Us"
 msgstr "加入我們"
 
-#: lib/dotcom_web/views/layout_view.ex:208
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Work with Us"
 msgstr "加入我們"
 
-#: lib/dotcom_web/components/stops.ex:81
+#: lib/dotcom_web/components/stops.ex
 #, elixir-autogen, elixir-format
 msgid "Working"
 msgstr "在職的"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:117
-#: lib/dotcom_web/views/layout_view.ex:100
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
+#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "世界盃指南"
 
-#: lib/dotcom_web/live/world_cup_timetable_live.html.heex:31
+#: lib/dotcom_web/live/world_cup_timetable_live.html.heex
 #, elixir-autogen, elixir-format
 msgid "World Cup Matches"
 msgstr "世界盃比賽"
 
-#: lib/dotcom_web/controllers/customer_support_controller.ex:53
+#: lib/dotcom_web/controllers/customer_support_controller.ex
 #, elixir-autogen, elixir-format
 msgid "Write to Us"
 msgstr "請寫信給我們"
 
-#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex:1
+#: lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
 #, elixir-autogen, elixir-format
 msgid "Year-Round"
 msgstr "全年"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:10
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can also email"
 msgstr "您也可以透過電子郵件聯絡我。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:44
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You can expect a response to most tickets within 5 business days. Certain complaints may require longer investigations, up to 30 days."
 msgstr "大多數車票申請會在 5 個工作天內回覆。 某些投訴可能需要更長的調查，最長可達 30 天。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:38
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "You can pay for your fare with"
 msgstr "您可以使用以下方式支付車資："
 
-#: lib/dotcom_web/views/customer_support_view.ex:138
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must agree to our Privacy Policy before submitting your feedback."
 msgstr "您必須同意我們的隱私權政策才能提交回饋。"
 
-#: lib/dotcom_web/views/customer_support_view.ex:141
+#: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "您必須先完成 reCAPTCHA 驗證才能提交回饋。"
 
-#: lib/dotcom_web/components/components.ex:424
+#: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr "世界盃將影響您的通勤鐵路行程。"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:34
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "Your Polling Place"
 msgstr "您的投票站"
 
-#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex:12
+#: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #, elixir-autogen, elixir-format
 msgid "Zone"
 msgstr "區"
 
-#: lib/dotcom_web/components/transit_icons.ex:36
-#: lib/fares/format.ex:101
+#: lib/dotcom_web/components/transit_icons.ex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zone %{zone}"
 msgstr "區域%{zone}"
 
-#: lib/fares/format.ex:189
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Zones 1A-10"
 msgstr "1A-10區"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "a crew member"
 msgstr "一名船員"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:69
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "accessible spots"
 msgstr "無障礙設施"
 
-#: lib/dotcom_web/templates/alert/show.html.heex:9
-#: lib/dotcom_web/templates/page/_alerts.html.heex:17
+#: lib/dotcom_web/templates/alert/show.html.heex
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "alerts at this time"
 msgstr "此時發出警報"
 
-#: lib/util/and_or.ex:13
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "和"
 
-#: lib/vehicle_helpers.ex:159
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "arrived at"
 msgstr "到達"
 
-#: lib/dotcom/transit_near_me.ex:109
-#: lib/dotcom/transit_near_me.ex:115
+#: lib/dotcom/transit_near_me.ex
 #, elixir-autogen, elixir-format
 msgid "arriving"
 msgstr "抵達"
 
-#: lib/dotcom_web/templates/page/_alerts.html.heex:48
+#: lib/dotcom_web/templates/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "at this time"
 msgstr "此時"
 
-#: lib/dotcom_web/components/system_status/status_row_heading.ex:181
+#: lib/dotcom_web/components/system_status/status_row_heading.ex
 #, elixir-autogen, elixir-format
 msgid "between %{first} and %{last}"
 msgstr "介於%{first}和%{last}之間"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:265
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "boat"
 msgstr "船"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:266
-#: lib/dotcom_web/controllers/schedule/alerts_controller.ex:61
-#: lib/dotcom_web/controllers/schedule/line_controller.ex:274
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/controllers/schedule/alerts_controller.ex
+#: lib/dotcom_web/controllers/schedule/line_controller.ex
 #, elixir-autogen, elixir-format
 msgid "bus"
 msgstr "巴士"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:163
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "bus stop"
 msgstr "巴士站"
 
-#: lib/fares/format.ex:36
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "cash"
 msgstr "現金"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "change"
 msgstr "改變"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:12
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "changes"
 msgstr "變化"
 
-#: lib/fares/format.ex:40
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "contactless payment"
 msgstr "非接觸式支付"
 
-#: lib/dotcom_web/views/alert_view.ex:92
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "current"
 msgstr "目前的"
 
-#: lib/vehicle_helpers.ex:159
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "departed"
 msgstr "已離開"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:67
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "docks"
 msgstr "碼頭"
 
-#: lib/dotcom_web/views/schedule_view.ex:126
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "east"
 msgstr "東方"
 
-#: lib/dotcom_web/views/schedule_view.ex:543
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "few"
 msgstr "很少"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:215
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "為了"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:135
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
 #, elixir-autogen, elixir-format
 msgid "from %{origin}"
 msgstr "來自%{origin}"
 
-#: lib/vehicle_helpers.ex:160
+#: lib/vehicle_helpers.ex
 #, elixir-autogen, elixir-format
 msgid "has left"
 msgstr "已離開"
 
-#: lib/dotcom_web/views/schedule_view.ex:123
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "inbound"
 msgstr "進站"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:46
-#: lib/dotcom_web/templates/stop/index.html.heex:56
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "info"
 msgstr "資訊"
 
-#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex:2
+#: lib/dotcom_web/templates/schedule/_timetable_blocked.html.heex
 #, elixir-autogen, elixir-format
 msgid "is temporarily unavailable due to a service change."
 msgstr "由於服務變更，暫時無法使用。"
 
-#: lib/dotcom_web/views/helpers.ex:559
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "line"
 msgstr "線"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:51
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "location"
 msgstr "地點"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:29
-#: lib/fares/format.ex:41
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "mTicket App"
 msgstr "mTicket App"
 
-#: lib/dotcom_web/views/schedule_view.ex:541
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "many"
 msgstr "許多"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:54
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "nearby retail location"
 msgstr "附近零售店"
 
-#: lib/dotcom_web/views/schedule_view.ex:127
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "north"
 msgstr "北"
 
-#: lib/alerts/alert.ex:289
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than 30 min"
 msgstr "超過30分鐘"
 
-#: lib/alerts/alert.ex:290
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "of more than an hour"
 msgstr "超過一個小時"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:218
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "onto"
 msgstr "到"
 
-#: lib/util/and_or.ex:17
+#: lib/util/and_or.ex
 #, elixir-autogen, elixir-format
 msgid "or"
 msgstr "或"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:44
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "or "
 msgstr "或 "
 
-#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex:4
+#: lib/dotcom_web/templates/customer_support/_accessibility.html.heex
 #, elixir-autogen, elixir-format
 msgid "or complete the feedback form on this page."
 msgstr "或填寫此頁面上的回饋表。"
 
-#: lib/dotcom_web/components/stops/fare_amenity.html.heex:56
+#: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "or pay with cash on any bus"
 msgstr "或在任何巴士上用現金支付"
 
-#: lib/dotcom_web/views/schedule_view.ex:124
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "outbound"
 msgstr "出站"
 
-#: lib/fares/format.ex:42
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "paper ferry ticket"
 msgstr "紙質渡輪車票"
 
-#: lib/dotcom_web/views/alert_view.ex:88
+#: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "planned"
 msgstr "計劃"
 
-#: lib/fares/format.ex:25
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "reduced fare card"
 msgstr "減價票卡"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:42
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "registration in advance"
 msgstr "提前註冊"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "report an issue"
 msgstr "報告問題"
 
-#: lib/dotcom_web/components/stops/bike_amenity.html.heex:40
+#: lib/dotcom_web/components/stops/bike_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "requires"
 msgstr "需要"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:19
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "retail sales location finder"
 msgstr "零售店位置查找器"
 
-#: lib/dotcom_web/views/helpers.ex:558
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "route"
 msgstr "路線"
 
-#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex:11
+#: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
 msgid "see a map of all proposed sales locations"
 msgstr "查看所有擬定銷售地點的地圖"
 
-#: lib/dotcom_web/templates/cms/page/_alerts.html.heex:11
+#: lib/dotcom_web/templates/cms/page/_alerts.html.heex
 #, elixir-autogen, elixir-format
 msgid "service"
 msgstr "服務"
 
-#: lib/dotcom_web/views/schedule_view.ex:542
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "some"
 msgstr "一些"
 
-#: lib/dotcom_web/views/schedule_view.ex:128
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "south"
 msgstr "南"
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:174
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "station"
 msgstr "車站"
 
-#: lib/dotcom_web/controllers/schedule/timetable_controller.ex:68
+#: lib/dotcom_web/controllers/schedule/timetable_controller.ex
 #, elixir-autogen, elixir-format
 msgid "stations"
 msgstr "車站"
 
-#: lib/dotcom_web/views/stop_view.ex:63
+#: lib/dotcom_web/views/stop_view.ex
 #, elixir-autogen, elixir-format
 msgid "stop"
 msgstr "停止"
 
-#: lib/dotcom_web/templates/stop/index.html.heex:73
+#: lib/dotcom_web/templates/stop/index.html.heex
 #, elixir-autogen, elixir-format
 msgid "stops"
 msgstr "停止"
 
-#: lib/dotcom_web/templates/error/error_layout.html.heex:26
+#: lib/dotcom_web/templates/error/error_layout.html.heex
 #, elixir-autogen, elixir-format
 msgid "the MBTA's home page"
 msgstr "MBTA首頁"
 
-#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex:21
+#: lib/dotcom_web/templates/schedule/_timetable_icon_key.html.heex
 #, elixir-autogen, elixir-format
 msgid "the conductor"
 msgstr "指揮家"
 
-#: lib/dotcom_web/live/schedule_finder_live.ex:484
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "the next morning"
 msgstr "第二天早上"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:216
+#: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "through"
 msgstr "透過"
 
-#: lib/dotcom_web/components/timetable.ex:51
-#: lib/dotcom_web/components/timetable.ex:197
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "timetable for"
 msgstr "時間表"
 
-#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex:70
-#: lib/dotcom_web/views/helpers.ex:227
+#: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+#: lib/dotcom_web/views/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "到"
 
-#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex:134
-#: lib/dotcom_web/live/schedule_finder_live.ex:579
+#: lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "to %{destination}"
 msgstr "至%{destination}"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:58
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to find your polling place, and then use the"
 msgstr "找到你的投票地點，然後使用"
 
-#: lib/dotcom_web/templates/vote/show.html.heex:62
+#: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format
 msgid "to plan your trip"
 msgstr "規劃您的行程"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:66
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "total parking spots"
 msgstr "停車位總數"
 
-#: lib/dotcom_web/components/trip_planner/helpers.ex:217
-#: lib/dotcom_web/live/schedule_finder_live.ex:383
+#: lib/dotcom_web/components/trip_planner/helpers.ex
+#: lib/dotcom_web/live/schedule_finder_live.ex
 #, elixir-autogen, elixir-format
 msgid "towards"
 msgstr "向"
 
-#: lib/journey.ex:234
+#: lib/journey.ex
 #, elixir-autogen, elixir-format
 msgid "track "
 msgstr "追蹤 "
 
-#: lib/dotcom_web/components/trip_planner/transit_leg.ex:267
+#: lib/dotcom_web/components/trip_planner/transit_leg.ex
 #, elixir-autogen, elixir-format
 msgid "train"
 msgstr "火車"
 
-#: lib/dotcom_web/templates/schedule/_empty.html.heex:5
+#: lib/dotcom_web/templates/schedule/_empty.html.heex
 #, elixir-autogen, elixir-format
 msgid "trips for today"
 msgstr "今日行程"
 
-#: lib/alerts/alert.ex:284
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 10 min"
 msgstr "最多 10 分鐘"
 
-#: lib/alerts/alert.ex:285
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 15 min"
 msgstr "最多 15 分鐘"
 
-#: lib/alerts/alert.ex:286
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 20 min"
 msgstr "最多 20 分鐘"
 
-#: lib/alerts/alert.ex:287
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 25 min"
 msgstr "最多 25 分鐘"
 
-#: lib/alerts/alert.ex:288
+#: lib/alerts/alert.ex
 #, elixir-autogen, elixir-format
 msgid "up to 30 min"
 msgstr "最多 30 分鐘"
 
-#: lib/dotcom_web/components/stops/parking_amenity.html.heex:78
+#: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "website"
 msgstr "網站"
 
-#: lib/dotcom_web/views/schedule_view.ex:129
+#: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "west"
 msgstr "西方"
 
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:93
-#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex:119
-#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex:56
+#: lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+#: lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
 #, elixir-autogen, elixir-format
 msgid "with"
 msgstr "和"
 
-#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex:11
+#: lib/dotcom_web/templates/customer_support/_request_public_records.html.heex
 #, elixir-autogen, elixir-format
 msgid "with your request."
 msgstr "滿足您的要求。"
 
-#: lib/fares/format.ex:98
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Inner Harbor Zone 1A"
 msgstr ""
 
-#: lib/fares/format.ex:96
+#: lib/fares/format.ex
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""


### PR DESCRIPTION
* Adds CI check for ensuring translations are up to date (Tip: Be sure to run `mix localize` locally before pushing up your PR!)
* Removes line numbers from `.pot` files to prevent how much the `.po`/`.pot` files have to be updated. Right now, there will be updates whenever content moves to a different line in the source code (even if the content of those translated messages itself does not change). My Charlie removed line numbers for this reason, and I figured it made sense to do the same here.