### PR TITLE
fix(departures): Show `Stopped at Station` for vehicle status when appropriate

### DIFF
--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -207,7 +207,6 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
            %PredictedSchedule{
              prediction: %Prediction{
                arrival_time: nil,
-               departure_time: departure_time,
                trip: %Trip{id: prediction_trip_id}
              }
            } = ps
@@ -219,7 +218,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
 
     %VehicleInfo{
       crowding: crowding,
-      departure_time: {:time, departure_time |> truncate(:minute)},
+      departure_time: trip_stop_time(ps),
       platform_name: platform_name(ps),
       status: :waiting_to_depart,
       stop_id: stop.parent_id || stop.id,

--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -215,7 +215,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
 
     %VehicleInfo{
       crowding: crowding,
-      departure_time: departure_time,
+      departure_time: departure_time |> truncate(:minute),
       platform_name: platform_name(ps),
       status: :waiting_to_depart,
       stop_id: stop.parent_id || stop.id,

--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -15,10 +15,14 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
           vehicle_info: nil | __MODULE__.VehicleInfo.t()
         }
 
+  @type time_t() :: {:time, DateTime.t()} | {:status, String.t()}
+
   defmodule TripStop do
     @moduledoc """
     A simple struct representing the stops visited and arrival times as part of a `TripDetails`.
     """
+
+    alias Dotcom.ScheduleFinder.TripDetails
 
     defstruct [
       :cancelled?,
@@ -29,15 +33,13 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
       :time
     ]
 
-    @type time_t() :: {:time, DateTime.t()} | {:status, String.t()}
-
     @type t :: %__MODULE__{
             cancelled?: boolean(),
             platform_name: nil | String.t(),
             stop_id: Stops.Stop.id_t(),
             stop_name: String.t(),
             stop_sequence: non_neg_integer(),
-            time: time_t()
+            time: TripDetails.time_t()
           }
   end
 
@@ -45,6 +47,8 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
     @moduledoc """
     A struct representing the status of a vehicle associated with the trip
     """
+
+    alias Dotcom.ScheduleFinder.TripDetails
 
     defstruct [
       :crowding,
@@ -63,7 +67,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
 
     @type t :: %__MODULE__{
             crowding: Vehicles.Vehicle.crowding(),
-            departure_time: DateTime.t(),
+            departure_time: TripDetails.time_t(),
             platform_name: nil | String.t(),
             status: trip_vehicle_status_t(),
             stop_id: Stops.Stop.id_t(),
@@ -179,7 +183,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
          | _
        ]) do
     %VehicleInfo{
-      departure_time: departure_time |> truncate(:minute),
+      departure_time: {:time, departure_time |> truncate(:minute)},
       platform_name: platform_name(ps),
       status: :scheduled_to_depart,
       stop_id: stop.id,
@@ -215,7 +219,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
 
     %VehicleInfo{
       crowding: crowding,
-      departure_time: departure_time |> truncate(:minute),
+      departure_time: {:time, departure_time |> truncate(:minute)},
       platform_name: platform_name(ps),
       status: :waiting_to_depart,
       stop_id: stop.parent_id || stop.id,

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -427,7 +427,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
           />
         </div>
         <div :if={@trip_details.vehicle_info.departure_time}>
-          <Departures.formatted_time time={@trip_details.vehicle_info.departure_time} />
+          <.trip_stop_time time={@trip_details.vehicle_info.departure_time} />
         </div>
       </.lined_list_item>
       <details

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2702,6 +2702,42 @@ defmodule Dotcom.UpcomingDeparturesTest do
       assert trip_details.vehicle_info.departure_time == {:time, time |> truncate(:minute)}
     end
 
+    test "shows a prediction status with a :waiting_to_depart subway vehicle when present" do
+      # Setup
+      %{
+        predictions: predictions,
+        predicted_departure_times: [time | _],
+        prediction_statuses: [origin_prediction_status, _, _],
+        stop_sequences: [_, stop_seq, _],
+        stops: [_, stop, _],
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          include_prediction_statuses: true,
+          route_factory_types: [:subway_route],
+          vehicle_stop_index: 0,
+          vehicle_statuses: [:stopped]
+        )
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      trip_details =
+        UpcomingDepartures.trip_details(%{
+          now: Generators.ServiceDateTime.earlier_on_day(time),
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
+        })
+
+      # Verify
+      assert trip_details.vehicle_info.status == :waiting_to_depart
+      assert trip_details.vehicle_info.departure_time == {:status, origin_prediction_status}
+    end
+
     test "does not show :scheduled_to_depart if the vehicle is underway, even when the first schedule is in the future" do
       # Setup
       %{

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2511,6 +2511,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       assert trip_details.vehicle_info.status == :scheduled_to_depart
+      assert trip_details.vehicle_info.departure_time == departure_time |> truncate(:minute)
     end
 
     test "shows a vehicle status of :location_unavailable if the trip has no predictions and some schedules are in the past" do
@@ -2658,6 +2659,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       assert trip_details.vehicle_info.status == :waiting_to_depart
+      assert trip_details.vehicle_info.departure_time == time |> truncate(:minute)
     end
 
     test "does not show :scheduled_to_depart if the vehicle is underway, even when the first schedule is in the future" do

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2194,6 +2194,44 @@ defmodule Dotcom.UpcomingDeparturesTest do
              ]
     end
 
+    test "puts a status in other stops' times for subway trips when present" do
+      # Setup
+      %{
+        predictions: predictions,
+        predicted_arrival_times: [_, time, _],
+        prediction_statuses: [status_before, status_here, status_after],
+        stops: [_, stop, _],
+        stop_sequences: [_, seq, _],
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          include_prediction_statuses: true,
+          route_factory_types: [:subway_route],
+          vehicle_stop_index: 0
+        )
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      trip_details =
+        UpcomingDepartures.trip_details(%{
+          now: Generators.ServiceDateTime.earlier_on_day(time),
+          trip_id: trip_id,
+          stop_sequence: seq,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert trip_details.stops_before |> Enum.map(& &1.time) == [{:status, status_before}]
+
+      assert trip_details.stop.time == {:status, status_here}
+
+      assert trip_details.stops_after |> Enum.map(& &1.time) == [{:status, status_after}]
+    end
+
     test "splits stops_before and stops_after based on stop_sequence if a trip visits a stop multiple times" do
       # Setup
       [stop_id_multi, stop_id_1, stop_id_2, stop_id_3] =

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2549,7 +2549,9 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       assert trip_details.vehicle_info.status == :scheduled_to_depart
-      assert trip_details.vehicle_info.departure_time == departure_time |> truncate(:minute)
+
+      assert trip_details.vehicle_info.departure_time ==
+               {:time, departure_time |> truncate(:minute)}
     end
 
     test "shows a vehicle status of :location_unavailable if the trip has no predictions and some schedules are in the past" do
@@ -2697,7 +2699,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       assert trip_details.vehicle_info.status == :waiting_to_depart
-      assert trip_details.vehicle_info.departure_time == time |> truncate(:minute)
+      assert trip_details.vehicle_info.departure_time == {:time, time |> truncate(:minute)}
     end
 
     test "does not show :scheduled_to_depart if the vehicle is underway, even when the first schedule is in the future" do


### PR DESCRIPTION
## Scope

**Asana Ticket:** [📅🔎 Show "Stopped at Station" for vehicle status when appropriate](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1215284963553513?focus=true)

## Implementation

> [!TIP]
> This PR may be easiest to review commit-by-commit.

A brief summary of the whole thing:
- Use `{:time, time}` instead of just a straight time for vehicle status departure time.
- Call `trip_stop_time/1` (which already does the right thing and is used for trip-stop rows in trip details) in order to get either `{:time, time}` or `{:status, status}`.
- Augment test coverage.

## Screenshots

<img width="2004" height="1620" alt="Screenshot 2026-07-17 at 8 43 44 AM" src="https://github.com/user-attachments/assets/f933a925-0da6-49d8-a18b-073f8ffefe1d" />

## How to test

I tested by opening all of the terminus departure pages, and waiting until one of them showed `Stopped at Station`. Then I could compare this branch versus production.

- [Alewife](http://localhost:4001/departures?route_id=Red&direction_id=0&stop_id=place-alfcl)
- [Braintree](http://localhost:4001/departures?route_id=Red&direction_id=1&stop_id=place-brntn)
- [Ashmont](http://localhost:4001/departures?route_id=Red&direction_id=1&stop_id=place-asmnl)
- [Oak Grove](http://localhost:4001/departures?route_id=Orange&direction_id=0&stop_id=place-ogmnl)
- [Forest Hills](http://localhost:4001/departures?route_id=Orange&direction_id=1&stop_id=place-forhl)
- [Wonderland](http://localhost:4001/departures?route_id=Blue&direction_id=0&stop_id=place-wondl)
- [Bowdoin](http://localhost:4001/departures?route_id=Blue&direction_id=1&stop_id=place-bomnl)
