### PR TITLE
cleanup(timetables): Remove alert icons

### DIFF
--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -125,15 +125,6 @@ defmodule DotcomWeb.Components.Timetable do
           <.stop_header_cell
             cell_background={cell_background(idx)}
             stop={stop}
-            alert_for_stop?={
-              fn stop_id ->
-                Alerts.Stop.match(@alerts, stop_id,
-                  route: @route.id,
-                  time: @date,
-                  direction_id: @direction_id
-                ) != []
-              end
-            }
           />
 
           <td class="js-tt-cell hidden-no-js" style="padding-left: 0.5rem">
@@ -225,15 +216,6 @@ defmodule DotcomWeb.Components.Timetable do
           <.stop_header_cell
             cell_background={cell_background(idx)}
             stop={row.stop}
-            alert_for_stop?={
-              fn stop_id ->
-                Alerts.Stop.match(@alerts, stop_id,
-                  route: @route.id,
-                  time: @date,
-                  direction_id: @direction_id
-                ) != []
-              end
-            }
           />
           <td class="js-tt-cell hidden-no-js" style="padding-left: 0.5rem">
             <div class="m-timetable__row-header"></div>
@@ -293,14 +275,6 @@ defmodule DotcomWeb.Components.Timetable do
               <span class="sr-only">{~t(May not be accessible)}</span>
             <% end %>
           <% end %>
-
-          <.tooltip
-            :if={@alert_for_stop?.(@stop.id)}
-            title={~t(Service alert or delay)}
-            placement={:top}
-          >
-            <.icon name="triangle-exclamation" class="h-4 w-4" aria-hidden="true" />
-          </.tooltip>
         </div>
       </div>
     </th>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -63,8 +63,6 @@
     <% true -> %>
       <%= if assigns[:linear_timetable?] do %>
         <DotcomWeb.Components.Timetable.linear_timetable
-          date={@date}
-          direction_id={@direction_id}
           direction_name={@direction_name}
           formatted_date={@formatted_date}
           header_schedules={@header_schedules}
@@ -78,8 +76,6 @@
         />
       <% else %>
         <DotcomWeb.Components.Timetable.timetable
-          date={@date}
-          direction_id={@direction_id}
           direction_name={@direction_name}
           formatted_date={@formatted_date}
           offset={assigns[:offset]}

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -63,7 +63,6 @@
     <% true -> %>
       <%= if assigns[:linear_timetable?] do %>
         <DotcomWeb.Components.Timetable.linear_timetable
-          alerts={@alerts}
           date={@date}
           direction_id={@direction_id}
           direction_name={@direction_name}
@@ -79,7 +78,6 @@
         />
       <% else %>
         <DotcomWeb.Components.Timetable.timetable
-          alerts={@alerts}
           date={@date}
           direction_id={@direction_id}
           direction_name={@direction_name}


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⛴️ Remove alert icons (from all timetables)](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215424202403218?focus=true)

## Implementation

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExazZ6ODZtNThrYno0cWRuMWkyY3Fhbnp0Mm50dmY0a3gxbXE5dHR6aiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eHjLimfWbRzTzqIfiO/giphy.gif)

## Screenshots
<img width="2004" height="1066" alt="Screenshot 2026-07-08 at 1 13 58 PM" src="https://github.com/user-attachments/assets/871a0a7c-8792-4fc9-be60-4c93a7ab4235" />

## How to test

Look at a [timetable page](http://localhost:4001/schedules/CR-Needham/timetable?schedule_direction[direction_id]=0#direction-filter) where you'd expect to see station alerts (right now there are some on every line except for Greenbush and Kingston, and there are some on the [HIngham/Hull ferry timetable](http://localhost:4001/schedules/Boat-F2H/timetable) as well). Note that the alert icons are no longer visible on this branch. 