### PR TITLE
QF | [WC Cleanup]: Keolis pixel code removal

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -1,17 +1,6 @@
 <!DOCTYPE html>
 <html lang={Map.get(assigns, :locale, "en")}>
   <head>
-    <%= if (@conn.request_path |> String.contains?("world-cup-guide")) do %>
-      <!-- Google Tag Manager -->
-      <script>
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-594M28WJ');
-      </script>
-      <!-- End Google Tag Manager -->
-    <% end %>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -75,19 +64,6 @@
     <% end %>
   </head>
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
-    <%= if (@conn.request_path |> String.contains?("world-cup-guide")) do %>
-      <!-- Google Tag Manager (noscript) -->
-      <noscript>
-        <iframe
-          src="https://www.googletagmanager.com/ns.html?id=GTM-594M28WJ"
-          height="0"
-          width="0"
-          style="display:none;visibility:hidden"
-        >
-        </iframe>
-      </noscript>
-      <!-- End Google Tag Manager (noscript) -->
-    <% end %>
     <div class="body-wrapper" id="body-wrapper">
       <%= if !Application.get_env(:dotcom, :is_prod_env?) && !Laboratory.enabled?(@conn, :use_smartling_translations) do %>
         <% language =


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [[After 7/13] QF | ⚽️❌ Keolis pixel code removal](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215174051172167?focus=true)

## Implementation

Removed code blocks that inserted Keolis's Google Analytics code onto the World Cup Guide


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

The World Cup Guide page is gone already, not really possible to test properly.

## How to test

Ditto

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
