### PR TITLE
QF | [WC cleanup] Remove Boston Stadium Train tile on homepage

### DIFF
--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -144,7 +144,7 @@ defmodule DotcomWeb.PageView do
   end
 
   def shortcut_icons do
-    [:commuter_rail, :subway, :bus, :ferry, :the_ride, :football]
+    [:commuter_rail, :subway, :bus, :ferry, :the_ride]
     |> Enum.map(&shortcut_icon/1)
   end
 
@@ -169,9 +169,6 @@ defmodule DotcomWeb.PageView do
 
   defp shortcut_link(:commuter_rail),
     do: schedule_path(DotcomWeb.Endpoint, :show, :"commuter-rail")
-
-  defp shortcut_link(:football),
-    do: ~p"/schedules/bostonstadium"
 
   defp shortcut_link(mode), do: schedule_path(DotcomWeb.Endpoint, :show, mode)
 
@@ -198,10 +195,6 @@ defmodule DotcomWeb.PageView do
     ]
   end
 
-  defp shortcut_text(:football) do
-    content_tag(:span, ~t"Boston Stadium Trains")
-  end
-
   defp shortcut_text(mode) do
     [
       mode_name(mode),
@@ -212,7 +205,6 @@ defmodule DotcomWeb.PageView do
   defp shortcut_svg_name(:stations), do: "icon-circle-t-default.svg"
   defp shortcut_svg_name(:the_ride), do: "icon-the-ride-default.svg"
   defp shortcut_svg_name(:commuter_rail), do: shortcut_svg_name(:"commuter-rail")
-  defp shortcut_svg_name(:football), do: "football.svg"
   defp shortcut_svg_name(mode), do: "icon-mode-#{mode}-default.svg"
 
   def schedule_separator do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -735,7 +735,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr ""
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -735,7 +735,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr ""
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -738,7 +738,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "Boston Stadium Boleto de Tren debe comprar con antelación en la app mTicket . Para más información, lee nuestro %{world_cup_link}"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Trenes"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -738,7 +738,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "Boston Stadium billet de train doit être acheté à l’avance sur l’application mTicket . Pour plus d’informations, consultez notre %{world_cup_link}"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Trains"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -738,7 +738,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "Ou dwe achte tikè tren pou Boston Stadium davans sou aplikasyon mTicket la. Pou plis enfòmasyon, li %{world_cup_link}nou an"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Tren Boston Stadium"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -738,7 +738,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "A passagem Boston Stadium Train deve ser comprada antecipadamente no aplicativo mTicket . Para obter mais informações, leia nosso %{world_cup_link}"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Trens Boston Stadium"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -732,7 +732,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "Boston Stadium Train vé phải được mua trước trên ứng dụng mTicket . Để biết thêm thông tin, hãy đọc %{world_cup_link}của chúng tôi."
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium Tàu hỏa"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -729,7 +729,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "前往Boston Stadium火车车票必须提前在mTicket应用程序上购买。 欲了解更多信息，请阅读我们的%{world_cup_link}"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium专列"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -729,7 +729,6 @@ msgid "Boston Stadium Train tickets must be purchased in advance on the mTicket 
 msgstr "Boston Stadium火車票必須提前在mTicket應用程式上購買。 欲了解更多信息，請閱讀我們的%{world_cup_link}"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
-#: lib/dotcom_web/views/page_view.ex
 #, elixir-autogen, elixir-format
 msgid "Boston Stadium Trains"
 msgstr "Boston Stadium專列"

--- a/test/dotcom_web/views/page_view_test.exs
+++ b/test/dotcom_web/views/page_view_test.exs
@@ -43,7 +43,7 @@ defmodule DotcomWeb.PageViewTest do
   describe "shortcut_icons/0" do
     test "renders shortcut icons" do
       icons = PageView.shortcut_icons()
-      assert length(icons) == 6
+      assert length(icons) == 5
 
       icon =
         List.first(icons)


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Remove Boston Stadium Train tile on homepage](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427718852477?focus=true)

## Implementation

Removed the tile and it's supporting functions.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="642" height="349" alt="Screenshot 2026-07-10 at 1 24 02 PM" src="https://github.com/user-attachments/assets/ca52e2e1-9958-4cec-b26c-3c5d9feb2fe9" />



## How to test

http://localhost:4001/  Confirm it's gone

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
