### PR TITLE
QF | [WC LateNight] Revert the 6/14 specific hardcoded late night service changes

### DIFF
--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -31,23 +31,11 @@ defmodule Dotcom.UpcomingDepartures.Server do
     _ = Dotcom.Predictions.Manager.subscribe(params)
 
     schedules_fn = fn date ->
-      yesterday_late_night_schedules =
-        if date == ~D[2026-06-14] do
-          @schedules_repo.by_route_ids([route_id],
-            direction_id: direction_id,
-            date: ~D[2026-06-13],
-            stop_ids: [stop_id]
-          )
-        else
-          []
-        end
-
-      yesterday_late_night_schedules ++
-        @schedules_repo.by_route_ids([route_id],
-          direction_id: direction_id,
-          date: date,
-          stop_ids: [stop_id]
-        )
+      @schedules_repo.by_route_ids([route_id],
+        direction_id: direction_id,
+        date: date,
+        stop_ids: [stop_id]
+      )
     end
 
     upcoming_departures_fn = fn predicted_schedules ->

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -211,23 +211,6 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     assign(socket, :last_trip_time, nil)
   end
 
-  # WC special!
-  defp assign_last_trip_time(
-         %{assigns: assigns} = socket,
-         %Date{month: 6, day: 14, year: 2026} = date
-       ) do
-    yesterday_last_scheduled_time = get_last_trip_time(assigns, ~D[2026-06-13])
-
-    if last_trip_has_passed?(yesterday_last_scheduled_time) do
-      assign(socket, :last_trip_time, get_last_trip_time(assigns, date))
-    else
-      # don't reassign the last_trip_time! we'll have to reassign it later.
-      later = ServiceDateRollover.ms_to_next_rollover(yesterday_last_scheduled_time)
-      Process.send_after(self(), {:service_date_rollover, date}, later)
-      assign(socket, :last_trip_time, yesterday_last_scheduled_time)
-    end
-  end
-
   defp assign_last_trip_time(socket, date) do
     assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
   end

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -215,12 +215,6 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
   end
 
-  defp last_trip_has_passed?(nil), do: false
-
-  defp last_trip_has_passed?(time) do
-    @date_time.now() |> DateTime.after?(time)
-  end
-
   defp get_last_trip_time(assigns, date) do
     [assigns.route_id]
     |> @schedules_repo.by_route_ids(


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Revert the 6/14 specific hardcoded late night service changes](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216209843679707?focus=true)

## Implementation

Removed late night stuff for last trip time and late night schedules

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A?

## How to test

I'm not sure...

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
