### PR TITLE
fix(fares): Allow grouped fare cards to ingest Summarys

### DIFF
--- a/lib/dotcom/content_rewriters/liquid_objects/fare.ex
+++ b/lib/dotcom/content_rewriters/liquid_objects/fare.ex
@@ -118,6 +118,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
   @spec fare_request(String.t()) :: {:ok, String.t()} | request_error
   def fare_request(string) do
     string
+    |> String.trim()
     |> String.split(":", trim: true)
     |> parse_tokens()
     |> compose_args()
@@ -129,6 +130,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
   def fare_object_request(string) do
     tokens =
       string
+      |> String.trim()
       |> String.split(":", trim: true)
       |> parse_tokens()
 

--- a/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
@@ -1,16 +1,27 @@
 <%= if @fare_cards && length(@fare_cards) == 2 do %>
   <% group_fare_card = List.first(@fare_cards)
 
-  group_fare = fare_from_token(group_fare_card.fare_token)
+  group_fare = fare_from_token(group_fare_card.fare_token) |> dbg()
+
+  group_fare_info =
+    case group_fare do
+      # Put info from Fares.Summary into a more Fares.Fare-like format
+      %{modes: _} ->
+        %{
+          mode: List.first(group_fare.modes),
+          link: %{url: group_fare.url},
+        }
+      _ -> group_fare
+    end
 
   link_class =
-    case group_fare_card.link do
+    case group_fare_info.link do
       nil -> "static"
       _ -> "linked"
     end
 
   card_classes =
-    ["c-fare-card", "grouped", CSSHelpers.atom_to_class(group_fare.mode), link_class]
+    ["c-fare-card", "grouped", CSSHelpers.atom_to_class(group_fare_info.mode), link_class]
     |> Enum.intersperse(" c-fare-card--")
     |> Enum.join("")
 
@@ -20,17 +31,25 @@
       _ -> "u-linked-card #{card_classes}"
     end
 
-  card_title = [
-    content_tag(:span, Fares.Format.name(group_fare), class: "c-fare-card__mode"),
-    " ",
-    content_tag(:span, Fares.Format.duration(group_fare), class: "c-fare-card__duration")
-  ] %>
+  duration = Fares.Format.duration(group_fare)
+
+  card_title =
+    if is_binary(group_fare.name) do
+      group_fare.name
+    else
+      [
+        content_tag(:span, Fares.Format.name(group_fare), class: "c-fare-card__mode"),
+        " ",
+        content_tag(:span, Fares.Format.duration(group_fare), class: "c-fare-card__duration")
+      ]
+    end
+%>
 
   <%= extend_width :cards do %>
     <%= content_tag :div, class: card_classes do %>
       <div class="c-fare-card__header">
         <div class="c-fare-card__icon" aria-hidden="true">
-          {mode_icon(group_fare.mode, :default)}
+          {mode_icon(group_fare_info.mode, :default)}
         </div>
 
         <h3 class="c-fare-card__name">
@@ -44,11 +63,18 @@
 
       <div class="c-multi-column__row row">
         <%= for fare_card <- @fare_cards do %>
-          <% fare = fare_from_token(fare_card.fare_token) %>
+          <%
+            fare = fare_from_token(fare_card.fare_token)
+            price =
+              case fare do
+                %{fares: _} -> Fares.Summary.price_range(fare)
+                _ -> Fares.Format.price(fare)
+              end
+          %>
 
           <div class="c-multi-column__column col-sm-6">
             <div class="c-fare-card__fare h3">
-              {Fares.Format.price(fare)}
+              {price}
             </div>
 
             <%= if fare_card.show_media && Fares.Format.media(fare) do %>

--- a/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
@@ -1,27 +1,22 @@
 <%= if @fare_cards && length(@fare_cards) == 2 do %>
   <% group_fare_card = List.first(@fare_cards)
 
-  group_fare = fare_from_token(group_fare_card.fare_token) |> dbg()
+  group_fare = fare_from_token(group_fare_card.fare_token)
 
-  group_fare_info =
+  group_fare_mode =
     case group_fare do
-      # Put info from Fares.Summary into a more Fares.Fare-like format
-      %{modes: _} ->
-        %{
-          mode: List.first(group_fare.modes),
-          link: %{url: group_fare.url},
-        }
-      _ -> group_fare
+      %{modes: _} -> List.first(group_fare.modes)
+      _ -> group_fare.mode
     end
 
   link_class =
-    case group_fare_info.link do
+    case group_fare_card.link do
       nil -> "static"
       _ -> "linked"
     end
 
   card_classes =
-    ["c-fare-card", "grouped", CSSHelpers.atom_to_class(group_fare_info.mode), link_class]
+    ["c-fare-card", "grouped", CSSHelpers.atom_to_class(group_fare_mode), link_class]
     |> Enum.intersperse(" c-fare-card--")
     |> Enum.join("")
 
@@ -30,8 +25,6 @@
       nil -> card_classes
       _ -> "u-linked-card #{card_classes}"
     end
-
-  duration = Fares.Format.duration(group_fare)
 
   card_title =
     if is_binary(group_fare.name) do
@@ -42,14 +35,13 @@
         " ",
         content_tag(:span, Fares.Format.duration(group_fare), class: "c-fare-card__duration")
       ]
-    end
-%>
+    end %>
 
   <%= extend_width :cards do %>
     <%= content_tag :div, class: card_classes do %>
       <div class="c-fare-card__header">
         <div class="c-fare-card__icon" aria-hidden="true">
-          {mode_icon(group_fare_info.mode, :default)}
+          {mode_icon(group_fare_mode, :default)}
         </div>
 
         <h3 class="c-fare-card__name">
@@ -63,14 +55,13 @@
 
       <div class="c-multi-column__row row">
         <%= for fare_card <- @fare_cards do %>
-          <%
-            fare = fare_from_token(fare_card.fare_token)
-            price =
-              case fare do
-                %{fares: _} -> Fares.Summary.price_range(fare)
-                _ -> Fares.Format.price(fare)
-              end
-          %>
+          <% fare = fare_from_token(fare_card.fare_token)
+
+          price =
+            case fare do
+              %{fares: _} -> Fares.Summary.price_range(fare)
+              _ -> Fares.Format.price(fare)
+            end %>
 
           <div class="c-multi-column__column col-sm-6">
             <div class="c-fare-card__fare h3">

--- a/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
@@ -366,8 +366,17 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.FareTest do
   end
 
   describe "fare_object_request" do
-    test "it handles fare requests with trailing spaces" do
-      assert fare_request("subway ") == {:ok, "$2.40"}
+    test "it handles fare object requests with trailing spaces" do
+      result =
+        Repo.all(
+          name: :ferry_winthrop,
+          includes_media: :mticket,
+          reduced: nil,
+          duration: :single_trip
+        )
+        |> List.first()
+
+      assert fare_object_request("ferry_winthrop ") == result
     end
 
     test "it handles fare requests for a given mode name and media" do

--- a/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
@@ -6,6 +6,10 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.FareTest do
   alias Fares.{Fare, Format, Repo, Summary}
 
   describe "fare_request/1" do
+    test "it handles request strings that include trailing spaces" do
+      assert fare_request("subway ") == {:ok, "$2.40"}
+    end
+
     test "it handles fare requests for a given mode name and media" do
       assert [
                name: :local_bus,
@@ -362,6 +366,10 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.FareTest do
   end
 
   describe "fare_object_request" do
+    test "it handles fare requests with trailing spaces" do
+      assert fare_request("subway ") == {:ok, "$2.40"}
+    end
+
     test "it handles fare requests for a given mode name and media" do
       result =
         Repo.all(name: :local_bus, includes_media: :cash, reduced: nil, duration: :single_trip)


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞 500 error when visiting the latest (preview) version of the ferry fares page](https://app.asana.com/1/15492006741476/project/1213039586590742/task/1215975015154292)

## Implementation
Changes a few group_fare_card calls to handle the case that the fare returned from `fare_from_token` is a Summary instead of a Fare.

Additionally trims whitespace from tokens so `ferry_winthrop ` (note the space) doesn't result in an `invalid` fare

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before
before fixing grouped fare card:
<img width="442" height="494" alt="image" src="https://github.com/user-attachments/assets/e1e8b073-ec79-4aea-b758-35ddf40ab709" />

after fixing grouped fare card, before trimming single tokens: 
<img width="797" height="690" alt="image" src="https://github.com/user-attachments/assets/deefc589-7c7a-4aa2-b041-cc2403e3b325" />




After
<img width="798" height="692" alt="image" src="https://github.com/user-attachments/assets/9ae88411-f395-4275-8705-cddaf428ecc9" />

## How to test
Verify that this ferry fare [preview page](http://localhost:4001/fares/ferry-fares?preview=&vid=92067&nid=3643) loads and properly displays the grouped fare and the Winthrop fare.
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
