### PR TITLE
fix(StopController): remove AlertsByTimeframe

### DIFF
--- a/lib/dotcom_web/controllers/bus_stop_change_controller.ex
+++ b/lib/dotcom_web/controllers/bus_stop_change_controller.ex
@@ -17,7 +17,8 @@ defmodule DotcomWeb.BusStopChangeController do
   # groups into current & upcoming
   plug(DotcomWeb.Plugs.AlertsByTimeframe)
 
-  def show(%{query_params: %{"alerts_timeframe" => _alerts_timeframe}} = conn, _params) do
+  def show(%{query_params: %{"alerts_timeframe" => alerts_timeframe}} = conn, _params)
+      when alerts_timeframe in ["current", "upcoming", ""] do
     conn
     # Don't let Google crawl this page
     |> put_resp_header("x-robots-tag", "noindex")

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -31,8 +31,6 @@ defmodule DotcomWeb.StopController do
           routes: [route_with_directions]
         }
 
-  plug(DotcomWeb.Plugs.AlertsByTimeframe)
-
   def index(conn, _params) do
     redirect(conn, to: stop_path(conn, :show, :subway))
   end

--- a/lib/dotcom_web/plugs/alerts_by_timeframe.ex
+++ b/lib/dotcom_web/plugs/alerts_by_timeframe.ex
@@ -3,9 +3,7 @@ defmodule DotcomWeb.Plugs.AlertsByTimeframe do
   Filters alerts by timeframe. Used by pages that list alerts
   and have a timeframe filter:
 
-  - /alerts
-  - /schedules/ROUTE/alerts
-  - /stops/STOP/alerts
+  - /bus-stop-changes
   """
 
   use Plug.Builder


### PR DESCRIPTION

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞 Stop page | KeyError: key :alerts not found](https://app.asana.com/1/15492006741476/project/385363666817452/task/1216391479593930?focus=true)

## Implementation

Two different Sentry errors indicate the `AlertsByTimeframe` plug was erroring on stop pages because it needed `conn.assigns.alerts`.

However... the stop pages don't make use of `AlertsByTimeframe` (which segmented alerts into current and upcoming) anymore. So it turns out we could get rid of this call entirely.

The final place that plug is still used in is `BusStopChangesController`, which handles `/bus-stop-changes`.

## How to test

No more error on stop pages!