### PR TITLE
cleanup: Fix warnings in `<.cta />` component

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -475,26 +475,49 @@ defmodule DotcomWeb.Components do
   attr :icon_type, :string, required: false, default: "icon-svg"
   attr :rest, :global
 
-  def cta(assigns) do
+  slot :inner_block
+
+  def cta(%{link: link} = assigns) when link != nil do
     ~H"""
-    <.dynamic_tag
-      tag_name={
-        if @link do
-          "a"
-        else
-          "div"
-        end
-      }
-      href={@link}
-      class={"cta-a gap-2 " <> @classes}
-      {@rest}
-    >
+    <.cta_wrapper class={"cta-a gap-2 " <> @classes} link={@link} {@rest}>
       <.icon :if={@icon} type={@icon_type} name={@icon} class="size-5 shrink-0" aria-hidden />
       <span class="leading-tight grow">
         {render_slot(@inner_block)}
       </span>
       <span :if={@arrow} aria-hidden="true">&#8594;</span>
-    </.dynamic_tag>
+    </.cta_wrapper>
+    """
+  end
+
+  def cta(assigns) do
+    ~H"""
+    <.cta_wrapper class={"cta-a gap-2 " <> @classes} link={@link} {@rest}>
+      <.icon :if={@icon} type={@icon_type} name={@icon} class="size-5 shrink-0" aria-hidden />
+      <span class="leading-tight grow">
+        {render_slot(@inner_block)}
+      </span>
+      <span :if={@arrow} aria-hidden="true">&#8594;</span>
+    </.cta_wrapper>
+    """
+  end
+
+  attr :link, :any, required: false, default: nil
+  attr :rest, :global
+  slot :inner_block
+
+  defp cta_wrapper(%{link: link} = assigns) when link != nil do
+    ~H"""
+    <a href={@link} {@rest}>
+      {render_slot(@inner_block)}
+    </a>
+    """
+  end
+
+  defp cta_wrapper(assigns) do
+    ~H"""
+    <div {@rest}>
+      {render_slot(@inner_block)}
+    </div>
     """
   end
 end

--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -477,18 +477,6 @@ defmodule DotcomWeb.Components do
 
   slot :inner_block
 
-  def cta(%{link: link} = assigns) when link != nil do
-    ~H"""
-    <.cta_wrapper class={"cta-a gap-2 " <> @classes} link={@link} {@rest}>
-      <.icon :if={@icon} type={@icon_type} name={@icon} class="size-5 shrink-0" aria-hidden />
-      <span class="leading-tight grow">
-        {render_slot(@inner_block)}
-      </span>
-      <span :if={@arrow} aria-hidden="true">&#8594;</span>
-    </.cta_wrapper>
-    """
-  end
-
   def cta(assigns) do
     ~H"""
     <.cta_wrapper class={"cta-a gap-2 " <> @classes} link={@link} {@rest}>


### PR DESCRIPTION
## Scope

This cleans up some warnings that show up when running `mix compile`.

```elixir
     warning: undefined slot "inner_block" for component DotcomWeb.Components.cta/1
     │
 119 │         <.cta
     │         ~~~~~
     │
     └─ lib/dotcom_web/live/trip_planner_live.ex:119: (file)

     warning: undefined slot "inner_block" for component DotcomWeb.Components.cta/1
     │
 419 │     <.cta
     │     ~~~~~
     │
     └─ lib/dotcom_web/components/components.ex:419: (file)

     warning: undefined slot "inner_block" for component DotcomWeb.Components.cta/1
     │
 455 │     <.cta
     │     ~~~~~
     │
     └─ lib/dotcom_web/components/components.ex:455: (file)

     warning: undefined attribute "href" for component Phoenix.Component.dynamic_tag/1
     │
 488 │       href={@link}
     │       ~~~~~~~~~~~~
     │
     └─ lib/dotcom_web/components/components.ex:488: (file)
```

## Implementation

Two main changes:
- Define `slot :inner_block` as part of the `def cta(assigns)` definition.
- Replace `<.dynamic_tag />` (which is cool, but doesn't support `href`) with a custom `<.cta_wrapper />` that does the right thing with the `@link` assign.

## How to test

There are `<.cta />` components on [the trip planner page with "Prefer accessible routes" checked](http://localhost:4001/trip-planner?plan=hsQVX3VudXNlZF9kYXRldGltZV90eXBlxADECGRhdGV0aW1lxCAyMDI2LTA3LTE1VDE1OjEwOjA2Ljg4ODAzMC0wNDowMMQEZnJvbYTECGxhdGl0dWRlxAk0Mi4zNjUzOTbECWxvbmdpdHVkZcQKLTcxLjAxNzU0N8QEbmFtZcQUQm9zdG9uIExvZ2FuIEFpcnBvcnTEB3N0b3BfaWTEAMQFbW9kZXOJxANCVVPEBHRydWXEBUZFUlJZxAR0cnVlxARSQUlMxAR0cnVlxAZTVUJXQVnEBHRydWXEDl9wZXJzaXN0ZW50X2lkxAEwxAtfdW51c2VkX0JVU8QAxA1fdW51c2VkX0ZFUlJZxADEDF91bnVzZWRfUkFJTMQAxA5fdW51c2VkX1NVQldBWcQAxAJ0b4TECGxhdGl0dWRlxAk0Mi4zNjU1NzfECWxvbmdpdHVkZcQJLTcxLjA2MTI5xARuYW1lxA1Ob3J0aCBTdGF0aW9uxAdzdG9wX2lkxAtwbGFjZS1ub3J0aMQKd2hlZWxjaGFpcsQEdHJ1ZQ==) (`<div />`) and on [the departures page](http://localhost:4001/departures?route_id=Orange&direction_id=0&stop_id=place-ccmnl) when viewed in mobile (`<a />`). Take a look at those and make sure they look right!