### PR TITLE
feat(Dotcom.Telemetry): more memory metrics

### DIFF
--- a/lib/dotcom/telemetry.ex
+++ b/lib/dotcom/telemetry.ex
@@ -39,7 +39,12 @@ defmodule Dotcom.Telemetry do
 
   def metrics do
     [
-      Metrics.last_value("vm.memory.total", unit: :byte),
+      Metrics.last_value("vm.memory.total", unit: {:byte, :kilobyte}),
+      Metrics.last_value("vm.memory.processes", unit: {:byte, :kilobyte}),
+      Metrics.last_value("vm.memory.atom", unit: {:byte, :kilobyte}),
+      Metrics.last_value("vm.memory.binary", unit: {:byte, :kilobyte}),
+      Metrics.last_value("vm.memory.code", unit: {:byte, :kilobyte}),
+      Metrics.last_value("vm.memory.ets", unit: {:byte, :kilobyte}),
       Metrics.last_value("vm.total_run_queue_lengths.total"),
       Metrics.last_value("vm.total_run_queue_lengths.cpu"),
       Metrics.last_value("vm.system_counts.process_count")

--- a/lib/dotcom/telemetry.ex
+++ b/lib/dotcom/telemetry.ex
@@ -47,21 +47,7 @@ defmodule Dotcom.Telemetry do
       Metrics.last_value("vm.memory.ets", unit: {:byte, :kilobyte}),
       Metrics.last_value("vm.total_run_queue_lengths.total"),
       Metrics.last_value("vm.total_run_queue_lengths.cpu"),
-      Metrics.last_value("vm.system_counts.process_count"),
-      Metrics.summary("phoenix.router_dispatch.stop.duration",
-        tags: [:controller_action],
-        tag_values: &tag_controller_action/1,
-        unit: {:native, :millisecond}
-      )
+      Metrics.last_value("vm.system_counts.process_count")
     ]
-  end
-
-  # Extracts controller#action from route dispatch
-  defp tag_controller_action(%{plug: plug, plug_opts: plug_opts}) when is_atom(plug_opts) do
-    %{controller_action: "#{inspect(plug)}##{plug_opts}"}
-  end
-
-  defp tag_controller_action(%{plug: plug}) do
-    %{controller_action: inspect(plug)}
   end
 end

--- a/lib/dotcom/telemetry.ex
+++ b/lib/dotcom/telemetry.ex
@@ -47,7 +47,21 @@ defmodule Dotcom.Telemetry do
       Metrics.last_value("vm.memory.ets", unit: {:byte, :kilobyte}),
       Metrics.last_value("vm.total_run_queue_lengths.total"),
       Metrics.last_value("vm.total_run_queue_lengths.cpu"),
-      Metrics.last_value("vm.system_counts.process_count")
+      Metrics.last_value("vm.system_counts.process_count"),
+      Metrics.summary("phoenix.router_dispatch.stop.duration",
+        tags: [:controller_action],
+        tag_values: &tag_controller_action/1,
+        unit: {:native, :millisecond}
+      )
     ]
+  end
+
+  # Extracts controller#action from route dispatch
+  defp tag_controller_action(%{plug: plug, plug_opts: plug_opts}) when is_atom(plug_opts) do
+    %{controller_action: "#{inspect(plug)}##{plug_opts}"}
+  end
+
+  defp tag_controller_action(%{plug: plug}) do
+    %{controller_action: inspect(plug)}
   end
 end

--- a/lib/dotcom/telemetry.ex
+++ b/lib/dotcom/telemetry.ex
@@ -37,7 +37,7 @@ defmodule Dotcom.Telemetry do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  defp metrics do
+  def metrics do
     [
       Metrics.last_value("vm.memory.total", unit: :byte),
       Metrics.last_value("vm.total_run_queue_lengths.total"),

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -334,7 +334,8 @@ defmodule DotcomWeb.Router do
         csp_nonce_assign_key: :csp_nonce,
         additional_pages: [
           flame_on: FlameOn.DashboardPage
-        ]
+        ],
+        metrics: Dotcom.Telemetry
       )
     end
   end


### PR DESCRIPTION
1. Enables metrics on the LiveDashboard, which isn't pretty but does let us see metrics go up and down locally
2. Sends more detailed metrics about memory.

On dev-green you can see the additional metrics (bottom chart)
<img width="640" height="466" alt="image" src="https://github.com/user-attachments/assets/c8f2fc98-92ba-4f02-8b79-1ae85f219ef0" />
