### PR TITLE
feat(SystemStatus.SubwayCache): save status

### DIFF
--- a/lib/dotcom/system_status/subway_cache.ex
+++ b/lib/dotcom/system_status/subway_cache.ex
@@ -23,8 +23,14 @@ defmodule Dotcom.SystemStatus.SubwayCache do
   def subway_status() do
     :ets.lookup(:subway_status, "status")
     |> case do
-      [{"status", status}] -> status
-      _ -> status()
+      [{"status", status}] ->
+        status
+
+      _ ->
+        status = status()
+        :ets.insert(:subway_status, {"status", status})
+
+        status
     end
   end
 


### PR DESCRIPTION
Just noticed this while I was inspecting memory usage on the homepage. The homepage can call `subway_status()` and trigger a new computation of Subway Status. This PR enhances that by not only sending the newly-fetched status to the homepage, but also saving it into the ETS table for later retrieval!