### PR TITLE
QF | [WC Cleanup]: Remove Boston Stadium Train link on /schedules and restore CR-Foxboro

### DIFF
--- a/lib/dotcom_web/templates/mode/_grid_button.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.heex
@@ -7,13 +7,6 @@
     <% end %>
 
     <span class="c-grid-button__name notranslate">
-      <.icon
-        :if={!is_atom(@route) and @route.id == "Bostonstadium"}
-        type="icon-svg"
-        name="football"
-        class="size-4 relative top-[0.1em]"
-        aria-hidden="true"
-      />
       {grid_button_text(@route)}
     </span>
 

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -10,25 +10,7 @@
       index: idx
     )}
   <% end %>
-  <% wc_route =
-    %Routes.Route{
-      id: "Bostonstadium",
-      name: "Boston Stadium Trains",
-      type: 2
-    }
-
-  test_route = @routes |> Enum.at(0) %>
-  {if !is_atom(test_route) and test_route.type == 2,
-    do:
-      render("_grid_button.html",
-        conn: @conn,
-        route: wc_route,
-        show_icon?: @show_icons?,
-        link_path: ~p"/schedules/bostonstadium",
-        has_alert?: false,
-        id_prefix: assigns[:id_prefix],
-        index: Enum.count(@routes)
-      )}
+ 
   <%= if assigns[:sub_routes] do %>
     <div class="c-grid-button c-grid-buttons__condensed">
       <%= for {route, idx} <- Enum.with_index(Map.get(assigns, :sub_routes, [])) do %>

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -1,5 +1,5 @@
 <div class="c-grid-buttons">
-  <%= for {route, idx} <- (Enum.filter(@routes, fn(route) -> is_atom(route) or route.id != "CR-Foxboro" end) |> Enum.with_index()) do %>
+  <%= for {route, idx} <- (@routes |> Enum.with_index()) do %>
     {render("_grid_button.html",
       conn: @conn,
       route: route,
@@ -10,7 +10,7 @@
       index: idx
     )}
   <% end %>
- 
+
   <%= if assigns[:sub_routes] do %>
     <div class="c-grid-button c-grid-buttons__condensed">
       <%= for {route, idx} <- Enum.with_index(Map.get(assigns, :sub_routes, [])) do %>


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Remove Boston Stadium Train link on /schedules and restore CR-Foxboro](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427718852480?focus=true)

## Implementation

Removed Boston Stadium Trains link button from /schedules/ and /schedules/commuter-rail


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="721" height="522" alt="Screenshot 2026-07-20 at 3 56 52 PM" src="https://github.com/user-attachments/assets/f36f65c9-176a-4508-8e91-3a9974259133" />
<img width="720" height="576" alt="Screenshot 2026-07-20 at 3 56 43 PM" src="https://github.com/user-attachments/assets/7456fabd-5097-4bb0-8002-35c2c44d92cf" />


## How to test

http://localhost:4001/schedules/commuter-rail
http://localhost:4001/schedules/

Confirm that the Boston Stadium Trains link to the World Cup timetable is gone

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
