### PR TITLE
QF | [WC cleanup] Remove World Cup Guide intercepts

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -359,32 +359,6 @@ defmodule DotcomWeb.Components do
   attr(:class, :string, default: "")
 
   @doc """
-  A banner tailor made for the world cup. Default styling color is yellow.
-  """
-  def world_cup_intercept(assigns) do
-    ~H"""
-    <.descriptive_link
-      href="/WorldCup"
-      class={@class}
-      {@rest}
-    >
-      <:title>
-        {~t(Going to a World Cup match at Boston Stadium?)}
-      </:title>
-      <p class="c-descriptive-link__world-cup">
-        {gettext("Read our %{world_cup_link}",
-          world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
-        )
-        |> Phoenix.HTML.raw()}
-      </p>
-    </.descriptive_link>
-    """
-  end
-
-  attr(:rest, :global, include: ~w(disabled))
-  attr(:class, :string, default: "")
-
-  @doc """
   Same as above, but links to the timetable instead
   """
   def boston_stadium_intercept(assigns) do

--- a/lib/dotcom_web/live/trip_planner_live.ex
+++ b/lib/dotcom_web/live/trip_planner_live.ex
@@ -113,10 +113,7 @@ defmodule DotcomWeb.TripPlannerLive do
     ~H"""
     <div class="container">
       <h1>{~t(Trip Planner)}</h1>
-      <.world_cup_intercept
-        class="mb-5"
-        style="background-color: var(--colors-cobalt-80)"
-      />
+
       <div>
         <.input_form class="mb-4" changeset={@input_form.changeset} />
         <div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -12,11 +12,6 @@
   </div>
 </.promo_banner>
 
-<.world_cup_intercept
-  :if={@route.id == "CR-Franklin" || @route.id == "CR-Foxboro"}
-  class="mb-5"
-/>
-
 {DotcomWeb.AlertView.group(
   alerts: @banner_alerts,
   route: @route,

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -12,10 +12,6 @@
 
 <div class="container">
   <div class="page-section">
-    <.world_cup_intercept
-      :if={@stop.name == "Foxboro"}
-      class="mb-3"
-    />
     <.boston_stadium_intercept
       :if={@stop.name == "South Station"}
       class="mb-3"

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -1954,11 +1954,6 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr ""
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3469,11 +3464,6 @@ msgstr ""
 #: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
 msgstr ""
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -1954,11 +1954,6 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr ""
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3469,11 +3464,6 @@ msgstr ""
 #: lib/dotcom_web/views/alert_view.ex
 #, elixir-autogen, elixir-format
 msgid "Rail"
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
 msgstr ""
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -1958,11 +1958,6 @@ msgstr "Obtén sugerencias de viajes"
 msgid "Go"
 msgstr "Ve"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "¿Vas a un partido de la Copa del Mundo en el Boston Stadium?"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3485,11 +3480,6 @@ msgstr "Pregunta"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "ferrocarril"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "Lee nuestro %{world_cup_link}"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -1958,11 +1958,6 @@ msgstr "Obtenez des suggestions de voyage"
 msgid "Go"
 msgstr "Allez"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "Aller à un match de Coupe du Monde au Boston Stadium ?"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3487,11 +3482,6 @@ msgstr "Question"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "rail"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "Lisez notre %{world_cup_link}"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -1958,11 +1958,6 @@ msgstr "Jwenn sijesyon vwayaj"
 msgid "Go"
 msgstr "Ale"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "Ou pral nan yon match koup di mond nan Boston Stadium?"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3478,11 +3473,6 @@ msgstr "Kesyon"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "ranp"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "Li %{world_cup_link}nou an"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -1958,11 +1958,6 @@ msgstr "Receba sugestões de viagem"
 msgid "Go"
 msgstr "Ir"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "Vai assistir a um jogo da Copa do Mundo no Boston Stadium?"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3483,11 +3478,6 @@ msgstr "Pergunta"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "trilho"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "Leia nosso %{world_cup_link}"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -1952,11 +1952,6 @@ msgstr "Nhận gợi ý chuyến đi"
 msgid "Go"
 msgstr "Đi"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "Đi xem một trận đấu World Cup tại Boston Stadium?"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3479,11 +3474,6 @@ msgstr "Câu hỏi"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "đường ray"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "Đọc %{world_cup_link}của chúng tôi"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -1948,11 +1948,6 @@ msgstr "获取旅行建议"
 msgid "Go"
 msgstr "去"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "打算去Boston Stadium看世界杯比赛吗？"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3464,11 +3459,6 @@ msgstr "问题"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "铁路"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "阅读我们的%{world_cup_link}"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -1948,11 +1948,6 @@ msgstr "獲取旅行建議"
 msgid "Go"
 msgstr "去"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Going to a World Cup match at Boston Stadium?"
-msgstr "打算去Boston Stadium看世界盃比賽嗎？"
-
 #: lib/dotcom_web/components/stops/fare_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "Google Pay"
@@ -3464,11 +3459,6 @@ msgstr "問題"
 #, elixir-autogen, elixir-format
 msgid "Rail"
 msgstr "鐵路"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Read our %{world_cup_link}"
-msgstr "閱讀我們的%{world_cup_link}"
 
 #: lib/dotcom_web/templates/customer_support/_service_updates.html.heex
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Remove World Cup Guide intercepts](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427718852478?focus=true)

## Implementation

Removed .world_cup_intercept component and it's uses on trip_planner, stop page, and timetables


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Local - Trip Planner
<img width="523" height="278" alt="Screenshot 2026-07-09 at 2 13 19 PM" src="https://github.com/user-attachments/assets/55f0bddb-6bc3-44ae-955b-9c43049d43c9" />

### Dev - Trip Planner
<img width="510" height="306" alt="Screenshot 2026-07-09 at 2 13 02 PM" src="https://github.com/user-attachments/assets/b624d98f-d167-45d1-ad9f-57c1eccba2a5" />

### Local - Franklin line timetable
<img width="637" height="458" alt="Screenshot 2026-07-09 at 2 15 25 PM" src="https://github.com/user-attachments/assets/d94c3653-22ae-4181-a100-05ac8d8486ce" />

### Dev - Franklin line timetable
<img width="629" height="266" alt="Screenshot 2026-07-09 at 2 15 16 PM" src="https://github.com/user-attachments/assets/c650c23d-861d-43a1-a6bd-e7282e5d023c" />

### Local - Foxboro stop page
<img width="627" height="169" alt="Screenshot 2026-07-09 at 2 17 39 PM" src="https://github.com/user-attachments/assets/5f4fc549-5ab7-407c-bdd6-124add342295" />

### Dev - Foxboro stop page
<img width="623" height="264" alt="Screenshot 2026-07-09 at 2 17 33 PM" src="https://github.com/user-attachments/assets/01b10400-1c32-44dd-aeeb-15724121cb62" />



## How to test

http://localhost:4001/stops/place-FS-0049
http://localhost:4001/schedules/CR-Franklin/timetable
http://localhost:4001/trip-planner

Confirm that the world cup guide CTA has been removed

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
