### PR TITLE
QF | [WC Cleanup] Revert redirect from CR-Foxboro

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -225,9 +225,6 @@ defmodule DotcomWeb.Router do
       to: "/schedules/CR-NewBedford"
     )
 
-    # Redirect Foxboro line to World Cup Timetable Page for the World Cup (revert this later)
-    get("/schedules/CR-Foxboro/*path_params", Redirector, to: "/schedules/bostonstadium")
-
     # Redirect Boat-F1 to Boat-F2H until Boat-F1 can be unlisted
     get("/schedules/Boat-F1/*path_params", Plugs.PathParamsRedirector, to: "/schedules/Boat-F2H")
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Revert redirect from CR-Foxboro](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574982713972?focus=true)

## Implementation

Removed entry from router that sent riders to the WC timetable if they went to the Foxboro timetable


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

http://localhost:4001/schedules/CR-Foxboro

Confirm that this now goes to the Foxboro timetable

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
