### PR TITLE
chore(Routes.Route): remove param override

### DIFF
--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -307,12 +307,6 @@ defmodule Routes.Route do
   end
 end
 
-defimpl Phoenix.Param, for: Routes.Route do
-  alias Routes.Route
-  def to_param(%Route{id: "Green" <> _rest}), do: "Green"
-  def to_param(%Route{id: id}), do: id
-end
-
 defimpl Poison.Encoder, for: Routes.Route do
   def encode(
         %Routes.Route{

--- a/test/routes/route_test.exs
+++ b/test/routes/route_test.exs
@@ -212,25 +212,6 @@ defmodule Routes.RouteTest do
     end
   end
 
-  describe "Phoenix.Param.to_param" do
-    test "Green routes are normalized to Green" do
-      green_e = %Route{id: "Green-E"}
-      green_b = %Route{id: "Green-B"}
-      green_c = %Route{id: "Green-C"}
-      green_d = %Route{id: "Green-D"}
-      to_param = &Phoenix.Param.Routes.Route.to_param/1
-
-      for route <- [green_e, green_b, green_c, green_d] do
-        assert to_param.(route) == "Green"
-      end
-    end
-
-    test "Mattapan is kept as mattapan" do
-      mattapan = %Route{id: "Mattapan"}
-      assert Phoenix.Param.Routes.Route.to_param(mattapan) == "Mattapan"
-    end
-  end
-
   describe "hidden?/1" do
     test "Returns true for hidden routes" do
       hidden_routes = [


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞 GL search results aren't working for branches](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214902494254017?focus=true)

## Implementation

We used the `Phoenix.Param` [protocol](https://phoenix.hexdocs.pm/Phoenix.Param.html) to convert the Route struct into URL parameters, but I don't think we wish to convert all Green Line branch links to direct to the combined Green Line page anymore.

So I deleted this.

## How to test

`Util.site_path(:schedule_path, [:show, Routes.Repo.get("Green-B")])` outputs `"/schedules/Green-B"` instead of `"/schedules/Green"`
