### PR TITLE
Revert "feat(ServicePatterns): use real service names"

### DIFF
--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -42,14 +42,16 @@ defmodule Dotcom.ServicePatterns do
     |> dedup_similar_services()
   end
 
+  @type typical_type :: :monday_thursday | :friday | :weekday | :saturday | :sunday | :weekend
+  @type typical_label :: {:typical, typical_type, String.t()}
+  @type atypical_label :: {Service.typicality(), Date.t(), String.t()}
   @type pattern_group ::
           :holiday_service | :extra_service | :planned_disruption | :current | :future | :other
   @type pattern_group_label :: {pattern_group(), String.t()}
-  @type service_label :: {Service.typicality(), Date.t(), String.t()}
   @type service_pattern :: %{
           group_label: pattern_group_label(),
           dates: [Date.t()],
-          service_label: service_label()
+          service_label: typical_label() | atypical_label()
         }
 
   @spec patterns_for_route(Routes.Route.id_t(), Date.t()) :: [service_pattern()]
@@ -276,11 +278,35 @@ defmodule Dotcom.ServicePatterns do
           service: Service.t(),
           dates: [Date.t()],
           group_label: pattern_group_label()
-        }) :: service_label()
+        }) :: typical_label() | atypical_label()
+  defp similar_typical_items(%{
+         dates: dates,
+         service: %Service{typicality: :typical_service} = service
+       }) do
+    typical_groups = [
+      {:monday_thursday, ~t"Monday - Thursday schedules",
+       fn s ->
+         s.type == :weekday &&
+           (s.valid_days == [1, 2, 3, 4] || s.description =~ "Monday - Thursday")
+       end},
+      {:friday, ~t"Friday schedules",
+       fn s ->
+         s.type == :weekday && (s.valid_days == [5] || s.description =~ "Friday")
+       end},
+      {:weekday, ~t"Weekday schedules", fn s -> s.type == :weekday end},
+      {:saturday, ~t"Saturday schedules", fn s -> s.type == :saturday end},
+      {:sunday, ~t"Sunday schedules", fn s -> s.type == :sunday end},
+      {:weekend, ~t"Weekend schedules", fn s -> s.type == :weekend end}
+    ]
+
+    case Enum.find(typical_groups, fn {_, _, func} -> func.(service) end) do
+      {key, label, _} -> {:typical, key, label}
+      _ -> {service.typicality, List.first(dates), service.description}
+    end
+  end
+
   defp similar_typical_items(%{dates: dates, service: service}),
-    do:
-      {service.typicality, List.first(dates),
-       String.replace(service.description, " (no school)", "")}
+    do: {service.typicality, List.first(dates), service.description}
 
   defp merge_items({{group_label, label}, [%{service: _, dates: dates}]}) do
     %{service_label: label, dates: dates, group_label: group_label}

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5529,3 +5529,33 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -5529,3 +5529,33 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5553,3 +5553,33 @@ msgstr "Algo salió mal. Por favor, inténtalo de nuevo más tarde."
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "Persona en silla de ruedas-accesible transfers en Downtown Crossing puede requerir <strong>salir de la puerta de acceso.</strong> Consulta al personal"
 " de la estación para evitar pagar una tarifa adicional."
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5554,3 +5554,33 @@ msgstr "Quelque chose a mal tourné. Veuillez réessayer plus tard."
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "Fauteuil Roulant -accessible transferts à Downtown Crossing peuvent <strong>nécessiter de sortir du portique.</strong> Consultez station personnel pour"
 " éviter de payer un tarif supplémentaire."
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5540,3 +5540,33 @@ msgstr "Gen yon bagay ki pa mache byen. Tanpri eseye ankò pita."
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "sekirite woulant-aksesib transfè nan Downtown Crossing ka mande pou <strong>sòti nan pòt tarif la.</strong> Al wè pèsonèl estasyon an pou evite peye yon"
 " lòt tikè."
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5549,3 +5549,33 @@ msgstr "Algo deu errado. Por favor, tente novamente mais tarde."
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "Os traslados de rodas acessíveis no Downtown Crossing podem exigir <strong>a saída da cadeira de acesso.</strong> Consulte os funcionários da estação para"
 " evitar o pagamento de uma tarifa adicional."
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5545,3 +5545,33 @@ msgstr "Đã xảy ra lỗi. Vui lòng thử lại sau."
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "xe lăn-có thể tiếp cận được chuyển tại Downtown Crossing có thể yêu cầu <strong>thoát khỏi cổng soát vé.</strong> Gặp nhân viên nhà ga để tránh phải trả"
 " thêm tiền vé."
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5523,3 +5523,33 @@ msgstr "出问题了。请稍后再试。"
 #, elixir-autogen, elixir-format
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "在Downtown Crossing无障碍换乘可能需要<strong>退出闸机。</strong> 请向车站工作人员咨询，以免支付额外费用。"
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5523,3 +5523,33 @@ msgstr "出問題了。請稍後再試。"
 #, elixir-autogen, elixir-format
 msgid "Wheelchair-accessible transfers at Downtown Crossing may require <strong>exiting the fare gates.</strong> See station personnel to avoid paying an additional fare."
 msgstr "在Downtown Crossing無障礙換乘可能需要<strong>退出閘機。</strong> 請向車站工作人員諮詢，以免支付額外費用。"
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Friday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Monday - Thursday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Saturday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Sunday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekday schedules"
+msgstr ""
+
+#: lib/dotcom/service_patterns.ex
+#, elixir-autogen, elixir-format
+msgid "Weekend schedules"
+msgstr ""

--- a/test/dotcom/service_patterns_test.exs
+++ b/test/dotcom/service_patterns_test.exs
@@ -84,7 +84,7 @@ defmodule Dotcom.ServicePatternsTest do
         ]
       end)
 
-      assert [%{service_label: {_, _, "Weekdays"}}] =
+      assert [%{service_label: {:typical, :weekday, "Weekday schedules"}}] =
                patterns_for_route(route_id)
     end
 


### PR DESCRIPTION
Reverts mbta/dotcom#3274

I didn't feel like doing this one by hand, so I just hit the `Revert` button, I think we should be good though.

Ticket:  [QF | ⚽️❌  SF 2.0 services change to show "Friday and matchday"](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215944507039158?focus=true)

##Screenshots

### Dev-Green
<img width="606" height="221" alt="Screenshot 2026-07-22 at 11 52 37 AM" src="https://github.com/user-attachments/assets/93fecece-9cab-4cba-9c1b-811b2b7bec47" />

### Local
<img width="598" height="177" alt="Screenshot 2026-07-22 at 11 52 29 AM" src="https://github.com/user-attachments/assets/43792494-75de-4076-ae70-4f05843b1c70" />

##Testing

http://localhost:4001/departures?route_id=111&direction_id=1&stop_id=5588

Open the schedule picker and confirm that the original behavior is back.  Compare to dev.

