### PR TITLE
QF | [WC Cleanup]: Revert re-named heading on CR alerts page

### DIFF
--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -206,10 +206,6 @@ defmodule DotcomWeb.AlertView do
     ]
   end
 
-  def group_header_name(%Route{id: "CR-Foxboro"}) do
-    ["Boston Stadium Trains"]
-  end
-
   def group_header_name(%Route{name: name}) do
     [name]
   end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Revert re-named heading on CR alerts page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574982713973?focus=true)

## Implementation

Removed override that replaced the default route subheading for CR-Foxboro with "Boston Stadium Trains"

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Dev-Blue
<img width="830" height="164" alt="Screenshot 2026-07-21 at 1 20 02 PM" src="https://github.com/user-attachments/assets/27930f1e-df46-4136-8aa2-301e26ea50d3" />

### Local
<img width="830" height="158" alt="Screenshot 2026-07-21 at 1 19 43 PM" src="https://github.com/user-attachments/assets/c4a9bcca-b381-49b1-b9f4-32b3f2f5255e" />


## How to test

http://localhost:4001/alerts/commuter-rail

Confirm that alerts for CR-Foxboro show up under the heading "Foxboro Event Service"

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
