### PR TITLE
fix(TripPlanner): Show grouped ferry routes nicely

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -123,6 +123,13 @@ defmodule DotcomWeb.Components.TripPlanner.ItinerarySummary do
     """
   end
 
+  # Group of ferry routes are summarized to one symbol.
+  defp leg_icon(%{routes: [%Route{type: 4} | _]} = assigns) do
+    ~H"""
+    <.mode_icon mode="ferry" class={@class} />
+    """
+  end
+
   # No grouping when there's only one route!
   defp leg_icon(%{routes: [%Route{}]} = assigns) do
     ~H"""


### PR DESCRIPTION
## Scope

**Asana Ticket:** [QF | 🗺️ 🐞 Trip Planner doesn't show grouped ferry routes well](https://app.asana.com/1/15492006741476/project/385363666817452/task/1215429982941773?focus=true)

## Screenshots

<img width="1004" height="400" alt="Screenshot 2026-07-20 at 5 24 01 PM" src="https://github.com/user-attachments/assets/9ed39348-8f67-4133-8c9d-0e09e088a5e0" />

<img width="987" height="395" alt="Screenshot 2026-07-20 at 5 31 40 PM" src="https://github.com/user-attachments/assets/36cdd892-96ac-4d1e-80b7-8df1b2930e2a" />


## How to test

The Quincy, Winthrop, and Harbor Loop ferry routes have a decent amount of overlap in what docks they serve, which means that trips like [this one from Fan Pier to Logan](http://localhost:4001/trip-planner?plan=jcQVX3VudXNlZF9kYXRldGltZV90eXBlxADEF191bnVzZWRfdGltZXBpY2tlcl9hbXBtxADEF191bnVzZWRfdGltZXBpY2tlcl9ob3VyxADEGV91bnVzZWRfdGltZXBpY2tlcl9taW51dGXEAMQSX3VudXNlZF93aGVlbGNoYWlyxADECGRhdGV0aW1lxBkyMDI2LTA4LTI3VDE2OjI1OjAwLTA0OjAwxA1kYXRldGltZV90eXBlxAhsZWF2ZV9hdMQEZnJvbYTECGxhdGl0dWRlxAg0Mi4zNTM0OcQJbG9uZ2l0dWRlxAktNzEuMDQzMjLEBG5hbWXEEFNlYXBvcnQvRmFuIFBpZXLEB3N0b3BfaWTECEJvYXQtRmFuxAVtb2Rlc4nEA0JVU8QEdHJ1ZcQFRkVSUlnEBHRydWXEBFJBSUzEBHRydWXEBlNVQldBWcQEdHJ1ZcQOX3BlcnNpc3RlbnRfaWTEATDEC191bnVzZWRfQlVTxADEDV91bnVzZWRfRkVSUlnEAMQMX3VudXNlZF9SQUlMxADEDl91bnVzZWRfU1VCV0FZxADED3RpbWVwaWNrZXJfYW1wbcQCUE3ED3RpbWVwaWNrZXJfaG91csQBNMQRdGltZXBpY2tlcl9taW51dGXEAjI1xAJ0b4TECGxhdGl0dWRlxAg0Mi4zNTk4NcQJbG9uZ2l0dWRlxAktNzEuMDI3NjfEBG5hbWXEHExvZ2FuIEFpcnBvcnQgRmVycnkgVGVybWluYWzEB3N0b3BfaWTECkJvYXQtTG9nYW4=) or [this one from Central Wharf to Logan](http://localhost:4001/trip-planner?plan=jMQXX3VudXNlZF90aW1lcGlja2VyX2FtcG3EAMQXX3VudXNlZF90aW1lcGlja2VyX2hvdXLEAMQZX3VudXNlZF90aW1lcGlja2VyX21pbnV0ZcQAxBJfdW51c2VkX3doZWVsY2hhaXLEAMQIZGF0ZXRpbWXEGTIwMjYtMDctMzFUMDk6MzA6MDAtMDQ6MDDEDWRhdGV0aW1lX3R5cGXECGxlYXZlX2F0xARmcm9thMQIbGF0aXR1ZGXECDQyLjM1ODg2xAlsb25naXR1ZGXECC03MS4wNDg2xARuYW1lxBVDZW50cmFsIFdoYXJmIChTb3V0aCnEB3N0b3BfaWTEDUJvYXQtQXF1YXJpdW3EBW1vZGVzicQDQlVTxAR0cnVlxAVGRVJSWcQEdHJ1ZcQEUkFJTMQEdHJ1ZcQGU1VCV0FZxAR0cnVlxA5fcGVyc2lzdGVudF9pZMQBMMQLX3VudXNlZF9CVVPEAMQNX3VudXNlZF9GRVJSWcQAxAxfdW51c2VkX1JBSUzEAMQOX3VudXNlZF9TVUJXQVnEAMQPdGltZXBpY2tlcl9hbXBtxAJBTcQPdGltZXBpY2tlcl9ob3VyxAE5xBF0aW1lcGlja2VyX21pbnV0ZcQCMzDEAnRvhMQIbGF0aXR1ZGXECDQyLjM1OTg1xAlsb25naXR1ZGXECS03MS4wMjc2N8QEbmFtZcQcTG9nYW4gQWlycG9ydCBGZXJyeSBUZXJtaW5hbMQHc3RvcF9pZMQKQm9hdC1Mb2dhbg==) show grouped ferries. See if you can find other ones!