### PR TITLE
QF | [WC Cleanup]: Remove logic handling special World Cup icon in search

### DIFF
--- a/assets/css/_icons.scss
+++ b/assets/css/_icons.scss
@@ -355,9 +355,3 @@ a {
     color: black;
   }
 }
-
-.c-search-result__content-icon.worldcup {
-  height: 17px;
-  width: 17px;
-  margin-top: -3px;
-}

--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -174,7 +174,7 @@ export const algoliaSource = (
         })
       })
         .then(res => res.json())
-        .then(({ results }) =>  results)
+        .then(({ results }) => results)
         .catch(() => []);
     },
     ...(withLink && {

--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -174,22 +174,7 @@ export const algoliaSource = (
         })
       })
         .then(res => res.json())
-        .then(({ results }) => {
-          // Find World Cup content and move it to the front
-          const worldCupIndex = results.findIndex(
-            (item: AutocompleteItem) =>
-              (item as any)._content_url === "/guides/world-cup-guide" // eslint-disable-line
-          );
-
-          if (worldCupIndex > 0) {
-            // Remove World Cup item from its current position
-            const worldCupItem = results.splice(worldCupIndex, 1)[0];
-            // Add it to the front
-            results.unshift(worldCupItem);
-          }
-
-          return results;
-        })
+        .then(({ results }) =>  results)
         .catch(() => []);
     },
     ...(withLink && {

--- a/assets/ts/ui/autocomplete/templates/helpers_algolia.js
+++ b/assets/ts/ui/autocomplete/templates/helpers_algolia.js
@@ -90,8 +90,6 @@ export function contentIcon(hit) {
 
   if (hit.search_api_datasource === "entity:file") {
     icon = _fileIcon(hit);
-  } else if (hit._content_url === "/guides/world-cup-guide") {
-    return worldCupIcon();
   } else {
     const iconMapper = {
       search_result: "fa-info",
@@ -109,10 +107,6 @@ export function contentIcon(hit) {
   }
 
   return TEMPLATES.fontAwesomeIcon.render({ icon });
-}
-
-function worldCupIcon() {
-  return TEMPLATES.worldCupIcon.render();
 }
 
 function _getStopOrStationIcon(hit) {
@@ -395,8 +389,5 @@ const TEMPLATES = {
   ),
   formattedDate: hogan.compile(
     `<span class="c-search-result__event-date">{{date}}</span>`
-  ),
-  worldCupIcon: hogan.compile(
-    `<img src="/icon-svg/football.svg" class="c-search-result__content-icon worldcup" />`
   )
 };


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Remove logic handling special World Cup icon in search](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427718852479?focus=true)

## Implementation

Removed style and logic that added a soccer ball icon to the world cup guide search result and sorted it to the top.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A, World Cup Guide is already gone

## How to test

Ditto

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
