### PR TITLE
feat: Have new ferry timetables scroll to the right trip

### DIFF
--- a/lib/dotcom/timetables.ex
+++ b/lib/dotcom/timetables.ex
@@ -422,6 +422,34 @@ defmodule Dotcom.Timetables do
     %Timetable{rows: rows, trips: trips, offset: offset}
   end
 
+  @doc """
+  Calculates the index of the first trip that has at least one stop
+  in the future.  If the offset would go past the end of the list,
+  returns the index of the last element.
+  """
+  @spec first_unfinished_trip_index(Timetable.t(), DateTime.t()) :: non_neg_integer()
+  def first_unfinished_trip_index(%Timetable{} = timetable, %DateTime{} = now) do
+    trip_end_times =
+      timetable.rows
+      |> Enum.reduce(
+        timetable.trips |> Enum.map(fn _ -> nil end),
+        fn %{cells: cells}, last_times ->
+          Enum.zip(cells, last_times)
+          |> Enum.map(fn
+            {%{time: nil}, time} -> time
+            {%{time: time}, _} -> time
+          end)
+        end
+      )
+
+    trip_end_times
+    |> Enum.find_index(fn end_time -> DateTime.after?(end_time, now) end)
+    |> case do
+      nil -> max(Enum.count(trip_end_times) - 1, 0)
+      index -> index
+    end
+  end
+
   # Calculates the offset: the index of the first trip that has at least one stop in the future.
   # If the offset would go past the end of the list, returns the index of the last element.
   defp calculate_offset(schedule_lists_for_trips, date_time) do

--- a/lib/dotcom/timetables.ex
+++ b/lib/dotcom/timetables.ex
@@ -15,25 +15,30 @@ defmodule Dotcom.Timetables do
   The entries in each list correspond to the trips that visit that stop, so, for instance, the
   second item in each list will all be visits from the same trip.
 
+      iex> time_1_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_1_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_1,
       ...>       stop: %Stops.Stop{id: "first_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_1,
       ...>       stop: %Stops.Stop{id: "first_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
@@ -46,11 +51,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:05 PM",
+                time: time_1_1,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:05 PM",
+                time: time_2_1,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -61,11 +66,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "second_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:25 PM",
+                time: time_1_2,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:25 PM",
+                time: time_2_2,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -78,34 +83,40 @@ defmodule Dotcom.Timetables do
       }
 
   For trips that don't visit all of the stops, `from_schedules/1` inserts empty cells (with
-  `time = ""`) in order to make the rows and columns line up:
+  `time = nil`) in order to make the rows and columns line up:
 
+      iex> time_1_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_1_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_1_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_3 = ~N[2026-05-27T13:35:00] |> Timex.Timezone.convert("America/New_York")
+      iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
       ...>     # First trip visits all of the stops
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_1,
       ...>       stop: %Stops.Stop{id: "first_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_3,
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     # Second trip doesn't visit `second_stop`.
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_1,
       ...>       stop: %Stops.Stop{id: "first_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:35:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_3,
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
@@ -117,11 +128,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:05 PM",
+                time: time_1_1,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:05 PM",
+                time: time_2_1,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -132,11 +143,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "second_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:25 PM",
+                time: time_1_2,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "",
+                time: nil,
                 trip: %{id: "second_trip", name: nil}
               }
             ]
@@ -145,11 +156,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "third_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:45 PM",
+                time: time_1_3,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:35 PM",
+                time: time_2_3,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -164,20 +175,24 @@ defmodule Dotcom.Timetables do
   When different trips visit the same stops in a different order, or when a single trip visits the same stop
   multiple times, `from_schedules/1` add multiple rows for the same stop.
 
+      iex> time_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1,
       ...>       stop: %Stops.Stop{id: "first_and_last_stop"},
       ...>       trip: %Schedules.Trip{id: "loop_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "loop_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_3,
       ...>       stop: %Stops.Stop{id: "first_and_last_stop"},
       ...>       trip: %Schedules.Trip{id: "loop_trip"}
       ...>     }
@@ -189,7 +204,7 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_and_last_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:05 PM",
+                time: time_1,
                 trip: %Schedules.Trip{id: "loop_trip"}
               }
             ]
@@ -198,7 +213,7 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "second_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:25 PM",
+                time: time_2,
                 trip: %Schedules.Trip{id: "loop_trip"}
               }
             ]
@@ -207,7 +222,7 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_and_last_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:45 PM",
+                time: time_3,
                 trip: %Schedules.Trip{id: "loop_trip"}
               }
             ]
@@ -218,36 +233,43 @@ defmodule Dotcom.Timetables do
         ]
       }
 
+      iex> time_1_2 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_1_3 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_1_1 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> time_2_3 = ~N[2026-05-27T13:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
       ...>     # First trip visits `first_or_last_stop` last.
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_3,
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_1_1,
       ...>       stop: %Stops.Stop{id: "first_or_last_stop"},
       ...>       trip: %Schedules.Trip{id: "first_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_1,
       ...>       stop: %Stops.Stop{id: "first_or_last_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_2,
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
       ...>     %Schedules.Schedule{
-      ...>       departure_time: ~N[2026-05-27T13:45:00] |> Timex.Timezone.convert("America/New_York"),
+      ...>       departure_time: time_2_3,
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
@@ -261,11 +283,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_or_last_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "",
+                time: nil,
                 trip: %{id: "first_trip", name: nil}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:05 PM",
+                time: time_2_1,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -274,11 +296,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "second_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:05 PM",
+                time: time_1_2,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:25 PM",
+                time: time_2_2,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -287,11 +309,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "third_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:25 PM",
+                time: time_1_3,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "1:45 PM",
+                time: time_2_3,
                 trip: %Schedules.Trip{id: "second_trip"}
               }
             ]
@@ -302,11 +324,11 @@ defmodule Dotcom.Timetables do
             stop: %Stops.Stop{id: "first_or_last_stop"},
             cells: [
               %Dotcom.Timetables.Timetable.Cell{
-                time: "12:45 PM",
+                time: time_1_1,
                 trip: %Schedules.Trip{id: "first_trip"}
               },
               %Dotcom.Timetables.Timetable.Cell{
-                time: "",
+                time: nil,
                 trip: %{id: "second_trip", name: nil}
               }
             ]
@@ -417,7 +439,7 @@ defmodule Dotcom.Timetables do
           cells_at_stop
           |> Enum.map(
             &%Timetable.Cell{
-              time: &1 |> time() |> format!(),
+              time: &1 |> time(),
               trip: &1.trip
             }
           )
@@ -431,9 +453,6 @@ defmodule Dotcom.Timetables do
   defp time(schedule) do
     schedule.departure_time || schedule.arrival_time
   end
-
-  defp format!(nil), do: ""
-  defp format!(time), do: Dotcom.Utils.Time.format!(time, :hour_12_minutes)
 
   # This function combines two lists of stops into a single list that
   # has all of the stops for both lists in the right order, possibly

--- a/lib/dotcom/timetables.ex
+++ b/lib/dotcom/timetables.ex
@@ -15,10 +15,18 @@ defmodule Dotcom.Timetables do
   The entries in each list correspond to the trips that visit that stop, so, for instance, the
   second item in each list will all be visits from the same trip.
 
+  ## Options
+
+  * `:date_time` - (required) A DateTime to use when calculating the offset. The offset will be
+    the index of the first trip in the trips list that has at least one stop in the future.
+
+  ## Examples
+
       iex> time_1_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_1_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
+      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -42,7 +50,8 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
-      ...>   ]
+      ...>   ],
+      ...>   date_time: now
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -79,10 +88,11 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ]
+        ],
+        offset: 0
       }
 
-  For trips that don't visit all of the stops, `from_schedules/1` inserts empty cells (with
+  For trips that don't visit all of the stops, `from_schedules/2` inserts empty cells (with
   `time = nil`) in order to make the rows and columns line up:
 
       iex> time_1_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
@@ -90,6 +100,7 @@ defmodule Dotcom.Timetables do
       iex> time_1_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_3 = ~N[2026-05-27T13:35:00] |> Timex.Timezone.convert("America/New_York")
+      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -120,7 +131,8 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
-      ...>   ]
+      ...>   ],
+      ...>   date_time: now
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -169,15 +181,17 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ]
+        ],
+        offset: 0
       }
 
   When different trips visit the same stops in a different order, or when a single trip visits the same stop
-  multiple times, `from_schedules/1` add multiple rows for the same stop.
+  multiple times, `from_schedules/2` add multiple rows for the same stop.
 
       iex> time_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -196,7 +210,8 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "first_and_last_stop"},
       ...>       trip: %Schedules.Trip{id: "loop_trip"}
       ...>     }
-      ...>   ]
+      ...>   ],
+      ...>   date_time: now
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -230,7 +245,8 @@ defmodule Dotcom.Timetables do
         ],
         trips: [
           %Schedules.Trip{id: "loop_trip"}
-        ]
+        ],
+        offset: 0
       }
 
       iex> time_1_2 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
@@ -239,6 +255,7 @@ defmodule Dotcom.Timetables do
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_3 = ~N[2026-05-27T13:45:00] |> Timex.Timezone.convert("America/New_York")
+      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -273,7 +290,8 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
-      ...>   ]
+      ...>   ],
+      ...>   date_time: now
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -337,7 +355,8 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ]
+        ],
+        offset: 0
       }
   """
 
@@ -351,8 +370,17 @@ defmodule Dotcom.Timetables do
   #
   # Second, it uses `build_timetable_rows/2` to map each trip onto the
   # combined stop list, inserting gaps where necessary.
-  @spec from_schedules([Schedules.Schedule.t()]) :: Timetable.t()
-  def from_schedules(schedules) do
+  @spec from_schedules([Schedules.Schedule.t()], keyword()) :: Timetable.t()
+  def from_schedules(schedules, opts \\ [])
+
+  def from_schedules([], opts) do
+    _date_time = Keyword.fetch!(opts, :date_time)
+    %Timetable{rows: [], trips: [], offset: 0}
+  end
+
+  def from_schedules(schedules, opts) do
+    date_time = Keyword.fetch!(opts, :date_time)
+
     schedule_lists_for_trips =
       schedules
       |> Enum.group_by(&%{id: &1.trip.id, name: &1.trip.name})
@@ -389,7 +417,32 @@ defmodule Dotcom.Timetables do
       schedule_lists_for_trips
       |> Enum.map(fn {_, [%Schedules.Schedule{trip: trip} | _]} -> trip end)
 
-    %Timetable{rows: rows, trips: trips}
+    offset = calculate_offset(schedule_lists_for_trips, date_time)
+
+    %Timetable{rows: rows, trips: trips, offset: offset}
+  end
+
+  # Calculates the offset: the index of the first trip that has at least one stop in the future.
+  # If the offset would go past the end of the list, returns the index of the last element.
+  defp calculate_offset(schedule_lists_for_trips, date_time) do
+    trip_count = length(schedule_lists_for_trips)
+
+    offset =
+      schedule_lists_for_trips
+      |> Enum.find_index(fn {_trip, schedules} ->
+        schedules
+        |> Enum.any?(fn schedule ->
+          schedule_time = time(schedule)
+          schedule_time && DateTime.compare(schedule_time, date_time) == :gt
+        end)
+      end)
+
+    # If no future trips found, return the index of the last element
+    # If offset is found, use it as-is
+    case offset do
+      nil -> max(trip_count - 1, 0)
+      index -> index
+    end
   end
 
   # Given a list of stops (the list that goes on the left on the

--- a/lib/dotcom/timetables.ex
+++ b/lib/dotcom/timetables.ex
@@ -15,18 +15,12 @@ defmodule Dotcom.Timetables do
   The entries in each list correspond to the trips that visit that stop, so, for instance, the
   second item in each list will all be visits from the same trip.
 
-  ## Options
-
-  * `:date_time` - (required) A DateTime to use when calculating the offset. The offset will be
-    the index of the first trip in the trips list that has at least one stop in the future.
-
   ## Examples
 
       iex> time_1_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_1_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
-      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -50,8 +44,7 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "second_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
-      ...>   ],
-      ...>   date_time: now
+      ...>   ]
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -88,8 +81,7 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ],
-        offset: 0
+        ]
       }
 
   For trips that don't visit all of the stops, `from_schedules/2` inserts empty cells (with
@@ -100,7 +92,6 @@ defmodule Dotcom.Timetables do
       iex> time_1_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_3 = ~N[2026-05-27T13:35:00] |> Timex.Timezone.convert("America/New_York")
-      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -131,8 +122,7 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     }
-      ...>   ],
-      ...>   date_time: now
+      ...>   ]
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -181,8 +171,7 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ],
-        offset: 0
+        ]
       }
 
   When different trips visit the same stops in a different order, or when a single trip visits the same stop
@@ -191,7 +180,6 @@ defmodule Dotcom.Timetables do
       iex> time_1 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2 = ~N[2026-05-27T12:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_3 = ~N[2026-05-27T12:45:00] |> Timex.Timezone.convert("America/New_York")
-      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -210,8 +198,7 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "first_and_last_stop"},
       ...>       trip: %Schedules.Trip{id: "loop_trip"}
       ...>     }
-      ...>   ],
-      ...>   date_time: now
+      ...>   ]
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -245,8 +232,7 @@ defmodule Dotcom.Timetables do
         ],
         trips: [
           %Schedules.Trip{id: "loop_trip"}
-        ],
-        offset: 0
+        ]
       }
 
       iex> time_1_2 = ~N[2026-05-27T12:05:00] |> Timex.Timezone.convert("America/New_York")
@@ -255,7 +241,6 @@ defmodule Dotcom.Timetables do
       iex> time_2_1 = ~N[2026-05-27T13:05:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_2 = ~N[2026-05-27T13:25:00] |> Timex.Timezone.convert("America/New_York")
       iex> time_2_3 = ~N[2026-05-27T13:45:00] |> Timex.Timezone.convert("America/New_York")
-      iex> now = ~N[2026-05-27T11:00:00] |> Timex.Timezone.convert("America/New_York")
       iex>
       iex> Dotcom.Timetables.from_schedules(
       ...>   [
@@ -290,8 +275,7 @@ defmodule Dotcom.Timetables do
       ...>       stop: %Stops.Stop{id: "third_stop"},
       ...>       trip: %Schedules.Trip{id: "second_trip"}
       ...>     },
-      ...>   ],
-      ...>   date_time: now
+      ...>   ]
       ...> )
       %Dotcom.Timetables.Timetable{
         rows: [
@@ -355,8 +339,7 @@ defmodule Dotcom.Timetables do
         trips: [
           %Schedules.Trip{id: "first_trip"},
           %Schedules.Trip{id: "second_trip"}
-        ],
-        offset: 0
+        ]
       }
   """
 
@@ -370,17 +353,8 @@ defmodule Dotcom.Timetables do
   #
   # Second, it uses `build_timetable_rows/2` to map each trip onto the
   # combined stop list, inserting gaps where necessary.
-  @spec from_schedules([Schedules.Schedule.t()], keyword()) :: Timetable.t()
-  def from_schedules(schedules, opts \\ [])
-
-  def from_schedules([], opts) do
-    _date_time = Keyword.fetch!(opts, :date_time)
-    %Timetable{rows: [], trips: [], offset: 0}
-  end
-
-  def from_schedules(schedules, opts) do
-    date_time = Keyword.fetch!(opts, :date_time)
-
+  @spec from_schedules([Schedules.Schedule.t()]) :: Timetable.t()
+  def from_schedules(schedules) do
     schedule_lists_for_trips =
       schedules
       |> Enum.group_by(&%{id: &1.trip.id, name: &1.trip.name})
@@ -417,9 +391,7 @@ defmodule Dotcom.Timetables do
       schedule_lists_for_trips
       |> Enum.map(fn {_, [%Schedules.Schedule{trip: trip} | _]} -> trip end)
 
-    offset = calculate_offset(schedule_lists_for_trips, date_time)
-
-    %Timetable{rows: rows, trips: trips, offset: offset}
+    %Timetable{rows: rows, trips: trips}
   end
 
   @doc """
@@ -446,29 +418,6 @@ defmodule Dotcom.Timetables do
     |> Enum.find_index(fn end_time -> DateTime.after?(end_time, now) end)
     |> case do
       nil -> max(Enum.count(trip_end_times) - 1, 0)
-      index -> index
-    end
-  end
-
-  # Calculates the offset: the index of the first trip that has at least one stop in the future.
-  # If the offset would go past the end of the list, returns the index of the last element.
-  defp calculate_offset(schedule_lists_for_trips, date_time) do
-    trip_count = length(schedule_lists_for_trips)
-
-    offset =
-      schedule_lists_for_trips
-      |> Enum.find_index(fn {_trip, schedules} ->
-        schedules
-        |> Enum.any?(fn schedule ->
-          schedule_time = time(schedule)
-          schedule_time && DateTime.compare(schedule_time, date_time) == :gt
-        end)
-      end)
-
-    # If no future trips found, return the index of the last element
-    # If offset is found, use it as-is
-    case offset do
-      nil -> max(trip_count - 1, 0)
       index -> index
     end
   end

--- a/lib/dotcom/timetables/timetable.ex
+++ b/lib/dotcom/timetables/timetable.ex
@@ -25,7 +25,7 @@ defmodule Dotcom.Timetables.Timetable do
     @moduledoc """
     A struct representing timetable cells. See `Dotcom.Timetables` for more information.
     """
-    defstruct [:time, :trip, :stop_id]
+    defstruct [:time, :trip]
 
     @type t() :: %__MODULE__{
             time: String.t(),

--- a/lib/dotcom/timetables/timetable.ex
+++ b/lib/dotcom/timetables/timetable.ex
@@ -2,11 +2,12 @@ defmodule Dotcom.Timetables.Timetable do
   @moduledoc """
   A struct representing timetables. See `Dotcom.Timetables` for more information.
   """
-  defstruct [:rows, :trips]
+  defstruct [:rows, :trips, :offset]
 
   @type t() :: %__MODULE__{
           rows: [__MODULE__.Row.t()],
-          trips: [Schedules.Trip.t()]
+          trips: [Schedules.Trip.t()],
+          offset: non_neg_integer()
         }
 
   defmodule Row do

--- a/lib/dotcom/timetables/timetable.ex
+++ b/lib/dotcom/timetables/timetable.ex
@@ -2,12 +2,11 @@ defmodule Dotcom.Timetables.Timetable do
   @moduledoc """
   A struct representing timetables. See `Dotcom.Timetables` for more information.
   """
-  defstruct [:rows, :trips, :offset]
+  defstruct [:rows, :trips]
 
   @type t() :: %__MODULE__{
           rows: [__MODULE__.Row.t()],
-          trips: [Schedules.Trip.t()],
-          offset: non_neg_integer()
+          trips: [Schedules.Trip.t()]
         }
 
   defmodule Row do

--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -224,7 +224,7 @@ defmodule DotcomWeb.Components.Timetable do
             :for={cell <- row.cells}
             class="js-tt-cell m-timetable__cell px-lg"
           >
-            {cell.time}
+            {format!(cell.time)}
           </td>
         </tr>
       </table>
@@ -353,4 +353,7 @@ defmodule DotcomWeb.Components.Timetable do
       "gray"
     end
   end
+
+  defp format!(nil), do: ""
+  defp format!(time), do: Dotcom.Utils.Time.format!(time, :hour_12_minutes)
 end

--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -201,7 +201,7 @@ defmodule DotcomWeb.Components.Timetable do
           <th
             :for={{trip, index} <- Enum.with_index(@timetable.trips)}
             class="m-timetable__header-cell"
-            data-scroll-to={index == @offset}
+            data-scroll-to={index == @timetable.offset}
             scope="col"
           >
             <span class="sr-only left-0">{~t(Trip)}</span>

--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -15,6 +15,8 @@ defmodule DotcomWeb.Components.Timetable do
 
   import MbtaMetro.Components.Icon
 
+  alias Dotcom.Timetables
+
   def linear_timetable(assigns) do
     ~H"""
     <div class="m-timetable__header hidden-no-js">
@@ -153,6 +155,10 @@ defmodule DotcomWeb.Components.Timetable do
   # `:if={!ferry?(@route)}`, which means that that section will need
   # to be added here before we can use this for non-ferry routes.
   def timetable(assigns) do
+    assigns =
+      assigns
+      |> assign(:offset, Timetables.first_unfinished_trip_index(assigns.timetable, assigns.now))
+
     ~H"""
     <div class="m-timetable__header hidden-no-js">
       <div class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header m-timetable__row-header--empty">
@@ -201,7 +207,7 @@ defmodule DotcomWeb.Components.Timetable do
           <th
             :for={{trip, index} <- Enum.with_index(@timetable.trips)}
             class="m-timetable__header-cell"
-            data-scroll-to={index == @timetable.offset}
+            data-scroll-to={index == @offset}
             scope="col"
           >
             <span class="sr-only left-0">{~t(Trip)}</span>

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -251,6 +251,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   def assign_trip_schedules(
         %{
           assigns: %{
+            date_time: date_time,
             route: route,
             blocking_alert: nil,
             date_in_rating?: true
@@ -265,7 +266,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     timetable =
       conn
       |> timetable_schedules()
-      |> Timetables.from_schedules()
+      |> Timetables.from_schedules(date_time: date_time)
 
     conn
     |> assign(:linear_timetable?, false)

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -251,7 +251,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   def assign_trip_schedules(
         %{
           assigns: %{
-            date_time: date_time,
             route: route,
             blocking_alert: nil,
             date_in_rating?: true
@@ -266,7 +265,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     timetable =
       conn
       |> timetable_schedules()
-      |> Timetables.from_schedules(date_time: date_time)
+      |> Timetables.from_schedules()
 
     conn
     |> assign(:linear_timetable?, false)

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -73,6 +73,7 @@
         <DotcomWeb.Components.Timetable.timetable
           direction_name={@direction_name}
           formatted_date={@formatted_date}
+	  now={@date_time}
           route={@route}
           timetable={@timetable}
           trip_count={@trip_count}

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -73,7 +73,6 @@
         <DotcomWeb.Components.Timetable.timetable
           direction_name={@direction_name}
           formatted_date={@formatted_date}
-          offset={assigns[:offset]}
           route={@route}
           timetable={@timetable}
           trip_count={@trip_count}

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -73,7 +73,7 @@
         <DotcomWeb.Components.Timetable.timetable
           direction_name={@direction_name}
           formatted_date={@formatted_date}
-	  now={@date_time}
+          now={@date_time}
           route={@route}
           timetable={@timetable}
           trip_count={@trip_count}

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -17,8 +17,7 @@ defmodule Dotcom.TimetablesTest do
 
   describe "from_schedules/2" do
     test "returns an empty list of rows if there are no schedules" do
-      now = Dotcom.Utils.DateTime.now()
-      assert %Timetables.Timetable{rows: []} = Timetables.from_schedules([], date_time: now)
+      assert %Timetables.Timetable{rows: []} = Timetables.from_schedules([])
     end
 
     test "serializes a single schedule into a single-cell timetable" do
@@ -27,7 +26,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1] = generate_times(1)
       trip = Factories.Schedules.Trip.build(:trip)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -38,7 +36,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -60,7 +58,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       trip = Factories.Schedules.Trip.build(:trip)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules =
         [
@@ -77,7 +74,7 @@ defmodule Dotcom.TimetablesTest do
         ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -105,7 +102,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       trip = Factories.Schedules.Trip.build(:trip)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules =
         [
@@ -122,7 +118,7 @@ defmodule Dotcom.TimetablesTest do
         ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -149,7 +145,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       [trip_1, trip_2] = generate_trips(2)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -165,7 +160,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -194,7 +189,6 @@ defmodule Dotcom.TimetablesTest do
       # this test mostly passed even without the sorting logic when
       # these were assigned as `[trip_1, trip2]`.
       [trip_2, trip_1] = generate_trips(2)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -210,7 +204,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -235,7 +229,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_1, time_1_2, time_2_1] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -256,7 +249,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -290,7 +283,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_1, time_1_2, time_2_2] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -311,7 +303,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -345,7 +337,6 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_2, time_2_1, time_2_2] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
-      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -366,7 +357,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert %Timetables.Timetable{
@@ -404,7 +395,7 @@ defmodule Dotcom.TimetablesTest do
           ServiceDateTime.end_of_service_day(today)
         })
 
-      timetable = Timetables.from_schedules([], date_time: now)
+      timetable = Timetables.from_schedules([])
 
       # Verify
       assert Timetables.first_unfinished_trip_index(timetable, now) == 0
@@ -431,7 +422,7 @@ defmodule Dotcom.TimetablesTest do
 
       # Exercise
       now = Generators.ServiceDateTime.earlier_on_day(time_1)
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert Timetables.first_unfinished_trip_index(timetable, now) == 0
@@ -463,11 +454,11 @@ defmodule Dotcom.TimetablesTest do
 
       # Exercise / Verify
       now = Generators.DateTime.random_time_range_date_time({time_1, time_2})
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
       assert Timetables.first_unfinished_trip_index(timetable, now) == 1
 
       now = Generators.DateTime.random_time_range_date_time({time_2, time_3})
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
       assert Timetables.first_unfinished_trip_index(timetable, now) == 2
     end
 
@@ -497,7 +488,7 @@ defmodule Dotcom.TimetablesTest do
 
       # Exercise
       now = Generators.ServiceDateTime.later_on_day(time_3)
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify
       assert Timetables.first_unfinished_trip_index(timetable, now) == 2
@@ -537,7 +528,7 @@ defmodule Dotcom.TimetablesTest do
 
       # Exercise
       now = Generators.DateTime.random_time_range_date_time({time_1_1, time_1_3})
-      timetable = Timetables.from_schedules(schedules, date_time: now)
+      timetable = Timetables.from_schedules(schedules)
 
       # Verify - should return 0 because trip_1 has at least one future stop
       assert Timetables.first_unfinished_trip_index(timetable, now) == 0

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -15,7 +15,7 @@ defmodule Dotcom.TimetablesTest do
     :ok
   end
 
-  describe "from_schedules/2" do
+  describe "from_schedules/1" do
     test "returns an empty list of rows if there are no schedules" do
       assert %Timetables.Timetable{rows: []} = Timetables.from_schedules([])
     end

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -407,7 +407,7 @@ defmodule Dotcom.TimetablesTest do
       timetable = Timetables.from_schedules([], date_time: now)
 
       # Verify
-      assert timetable.offset == 0
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
     end
 
     test "assigns an offset of 0 when date_time is before all trips" do
@@ -434,7 +434,7 @@ defmodule Dotcom.TimetablesTest do
       timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
-      assert timetable.offset == 0
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
     end
 
     test "assigns an offset of index of first trip with future stop when date_time is between trips" do
@@ -464,11 +464,11 @@ defmodule Dotcom.TimetablesTest do
       # Exercise / Verify
       now = Generators.DateTime.random_time_range_date_time({time_1, time_2})
       timetable = Timetables.from_schedules(schedules, date_time: now)
-      assert timetable.offset == 1
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 1
 
       now = Generators.DateTime.random_time_range_date_time({time_2, time_3})
       timetable = Timetables.from_schedules(schedules, date_time: now)
-      assert timetable.offset == 2
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 2
     end
 
     test "assigns an offset of last index when all trips are in the past" do
@@ -500,7 +500,7 @@ defmodule Dotcom.TimetablesTest do
       timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
-      assert timetable.offset == 2
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 2
     end
 
     test "considers any stop in the future for a trip" do
@@ -540,7 +540,7 @@ defmodule Dotcom.TimetablesTest do
       timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify - should return 0 because trip_1 has at least one future stop
-      assert timetable.offset == 0
+      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
     end
   end
 

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -47,7 +47,7 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1.time == format!(time_1)
+      assert entry_1.time == time_1
       assert entry_1.trip.id == trip.id
     end
 
@@ -85,13 +85,13 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1.time == format!(time_1)
+      assert entry_1.time == time_1
       assert entry_1.trip.id == trip.id
 
       assert [entry_2] = row_2.cells
       assert row_2.stop == stop_2
 
-      assert entry_2.time == format!(time_2)
+      assert entry_2.time == time_2
       assert entry_2.trip.id == trip.id
     end
 
@@ -129,13 +129,13 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1.time == format!(time_1)
+      assert entry_1.time == time_1
       assert entry_1.trip.id == trip.id
 
       assert [entry_2] = row_2.cells
       assert row_2.stop == stop_2
 
-      assert entry_2.time == format!(time_2)
+      assert entry_2.time == time_2
       assert entry_2.trip.id == trip.id
     end
 
@@ -171,10 +171,10 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1, entry_2] = row_1.cells
       assert row_1.stop == stop
 
-      assert entry_1.time == format!(time_1)
+      assert entry_1.time == time_1
       assert entry_1.trip.id == trip_1.id
 
-      assert entry_2.time == format!(time_2)
+      assert entry_2.time == time_2
       assert entry_2.trip.id == trip_2.id
     end
 
@@ -215,10 +215,10 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1, entry_2] = row_1.cells
       assert row_1.stop == stop
 
-      assert entry_1.time == format!(time_1)
+      assert entry_1.time == time_1
       assert entry_1.trip.id == trip_1.id
 
-      assert entry_2.time == format!(time_2)
+      assert entry_2.time == time_2
       assert entry_2.trip.id == trip_2.id
     end
 
@@ -260,19 +260,19 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1_1, entry_2_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1_1.time == format!(time_1_1)
+      assert entry_1_1.time == time_1_1
       assert entry_1_1.trip.id == trip_1.id
 
-      assert entry_2_1.time == format!(time_2_1)
+      assert entry_2_1.time == time_2_1
       assert entry_2_1.trip.id == trip_2.id
 
       assert [entry_1_2, entry_2_2] = row_2.cells
       assert row_2.stop == stop_2
 
-      assert entry_1_2.time == format!(time_1_2)
+      assert entry_1_2.time == time_1_2
       assert entry_1_2.trip.id == trip_1.id
 
-      assert entry_2_2.time == ""
+      assert entry_2_2.time == nil
       assert entry_2_2.trip.id == trip_2.id
     end
 
@@ -314,19 +314,19 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1_1, entry_2_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1_1.time == format!(time_1_1)
+      assert entry_1_1.time == time_1_1
       assert entry_1_1.trip.id == trip_1.id
 
-      assert entry_2_1.time == ""
+      assert entry_2_1.time == nil
       assert entry_2_1.trip.id == trip_2.id
 
       assert [entry_1_2, entry_2_2] = row_2.cells
       assert row_2.stop == stop_2
 
-      assert entry_1_2.time == format!(time_1_2)
+      assert entry_1_2.time == time_1_2
       assert entry_1_2.trip.id == trip_1.id
 
-      assert entry_2_2.time == format!(time_2_2)
+      assert entry_2_2.time == time_2_2
       assert entry_2_2.trip.id == trip_2.id
     end
 
@@ -368,19 +368,19 @@ defmodule Dotcom.TimetablesTest do
       assert [entry_1_1, entry_2_1] = row_1.cells
       assert row_1.stop == stop_1
 
-      assert entry_1_1.time == ""
+      assert entry_1_1.time == nil
       assert entry_1_1.trip.id == trip_1.id
 
-      assert entry_2_1.time == format!(time_2_1)
+      assert entry_2_1.time == time_2_1
       assert entry_2_1.trip.id == trip_2.id
 
       assert [entry_1_2, entry_2_2] = row_2.cells
       assert row_2.stop == stop_2
 
-      assert entry_1_2.time == format!(time_1_2)
+      assert entry_1_2.time == time_1_2
       assert entry_1_2.trip.id == trip_1.id
 
-      assert entry_2_2.time == format!(time_2_2)
+      assert entry_2_2.time == time_2_2
       assert entry_2_2.trip.id == trip_2.id
     end
   end
@@ -402,9 +402,5 @@ defmodule Dotcom.TimetablesTest do
       })
     end)
     |> Enum.sort(DateTime)
-  end
-
-  defp format!(time) do
-    Dotcom.Utils.Time.format!(time, :hour_12_minutes)
   end
 end

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -15,9 +15,10 @@ defmodule Dotcom.TimetablesTest do
     :ok
   end
 
-  describe "from_schedules/1" do
+  describe "from_schedules/2" do
     test "returns an empty list of rows if there are no schedules" do
-      assert %Timetables.Timetable{rows: []} = Timetables.from_schedules([])
+      now = Dotcom.Utils.DateTime.now()
+      assert %Timetables.Timetable{rows: []} = Timetables.from_schedules([], date_time: now)
     end
 
     test "serializes a single schedule into a single-cell timetable" do
@@ -26,6 +27,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1] = generate_times(1)
       trip = Factories.Schedules.Trip.build(:trip)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -36,7 +38,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -58,6 +60,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       trip = Factories.Schedules.Trip.build(:trip)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules =
         [
@@ -74,7 +77,7 @@ defmodule Dotcom.TimetablesTest do
         ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -102,6 +105,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       trip = Factories.Schedules.Trip.build(:trip)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules =
         [
@@ -118,7 +122,7 @@ defmodule Dotcom.TimetablesTest do
         ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -145,6 +149,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1, time_2] = generate_times(2)
       [trip_1, trip_2] = generate_trips(2)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -160,7 +165,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -189,6 +194,7 @@ defmodule Dotcom.TimetablesTest do
       # this test mostly passed even without the sorting logic when
       # these were assigned as `[trip_1, trip2]`.
       [trip_2, trip_1] = generate_trips(2)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -204,7 +210,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -229,6 +235,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_1, time_1_2, time_2_1] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -249,7 +256,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -283,6 +290,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_1, time_1_2, time_2_2] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -303,7 +311,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -337,6 +345,7 @@ defmodule Dotcom.TimetablesTest do
 
       [time_1_2, time_2_1, time_2_2] = generate_times(3)
       [trip_1, trip_2] = generate_trips(2)
+      now = Dotcom.Utils.DateTime.now()
 
       schedules = [
         Factories.Schedules.Schedule.build(:schedule,
@@ -357,7 +366,7 @@ defmodule Dotcom.TimetablesTest do
       ]
 
       # Exercise
-      timetable = Timetables.from_schedules(schedules)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
 
       # Verify
       assert %Timetables.Timetable{
@@ -382,6 +391,156 @@ defmodule Dotcom.TimetablesTest do
 
       assert entry_2_2.time == time_2_2
       assert entry_2_2.trip.id == trip_2.id
+    end
+
+    test "assigns an offset of 0 for empty schedule list" do
+      # Setup
+      today = Generators.Date.random_date()
+
+      # Exercise
+      now =
+        Generators.DateTime.random_time_range_date_time({
+          ServiceDateTime.beginning_of_service_day(today),
+          ServiceDateTime.end_of_service_day(today)
+        })
+
+      timetable = Timetables.from_schedules([], date_time: now)
+
+      # Verify
+      assert timetable.offset == 0
+    end
+
+    test "assigns an offset of 0 when date_time is before all trips" do
+      # Setup
+      stop = Factories.Stops.Stop.build(:stop)
+      [time_1, time_2] = generate_times(2)
+      [trip_1, trip_2] = generate_trips(2)
+
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1,
+          stop: stop
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_2,
+          departure_time: time_2,
+          stop: stop
+        )
+      ]
+
+      # Exercise
+      now = Generators.ServiceDateTime.earlier_on_day(time_1)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
+
+      # Verify
+      assert timetable.offset == 0
+    end
+
+    test "assigns an offset of index of first trip with future stop when date_time is between trips" do
+      # Setup
+      stop = Factories.Stops.Stop.build(:stop)
+      [time_1, time_2, time_3] = generate_times(3)
+      [trip_1, trip_2, trip_3] = generate_trips(3)
+
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1,
+          stop: stop
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_2,
+          departure_time: time_2,
+          stop: stop
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_3,
+          departure_time: time_3,
+          stop: stop
+        )
+      ]
+
+      # Exercise / Verify
+      now = Generators.DateTime.random_time_range_date_time({time_1, time_2})
+      timetable = Timetables.from_schedules(schedules, date_time: now)
+      assert timetable.offset == 1
+
+      now = Generators.DateTime.random_time_range_date_time({time_2, time_3})
+      timetable = Timetables.from_schedules(schedules, date_time: now)
+      assert timetable.offset == 2
+    end
+
+    test "assigns an offset of last index when all trips are in the past" do
+      # Setup
+      stop = Factories.Stops.Stop.build(:stop)
+      [time_1, time_2, time_3] = generate_times(3)
+      [trip_1, trip_2, trip_3] = generate_trips(3)
+
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1,
+          stop: stop
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_2,
+          departure_time: time_2,
+          stop: stop
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_3,
+          departure_time: time_3,
+          stop: stop
+        )
+      ]
+
+      # Exercise
+      now = Generators.ServiceDateTime.later_on_day(time_3)
+      timetable = Timetables.from_schedules(schedules, date_time: now)
+
+      # Verify
+      assert timetable.offset == 2
+    end
+
+    test "considers any stop in the future for a trip" do
+      # Setup - trip with multiple stops, only last one is in the future
+      stop_1 = Factories.Stops.Stop.build(:stop)
+      stop_2 = Factories.Stops.Stop.build(:stop)
+      stop_3 = Factories.Stops.Stop.build(:stop)
+
+      [time_1_1, time_1_2, time_1_3, time_2_1] = generate_times(4)
+      [trip_1, trip_2] = generate_trips(2)
+
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1_1,
+          stop: stop_1
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1_2,
+          stop: stop_2
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_1,
+          departure_time: time_1_3,
+          stop: stop_3
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          trip: trip_2,
+          departure_time: time_2_1,
+          stop: stop_1
+        )
+      ]
+
+      # Exercise
+      now = Generators.DateTime.random_time_range_date_time({time_1_1, time_1_3})
+      timetable = Timetables.from_schedules(schedules, date_time: now)
+
+      # Verify - should return 0 because trip_1 has at least one future stop
+      assert timetable.offset == 0
     end
   end
 

--- a/test/dotcom/timetables_test.exs
+++ b/test/dotcom/timetables_test.exs
@@ -383,10 +383,13 @@ defmodule Dotcom.TimetablesTest do
       assert entry_2_2.time == time_2_2
       assert entry_2_2.trip.id == trip_2.id
     end
+  end
 
-    test "assigns an offset of 0 for empty schedule list" do
+  describe "first_unfinished_trip_index/2" do
+    test "returns 0 for empty schedule list" do
       # Setup
       today = Generators.Date.random_date()
+      timetable = Timetables.from_schedules([])
 
       # Exercise
       now =
@@ -395,13 +398,13 @@ defmodule Dotcom.TimetablesTest do
           ServiceDateTime.end_of_service_day(today)
         })
 
-      timetable = Timetables.from_schedules([])
+      index = Timetables.first_unfinished_trip_index(timetable, now)
 
       # Verify
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
+      assert index == 0
     end
 
-    test "assigns an offset of 0 when date_time is before all trips" do
+    test "returns 0 when now is before all trips" do
       # Setup
       stop = Factories.Stops.Stop.build(:stop)
       [time_1, time_2] = generate_times(2)
@@ -420,15 +423,17 @@ defmodule Dotcom.TimetablesTest do
         )
       ]
 
+      timetable = Timetables.from_schedules(schedules)
+
       # Exercise
       now = Generators.ServiceDateTime.earlier_on_day(time_1)
-      timetable = Timetables.from_schedules(schedules)
+      index = Timetables.first_unfinished_trip_index(timetable, now)
 
       # Verify
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
+      assert index == 0
     end
 
-    test "assigns an offset of index of first trip with future stop when date_time is between trips" do
+    test "returns index of first trip with future stop when date_time is between trips" do
       # Setup
       stop = Factories.Stops.Stop.build(:stop)
       [time_1, time_2, time_3] = generate_times(3)
@@ -451,18 +456,22 @@ defmodule Dotcom.TimetablesTest do
           stop: stop
         )
       ]
+
+      timetable = Timetables.from_schedules(schedules)
 
       # Exercise / Verify
-      now = Generators.DateTime.random_time_range_date_time({time_1, time_2})
-      timetable = Timetables.from_schedules(schedules)
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 1
+      assert Timetables.first_unfinished_trip_index(
+               timetable,
+               Generators.DateTime.random_time_range_date_time({time_1, time_2})
+             ) == 1
 
-      now = Generators.DateTime.random_time_range_date_time({time_2, time_3})
-      timetable = Timetables.from_schedules(schedules)
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 2
+      assert Timetables.first_unfinished_trip_index(
+               timetable,
+               Generators.DateTime.random_time_range_date_time({time_2, time_3})
+             ) == 2
     end
 
-    test "assigns an offset of last index when all trips are in the past" do
+    test "returns the last index when all trips are in the past" do
       # Setup
       stop = Factories.Stops.Stop.build(:stop)
       [time_1, time_2, time_3] = generate_times(3)
@@ -485,13 +494,16 @@ defmodule Dotcom.TimetablesTest do
           stop: stop
         )
       ]
+
+      timetable = Timetables.from_schedules(schedules)
 
       # Exercise
       now = Generators.ServiceDateTime.later_on_day(time_3)
-      timetable = Timetables.from_schedules(schedules)
+
+      index = Timetables.first_unfinished_trip_index(timetable, now)
 
       # Verify
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 2
+      assert index == 2
     end
 
     test "considers any stop in the future for a trip" do
@@ -526,12 +538,14 @@ defmodule Dotcom.TimetablesTest do
         )
       ]
 
-      # Exercise
-      now = Generators.DateTime.random_time_range_date_time({time_1_1, time_1_3})
       timetable = Timetables.from_schedules(schedules)
 
+      # Exercise
+      now = Generators.DateTime.random_time_range_date_time({time_1_1, time_1_3})
+      index = Timetables.first_unfinished_trip_index(timetable, now)
+
       # Verify - should return 0 because trip_1 has at least one future stop
-      assert Timetables.first_unfinished_trip_index(timetable, now) == 0
+      assert index == 0
     end
   end
 


### PR DESCRIPTION
## Scope

~No ticket, but I noticed that this hasn't worked since [I introduced the new timetable for loopy ferries](https://github.com/mbta/dotcom/pull/3206)... I just completely forgot to do the offset thing!~

I was wrong! There was a ticket!

**Asana Ticket**: [⛴️🐞 New timetables don't auto-scroll to the right trip](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216392923703216?focus=true)

## Implementation

- Change the timetable to deal with `DateTime`'s instead of `String`'s. 
- Have the `Timetables` module calculate the offset based on a `date_time` argument.

The commits in this PR do somewhat show a journey, since I changed my approach partway through, but the easiest way to review it is probably to look at [the first commit](https://github.com/mbta/dotcom/pull/3361/changes/16b74de072b014f8e6c24a1f747bb0393fd831d9), which changes the times stored in the `Timetable` struct from strings to proper `DateTime`'s, and then to look at the whole PR (most importantly, the `Dotcom.Timetables.first_unfinished_trip_index/2` function).

## Screenshots

<img width="1998" height="1334" alt="Screenshot 2026-07-24 at 2 38 00 PM" src="https://github.com/user-attachments/assets/3d0f28f2-f5dd-40ff-8a0d-e3ba8eafef7d" />

## How to test

Check out timetables for the [Quincy](http://localhost:4001/schedules/Boat-F7/timetable), [Winthrop](http://localhost:4001/schedules/Boat-F6/timetable), and [Harbor Loop](http://localhost:4001/schedules/Boat-F10/timetable) ferries. Note that they scroll to the right trip.

You can fake the definition of `now` in order to try out other times (like before the first trip starts, or after the last trip ends) by changing [this line](https://github.com/mbta/dotcom/blob/63c29d0a1166b1b9a29c865c996d58756d469ff6/lib/dotcom/utils/date_time.ex#L30) to something like 👇 
```elixir
def now(), do: ~N[2026-07-24T14:43:00] |> Timex.to_datetime("America/New_York")
```
