### PR TITLE
chore: Add a mix task for deploying with the right tag

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,12 +4,12 @@
 
 This can be done on GitHub Actions via the following:
 
-- Create a tag following this format
-  - Pull the latest main locally
-  - Create a tag `git tag year.month.day.release_number` (ex. `2023.12.18.01`)
-  - Push the tag `git push origin --tags`
-- [Create a release](https://github.com/mbta/dotcom/releases). Select a relevant tag, follow the naming convention, click "generate release notes", and publish. This will trigger the [Deploy: release](.github/workflows/deploy-release.yml) workflow that will kick off a deploy to production.
-- [Manually](https://github.com/mbta/dotcom/actions/workflows/deploy-manual.yml). The [Deploy: selected branch](.github/workflows/deploy-manual.yml) workflow can be used to deploy to production by selecting the "prod" environment.
+- Automatic-ish.
+  - Run `mix deploy.prod`. This will open a version of the [New Release page](https://github.com/mbta/dotcom/releases/new) with a tag pre-populated.
+  - Check that it follows the tag naming convention of `year.month.day.release_number` (ex. `2023.12.18.01`), and update if necessary.
+  - Click "Generate release notes" and publish. This will trigger the [Deploy: release](.github/workflows/deploy-release.yml) workflow that will kick off a deploy to production.
+- [Manually](https://github.com/mbta/dotcom/actions/workflows/deploy-manual.yml).
+  - The [Deploy: selected branch](.github/workflows/deploy-manual.yml) workflow can be used to deploy to production by selecting the "prod" environment. This should be done only in emergencies.
 
 ![](run_workflow.png)
 

--- a/lib/mix/tasks/deploy.prod.ex
+++ b/lib/mix/tasks/deploy.prod.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Deploy.Prod do
   def run(_) do
     # This is necessary in order to call
     # `Dotcom.Utils.DateTime.today/0` below.
-    Application.ensure_all_started(:tzdata)
+    _ = Application.ensure_all_started(:tzdata)
 
     %{"previous_date" => previous_date, "previous_count" => previous_count} =
       latest_tag() |> parse_previous_date_and_count()
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Deploy.Prod do
   # description of the form `<latest_tag>-<other_stuff>`... with
   # `-<other_stuff>` trimmed off by `--abbrev=0`).
   defp latest_tag() do
-    System.cmd("git", ["fetch"])
+    _ = System.cmd("git", ["fetch"])
 
     System.cmd("git", ["describe", "origin/main", "--tags", "--abbrev=0"])
     |> then(fn {tag, 0} -> tag end)

--- a/lib/mix/tasks/deploy.prod.ex
+++ b/lib/mix/tasks/deploy.prod.ex
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.Deploy.Prod do
+  @moduledoc """
+  Open the Github Releases page that triggers a production deploy
+  """
+  use Mix.Task
+
+  @shortdoc "Open the Github Releases page that allows us to trigger a production deploy"
+  @spec run([binary]) :: any
+  def run(_) do
+    # This is necessary in order to call
+    # `Dotcom.Utils.DateTime.today/0` below.
+    Application.ensure_all_started(:tzdata)
+
+    %{"previous_date" => previous_date, "previous_count" => previous_count} =
+      latest_tag() |> parse_previous_date_and_count()
+
+    today = today_formatted()
+    count = new_count_formatted(previous_count, same_day?: previous_date == today)
+
+    new_release = "#{today}.#{count}"
+
+    System.cmd("open", [
+      "https://github.com/mbta/dotcom/releases/new?tag=#{new_release}"
+    ])
+  end
+
+  # Left-pads a numerical count to a length of 2 -
+  # e.g. format_count(2) == "02".
+  defp format_count(count) do
+    count
+    |> Integer.to_string()
+    |> String.pad_leading(2, "0")
+  end
+
+  # Fetches the latest tag using `git describe` (which returns a
+  # description of the form `<latest_tag>-<other_stuff>`... with
+  # `-<other_stuff>` trimmed off by `--abbrev=0`).
+  defp latest_tag() do
+    System.cmd("git", ["fetch"])
+
+    System.cmd("git", ["describe", "origin/main", "--tags", "--abbrev=0"])
+    |> then(fn {tag, 0} -> tag end)
+    |> String.trim()
+  end
+
+  # Increments and left-pads the previous count to a length of 2 if
+  # the previous release was on the same day. Returns "01" if the
+  # previous release was on a different day.
+  defp new_count_formatted(previous_count, same_day?: true),
+    do: format_count(parse_int!(previous_count) + 1)
+
+  defp new_count_formatted(_previous_count, same_day?: false), do: "01"
+
+  # A simpler string-to-int parse function to go straight from (e.g.)
+  # "02" -> 2.
+  defp parse_int!(str) do
+    str
+    |> Integer.parse()
+    |> then(fn {previous_count, ""} -> previous_count end)
+  end
+
+  # Splits a release tag of `YYYY.MM.DD.NN` (where `NN` is the count -
+  # "01" for the first release of a given day, "02" for the next, etc)
+  # into the date and the count. e.g. "2020.01.02.03" will get split
+  # into "2020.01.02" and "03".
+  defp parse_previous_date_and_count(tag) do
+    Regex.named_captures(~r/(?<previous_date>.*)\.(?<previous_count>\d\d)/, tag)
+  end
+
+  # Formats a date according to our release tag pattern of
+  # `YYYY.MM.DD`
+  defp today_formatted() do
+    Dotcom.Utils.DateTime.today()
+    |> Date.to_string()
+    |> String.replace("-", ".")
+  end
+end


### PR DESCRIPTION
## Scope

We've had a few instances recently of manually typing out the wrong tag number, and this is the sort of thing that computers can do quite well! So I stole a bit of [my work](https://github.com/mbta/skate/pull/2538) from my days on Skate, and this is the result!

## How to test

Run `mix deploy.prod` and see it open a browser window with the right tag selected.

You can also fiddle with the `today_formatted()` function if you want to pretend to be running the script on a different day, in order to test out the `same_day?` logic.

(Don't worry - the mix task won't actually execute a deploy - it just opens the [New Release page](https://github.com/mbta/dotcom/releases/new) with the right tag set - you'll still have to publish the release and approve the Github Action before anything goes to prod!)