### PR TITLE
hotfix(TripPlanner): Don't try to render non-string errors in `<.result_summary />`

### DIFF
--- a/lib/dotcom_web/components/trip_planner/results_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/results_summary.ex
@@ -36,11 +36,21 @@ defmodule DotcomWeb.Components.TripPlanner.ResultsSummary do
     """
   end
 
-  defp results_feedback(%{results: %{error: error}} = assigns) when not is_nil(error) do
+  defp results_feedback(%{results: %{error: error}} = assigns) when is_binary(error) do
     ~H"""
     <.feedback kind={:error}>
       <span data-test="results-summary:error">
         {@results.error}
+      </span>
+    </.feedback>
+    """
+  end
+
+  defp results_feedback(%{results: %{error: error}} = assigns) when not is_nil(error) do
+    ~H"""
+    <.feedback kind={:error}>
+      <span data-test="results-summary:error">
+        {~t"Something went wrong. Please try again later."}
       </span>
     </.feedback>
     """

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5516,3 +5516,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -5516,3 +5516,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr ""
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5538,3 +5538,8 @@ msgstr "Zona 1A del Puerto Interior"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop y Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5539,3 +5539,8 @@ msgstr "Zone 1A du port intérieur"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop et Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5526,3 +5526,8 @@ msgstr "Zòn Pò Enteryè 1A"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop ak Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5534,3 +5534,8 @@ msgstr "Zona 1A do Porto Interior"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Balsa Winthrop e Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5530,3 +5530,8 @@ msgstr "Khu vực cảng nội địa 1A"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop và Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5510,3 +5510,8 @@ msgstr "内港区 1A"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop和Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5510,3 +5510,8 @@ msgstr "內港區 1A"
 #, elixir-autogen, elixir-format
 msgid "Winthrop and Quincy Ferry"
 msgstr "Winthrop和Quincy Ferry"
+
+#: lib/dotcom_web/components/trip_planner/results_summary.ex
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again later."
+msgstr ""


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

Why does this PR exist? _To resolve an OTP outage_

No ticket.

## Implementation

The current implementation of `<.results_feedback />` has a pattern-match where it can take an `error` assign, but its implementation assumes that `error` will be a string. However, if OTP is down, then the error it gets will be a `Finch.TransportError`, which then causes the `<.results_feedback />` component to crash. That crash then causes the LiveView to try again, which sends another request to OTP.

This, in effect, was causing Dotcom to DDoS OTP.

## Screenshots

<img width="2140" height="882" alt="Screenshot 2026-07-10 at 2 22 16 PM" src="https://github.com/user-attachments/assets/bd940032-19b8-4417-bba7-d5239a3e458d" />

Snazzy new error message!

## How to test

Make sure that your `OPEN_TRIP_PLANNER_URL` is pointed to an address that doesn't work (e.g. `localhost:8888` if you don't have anything running at that port), and then try to plan a trip. On `main`, you'll see the loading spinner stick around, and you'll see an infinite number of `Finch.TransportError`'s in the logs (implying that we're retrying over and over and over and...). On this branch, you'll see a nice error message, and no log noise at all.