### PR TITLE
QF | [WC cleanup] Remove World Cup Guide link in menu

### DIFF
--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -97,7 +97,6 @@ defmodule DotcomWeb.LayoutView do
           %{
             sub_menu_section: ~t(Plan Your Journey),
             links: [
-              {~t(World Cup Guide), "/WorldCup", :internal_link},
               {~t(Trip Planner), "/trip-planner", :internal_link},
               {~t(Service Alerts), "/alerts", :internal_link},
               {~t(Sign Up for Service Alerts), "https://alerts.mbta.com/", :external_link},
@@ -257,23 +256,6 @@ defmodule DotcomWeb.LayoutView do
 
   def language_link_tuple(%Dotcom.Locale{code: code, endonym: endonym}) do
     {endonym, "?locale=#{code}", :internal_link}
-  end
-
-  def render_nav_link({link_name, href = "/WorldCup", _}) do
-    icon =
-      content_tag(:img, "",
-        src: "/icon-svg/football.svg",
-        class: "icon-small-inline -top-[0.125em]"
-      )
-
-    link_content = [content_tag(:div, [icon, content_tag(:span, link_name)])]
-    attrs = ["data-nav": "link", href: href, class: "m-menu__link"]
-
-    content_tag(
-      :a,
-      link_content,
-      attrs
-    )
   end
 
   def render_nav_link({link_name, href, link_host}) do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5032,7 +5032,6 @@ msgid "Working"
 msgstr ""
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -5032,7 +5032,6 @@ msgid "Working"
 msgstr ""
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5053,7 +5053,6 @@ msgid "Working"
 msgstr "Funcionamiento"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guía de la Copa del Mundo"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5054,7 +5054,6 @@ msgid "Working"
 msgstr "Fonctionnement"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guide de la Coupe du Monde"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5042,7 +5042,6 @@ msgid "Working"
 msgstr "Ap travay"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Gid pou koup di mond lan"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5049,7 +5049,6 @@ msgid "Working"
 msgstr "Trabalhando"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Guia da Copa do Mundo"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5046,7 +5046,6 @@ msgid "Working"
 msgstr "Đang làm việc"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "Hướng dẫn World Cup"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5026,7 +5026,6 @@ msgid "Working"
 msgstr "在职的"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "世界杯指南"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5026,7 +5026,6 @@ msgid "Working"
 msgstr "在職的"
 
 #: lib/dotcom_web/live/world_cup_timetable_live.html.heex
-#: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "World Cup Guide"
 msgstr "世界盃指南"


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Remove World Cup Guide link in menu](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427718852476?focus=true)

## Implementation

Removed the world cup guide link and supporting function (to render the ⚽️) from the main menu.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="517" height="458" alt="Screenshot 2026-07-10 at 1 33 04 PM" src="https://github.com/user-attachments/assets/bae80a33-f235-42aa-aeac-6abdc992ab7d" />
<img width="303" height="353" alt="Screenshot 2026-07-10 at 1 32 53 PM" src="https://github.com/user-attachments/assets/5f5220c6-62e8-471e-8ff9-9e2a4885fefa" />


## How to test

http://localhost:4001/ - Click on the main menu and confirm that the World Cup Guide link is gone.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
