### PR TITLE
fix(CMS.Repo): avoid caching errors as []

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -55,8 +55,8 @@ defmodule CMS.Repo do
   @spec news_entry_by(Keyword.t()) :: NewsEntry.t() | :not_found
   def news_entry_by(opts) do
     case do_news_entry_by(opts) do
-      [record | _] -> record
-      [] -> :not_found
+      {:ok, api_data} -> Enum.map(api_data, &NewsEntry.from_api/1) |> List.first(:not_found)
+      _ -> :not_found
     end
   end
 
@@ -66,8 +66,13 @@ defmodule CMS.Repo do
               opts: [ttl: 60_000]
             )
   def do_news_entry_by(opts) do
-    case @cms_api.view("/cms/news", opts) do
-      {:ok, api_data} -> Enum.map(api_data, &NewsEntry.from_api/1)
+    @cms_api.view("/cms/news", opts)
+  end
+
+  @spec events(Keyword.t()) :: [Event.t()]
+  def events(opts \\ []) do
+    case do_events(opts) do
+      {:ok, api_data} -> Enum.map(api_data, &Event.from_api/1)
       _ -> []
     end
   end
@@ -78,11 +83,8 @@ defmodule CMS.Repo do
               on_error: :nothing,
               opts: [ttl: @ttl]
             )
-  def events(opts \\ []) do
-    case @cms_api.view("/cms/events", opts) do
-      {:ok, api_data} -> Enum.map(api_data, &Event.from_api/1)
-      _ -> []
-    end
+  defp do_events(opts) do
+    @cms_api.view("/cms/events", opts)
   end
 
   @spec event(integer) :: Event.t() | :not_found
@@ -101,17 +103,21 @@ defmodule CMS.Repo do
     end
   end
 
+  def whats_happening do
+    case do_whats_happening() do
+      {:ok, api_data} -> Enum.map(api_data, &WhatsHappeningItem.from_api/1)
+      _ -> []
+    end
+  end
+
   @decorate cacheable(
               cache: @cache,
               key: "cms.repo|whats-happening",
               on_error: :nothing,
               opts: [ttl: @ttl]
             )
-  def whats_happening do
-    case @cms_api.view("/cms/whats-happening", []) do
-      {:ok, api_data} -> Enum.map(api_data, &WhatsHappeningItem.from_api/1)
-      _ -> []
-    end
+  def do_whats_happening do
+    @cms_api.view("/cms/whats-happening", [])
   end
 
   @spec banner() :: Banner.t() | nil

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -3861,11 +3861,6 @@ msgstr ""
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr ""
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -3861,11 +3861,6 @@ msgstr ""
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr ""
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -3879,11 +3879,6 @@ msgstr "Quejas de servicio"
 msgid "Service Inquiry"
 msgstr "Consulta de servicio"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "alertas de servicio o demora"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -3880,11 +3880,6 @@ msgstr "Service Réclamations"
 msgid "Service Inquiry"
 msgstr "Demande de service"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "alertes de service ou retard"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -3869,11 +3869,6 @@ msgstr "Plent Sèvis"
 msgid "Service Inquiry"
 msgstr "Demann Sèvis"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "avètisman sou sèvis oswa reta"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -3876,11 +3876,6 @@ msgstr "Reclamações de serviço"
 msgid "Service Inquiry"
 msgstr "Consulta de serviço"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "alertas de serviço ou atraso"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -3871,11 +3871,6 @@ msgstr "Khiếu nại dịch vụ"
 msgid "Service Inquiry"
 msgstr "Yêu cầu dịch vụ"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "cảnh báo dịch vụ hoặc trễ chuyến"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -3855,11 +3855,6 @@ msgstr "服务投诉"
 msgid "Service Inquiry"
 msgstr "服务查询"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "服务警报或间歇"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -3855,11 +3855,6 @@ msgstr "服務投訴"
 msgid "Service Inquiry"
 msgstr "服務查詢"
 
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Service alert or delay"
-msgstr "服務警報或間歇"
-
 #: lib/dotcom_web/components/components.ex
 #, elixir-autogen, elixir-format
 msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."


### PR DESCRIPTION
## Scope

Prompted by investigating the missing homepage content reported in [this thread](https://mbta.slack.com/archives/C022MNWN2CU/p1783693246668319) this morning!

## Implementation

The missing content on the page is associated with calls to `CMS.Repo.whats_happening()`. I noticed that its current implementation would cause errors from this call to get cached as empty lists.

### How?

To dissect the initial code:

```elixir
@decorate cacheable(..omitted for brevity)
def whats_happening do
  case @cms_api.view("/cms/whats-happening", []) do
    {:ok, api_data} -> Enum.map(api_data, &WhatsHappeningItem.from_api/1)
    _ -> []
  end
end
```

This `cacheable` decorator function has a default value set for its `:match` function as described [here](https://nebulex.hexdocs.pm/2.6.6/Nebulex.Caching.Decorators.html#module-shared-options), TLDR the following results are *not* cached: `:error`, `nil`, and `{:error, _}` tuples. Which means the above setup obscures errors from the `@cms_api.view/2` call by turning them into `[]`, which in turn **_will_** get cached.

To prevent this from happening, I adjusted this to follow a pattern we use in many places throughout Dotcom:

```elixir
def function_thats_called do
  case other_function_thats_cached do
    {:ok, value} -> (whatever)
    _ -> (whatever we want to obscure the error with)
  end
end

@decorate cacheable(...etc)
def other_function_thats_cached do
  @cms_api.view(...) # something that can actually return errors!
end
```

I took a cursory look for similar things happening elsewhere in the homepage, and adjusted those too.