### PR TITLE
chore: hibernate_after in many places

### DIFF
--- a/lib/alerts/cache/store.ex
+++ b/lib/alerts/cache/store.ex
@@ -149,7 +149,7 @@ defmodule Alerts.Cache.Store do
     # no cover
     _ = :ets.new(:alert_banner, [:set, :protected, :named_table, read_concurrency: true])
 
-    {:ok, []}
+    {:ok, [], :hibernate}
   end
 
   @impl true

--- a/lib/dotcom/cache/inspector/subscriber.ex
+++ b/lib/dotcom/cache/inspector/subscriber.ex
@@ -14,7 +14,7 @@ defmodule Dotcom.Cache.Inspector.Subscriber do
   @redix_pub_sub Application.compile_env!(:dotcom, :redix_pub_sub)
 
   def start_link(_) do
-    GenServer.start_link(__MODULE__, nil)
+    GenServer.start_link(__MODULE__, nil, hibernate_after: 15_000)
   end
 
   @impl GenServer

--- a/lib/dotcom/cache/subscriber.ex
+++ b/lib/dotcom/cache/subscriber.ex
@@ -16,7 +16,7 @@ defmodule Dotcom.Cache.Subscriber do
   @redix_pub_sub Application.compile_env!(:dotcom, :redix_pub_sub)
 
   def start_link(uuid) do
-    GenServer.start_link(__MODULE__, uuid, [])
+    GenServer.start_link(__MODULE__, uuid, hibernate_after: 15_000)
   end
 
   @impl GenServer

--- a/lib/dotcom/service_date_rollover.ex
+++ b/lib/dotcom/service_date_rollover.ex
@@ -40,7 +40,7 @@ defmodule Dotcom.ServiceDateRollover do
   @impl GenServer
   def handle_continue(:schedule_next_run, state) do
     Process.send_after(self(), :dispatch_change, ms_to_next_rollover())
-    {:noreply, state}
+    {:noreply, state, :hibernate}
   end
 
   def ms_to_next_rollover(boundary_datetime \\ end_of_service_day()) do

--- a/lib/dotcom/stream/vehicles.ex
+++ b/lib/dotcom/stream/vehicles.ex
@@ -5,7 +5,7 @@ defmodule Dotcom.Stream.Vehicles do
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    GenServer.start_link(__MODULE__, opts, name: name, hibernate_after: 15_000)
   end
 
   def init(opts) do

--- a/lib/dotcom/system_status/commuter_rail_cache.ex
+++ b/lib/dotcom/system_status/commuter_rail_cache.ex
@@ -35,12 +35,12 @@ defmodule Dotcom.SystemStatus.CommuterRailCache do
   def init(_opts) do
     Alerts.Cache.Store.subscribe()
 
-    {:ok, CommuterRail.commuter_rail_status()}
+    {:ok, CommuterRail.commuter_rail_status(), :hibernate}
   end
 
   @impl true
   def handle_call(:commuter_rail_status, _from, status) do
-    {:reply, status, status}
+    {:reply, status, status, :hibernate}
   end
 
   @impl true
@@ -51,6 +51,6 @@ defmodule Dotcom.SystemStatus.CommuterRailCache do
       DotcomWeb.Endpoint.broadcast(@pubsub_topic, "commuter_rail_status_updated", new_status)
     end
 
-    {:noreply, new_status}
+    {:noreply, new_status, :hibernate}
   end
 end

--- a/lib/dotcom/system_status/subway_cache.ex
+++ b/lib/dotcom/system_status/subway_cache.ex
@@ -44,7 +44,7 @@ defmodule Dotcom.SystemStatus.SubwayCache do
     :ets.new(:subway_status, [:named_table, :set, :protected, read_concurrency: true])
     :ets.insert(:subway_status, {"status", status})
 
-    {:ok, status}
+    {:ok, status, :hibernate}
   end
 
   @impl true
@@ -56,7 +56,7 @@ defmodule Dotcom.SystemStatus.SubwayCache do
       DotcomWeb.Endpoint.broadcast(@pubsub_topic, "subway_status_updated", new_status)
     end
 
-    {:noreply, new_status}
+    {:noreply, new_status, :hibernate}
   end
 
   defp status() do

--- a/lib/dotcom/system_status/subway_cache.ex
+++ b/lib/dotcom/system_status/subway_cache.ex
@@ -21,10 +21,9 @@ defmodule Dotcom.SystemStatus.SubwayCache do
 
   @impl Behaviour
   def subway_status() do
-    :ets.lookup(:subway_status, "status")
-    |> case do
-      [{"status", status}] -> status
-      _ -> status()
+    case stored_status() do
+      nil -> status()
+      status -> status
     end
   end
 
@@ -44,11 +43,12 @@ defmodule Dotcom.SystemStatus.SubwayCache do
     :ets.new(:subway_status, [:named_table, :set, :protected, read_concurrency: true])
     :ets.insert(:subway_status, {"status", status})
 
-    {:ok, status, :hibernate}
+    {:ok, nil, :hibernate}
   end
 
   @impl true
-  def handle_info(%{event: "alerts_updated"}, old_status) do
+  def handle_info(%{event: "alerts_updated"}, state) do
+    old_status = stored_status()
     new_status = status()
 
     if new_status != old_status do
@@ -56,10 +56,18 @@ defmodule Dotcom.SystemStatus.SubwayCache do
       DotcomWeb.Endpoint.broadcast(@pubsub_topic, "subway_status_updated", new_status)
     end
 
-    {:noreply, new_status, :hibernate}
+    {:noreply, state, :hibernate}
   end
 
   defp status() do
     SystemStatus.subway_status()
+  end
+
+  defp stored_status() do
+    :ets.lookup(:subway_status, "status")
+    |> case do
+      [{"status", status}] -> status
+      _ -> nil
+    end
   end
 end

--- a/lib/dotcom/via_fairmount.ex
+++ b/lib/dotcom/via_fairmount.ex
@@ -13,7 +13,8 @@ defmodule Dotcom.ViaFairmount do
           _ -> []
         end
       end,
-      name: __MODULE__
+      name: __MODULE__,
+      hibernate_after: 15_000
     )
   end
 

--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -99,7 +99,10 @@ defmodule DotcomWeb.CacheController do
     uuid = UUID.uuid4(:hex) |> String.upcase() |> String.to_atom()
     key = Enum.join(path, "|")
 
-    case GenServer.start_link(Dotcom.Cache.Inspector.Publisher, uuid, name: uuid) do
+    case GenServer.start_link(Dotcom.Cache.Inspector.Publisher, uuid,
+           name: uuid,
+           hibernate_after: 15_000
+         ) do
       {:ok, _} ->
         GenServer.cast(uuid, {:load, key})
 

--- a/lib/mbta/api/stream.ex
+++ b/lib/mbta/api/stream.ex
@@ -37,7 +37,7 @@ defmodule MBTA.Api.Stream do
   @spec start_link(Keyword.t()) :: {:ok, pid}
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    GenStage.start_link(__MODULE__, opts, name: name)
+    GenStage.start_link(__MODULE__, opts, name: name, hibernate_after: 15_000)
   end
 
   @doc """

--- a/lib/predictions/store.ex
+++ b/lib/predictions/store.ex
@@ -17,7 +17,7 @@ defmodule Predictions.Store do
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(_) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    GenServer.start_link(__MODULE__, [], name: __MODULE__, hibernate_after: 15_000)
   end
 
   @doc "Deletes predictions associated with the input fetch keys, e.g. clear([route: 'Red', direction: 1])"

--- a/lib/predictions/stream.ex
+++ b/lib/predictions/stream.ex
@@ -21,7 +21,8 @@ defmodule Predictions.Stream do
     GenStage.start_link(
       __MODULE__,
       opts,
-      name: name
+      name: name,
+      hibernate_after: 15_000
     )
   end
 

--- a/lib/routes/populate_caches.ex
+++ b/lib/routes/populate_caches.ex
@@ -15,7 +15,7 @@ defmodule Routes.PopulateCaches do
   @spec start_link([]) :: GenServer.on_start()
   def start_link([]) do
     # no cover
-    GenServer.start_link(__MODULE__, @routes_repo)
+    GenServer.start_link(__MODULE__, @routes_repo, hibernate_after: 15_000)
   end
 
   @impl GenServer

--- a/lib/vehicles/repo.ex
+++ b/lib/vehicles/repo.ex
@@ -77,7 +77,11 @@ defmodule Vehicles.Repo do
 
   def start_link(opts) do
     opts = Keyword.put_new(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
+
+    GenServer.start_link(__MODULE__, opts,
+      name: Keyword.fetch!(opts, :name),
+      hibernate_after: 15_000
+    )
   end
 
   @impl GenServer

--- a/lib/vehicles/repo.ex
+++ b/lib/vehicles/repo.ex
@@ -86,15 +86,13 @@ defmodule Vehicles.Repo do
 
   @impl GenServer
   def init(opts) do
-    ets =
-      opts
-      |> Keyword.fetch!(:name)
-      |> :ets.new([:named_table, :protected])
+    table_name = Keyword.fetch!(opts, :name)
+    _ = :ets.new(table_name, [:named_table, :protected])
 
     pubsub_fn = Keyword.get(opts, :pubsub_fn, &Phoenix.PubSub.subscribe/2)
     _ = pubsub_fn.(Vehicles.PubSub, "vehicles")
 
-    {:ok, %{ets: ets}}
+    {:ok, %{table_name: table_name}}
   end
 
   @impl GenServer
@@ -105,26 +103,29 @@ defmodule Vehicles.Repo do
 
   @impl GenServer
   def handle_info({:reset, vehicles}, state) do
-    _ = :ets.delete_all_objects(state.ets)
-    [] = :ets.tab2list(state.ets)
-    _ = add_vehicles(vehicles, state.ets)
+    table = table(state)
+    _ = :ets.delete_all_objects(table)
+    [] = :ets.tab2list(table)
+    _ = add_vehicles(vehicles, table)
     {:noreply, state}
   end
 
   def handle_info({:add, [%Vehicle{} = vehicle]}, state) do
-    _ = add_vehicles([vehicle], state.ets)
+    _ = add_vehicles([vehicle], table(state))
     {:noreply, state}
   end
 
-  def handle_info({:update, [%Vehicle{} = vehicle]}, %{ets: ets} = state) do
-    _ = add_vehicles([vehicle], ets)
+  def handle_info({:update, [%Vehicle{} = vehicle]}, state) do
+    _ = add_vehicles([vehicle], table(state))
     {:noreply, state}
   end
 
-  def handle_info({:remove, [<<id::binary>>]}, %{ets: ets} = state) do
-    _ = :ets.delete(ets, id)
+  def handle_info({:remove, [<<id::binary>>]}, state) do
+    _ = :ets.delete(table(state), id)
     {:noreply, state}
   end
+
+  defp table(%{table_name: table_name}), do: table_name
 
   @spec add_vehicles([Vehicle.t()], atom) :: true
   defp add_vehicles(vehicles, tab) when is_list(vehicles) do

--- a/lib/vehicles/stream.ex
+++ b/lib/vehicles/stream.ex
@@ -18,7 +18,8 @@ defmodule Vehicles.Stream do
     GenStage.start_link(
       __MODULE__,
       opts,
-      name: name
+      name: name,
+      hibernate_after: 15_000
     )
   end
 


### PR DESCRIPTION
From debugging our application locally over the past week, I found that
- most of our memory usage is tied up in **processes** (this is almost true for prod metrics too, but there we have even more memory attributed to our usage of ETS)
- many processes maintain a pretty large heap size.

From the GenServer documentation:

> Hibernating a [GenServer](https://elixir.hexdocs.pm/1.19.5/GenServer.html) causes garbage collection and leaves a continuous heap that minimises the memory used by the process.
>
> Hibernating should not be used aggressively as too much time could be spent garbage collecting, which would delay the processing of incoming messages. Normally it should only be used when you are not expecting new messages to immediately arrive and minimising the memory of the process is shown to be beneficial.

So in this branch I explored using this strategically.
- the alerts-fetching processes were already using `:hibernate` (except after initializing, which I've added here), so I figured it's ok to have the `SystemStatus` caches, which rely on alerts, to use these too
- `ServiceDateRollover` is a ~once a day thing, so I added `:hibernate` after that message,
- for a few other places: `:hibernate_after` will hibernate after a given amount of milliseconds without messages. This felt appropriate in most cases, because most of our GenServers have sporadic activity

Some slightly more involved tweaks here:
- fixup(SystemStatus.SubwayCache): remove state - since we already have the status saved in the ETS table, it didn't make sense to also save it in the GenServer state
- fixup(Vehicles.Repo): remove table from state - similar story here, but kept a reference to the table name

### Results 

Alas, what do the `:observer` load charts say. The lower left charts depict memory usage pretty soon after application startup.

| Before | After |
|--------|--------|
| <img width="1682" height="1002" alt="image" src="https://github.com/user-attachments/assets/c76e718c-f4e5-46f4-af17-96a3117287f5" /> | <img width="1684" height="997" alt="image" src="https://github.com/user-attachments/assets/0ff9f635-a465-4ebe-8ef2-84b2809db9bc" /> | 

There's a noticeable reduction in the baseline memory usage here.