### PR TITLE
Experiment:  Preserve customer support form info between refreshes

### DIFF
--- a/assets/js/support-form.js
+++ b/assets/js/support-form.js
@@ -21,6 +21,10 @@ export default function($ = window.jQuery) {
         handleSubmitClick($, toUpload);
         handleModeChangeSelection($);
         handleSubjectChange($);
+        loadCache();
+        document.getElementById("support").addEventListener("change", saveCache)
+        document.getElementById("support").addEventListener("submit", clearCache)
+
       });
     },
     { passive: true }
@@ -551,6 +555,7 @@ export function handleSubmitClick($, toUpload) {
         $(".support-confirmation--error").addClass("hidden-xs-up");
         reactivateSubmitButton($);
         $("#support").remove();
+        clearCache();
       },
       error: (xhr, errorString, errorObject) => {
         console.error(errorString);
@@ -575,4 +580,34 @@ export function handleSubjectChange($) {
   });
 
   subjectEl.change(); // initialize with right value
+}
+
+export const saveCache = ()=>{
+  const { elements } = document.getElementById("support")
+  const cacheString = JSON.stringify({time: Date.now(), data: Array.from(elements).map(elem => [elem.id, elem.checked || elem.value])})
+  console.log({cacheString})
+  localStorage.setItem("support-form-cache", cacheString)
+
+}
+
+export const loadCache = ()=>{
+  const cacheString = localStorage.getItem("support-form-cache")
+
+  if(!cacheString || cacheString.length<10){console.log("No data");return;}//No data, bail
+  const cacheData = JSON.parse(cacheString)
+  if(cacheData.time < Date.now()-86400000){console.log("Old data");return;}//Data is too old, bail
+  cacheData.data.forEach(([id, value])=>{
+    if(id && document.getElementById(id)){
+      if(value===true){
+        document.getElementById(id).click();
+      }else{
+        document.getElementById(id).value = value;
+      }
+    }
+  });
+}
+
+export const clearCache = ()=>{
+  console.log("CLEAR");
+  localStorage.setItem("support-form-cache","");
 }

--- a/assets/js/support-form.js
+++ b/assets/js/support-form.js
@@ -590,24 +590,39 @@ export const saveCache = ()=>{
 
 }
 
+const CACHE_MAX_AGE = 24 * 60 * 60 * 1000;
+
 export const loadCache = ()=>{
   const cacheString = localStorage.getItem("support-form-cache")
 
   if(!cacheString || cacheString.length<10){return;}//No data, bail
-  const cacheData = JSON.parse(cacheString)
-  if(cacheData.time < Date.now()-86400000){return;}//Data is too old, bail
-  cacheData.data.forEach(([id, value])=>{
-    const elem = document.getElementById(id);
-    if(id && elem){
-      if(elem.type == "file"){return;}
-      if(value===true){
-        elem.click();
-      }else{
-        elem.value = value;
-        elem.dispatchEvent(new Event("change"))
+  try{
+
+    const cacheData = JSON.parse(cacheString)
+    if(!cacheData.data || 
+      !cacheData.time || 
+      isNaN(cacheData.time) || 
+      cacheData.time < Date.now()-CACHE_MAX_AGE
+    ){
+      return;
+    }//Data is invalid or too old, bail
+
+    cacheData.data.forEach(([id, value])=>{
+      const elem = document.getElementById(id);
+      if(id && elem){
+        if(elem.type == "file"){return;}
+        if(value===true){
+          elem.click();
+        }else{
+          elem.value = value;
+          elem.dispatchEvent(new Event("change"))
+        }
       }
-    }
-  });
+    });
+
+  }catch(e){
+    console.log(`Error parsing saved form data: ${e.message}`)
+  }
 }
 
 export const clearCache = ()=>{

--- a/assets/js/support-form.js
+++ b/assets/js/support-form.js
@@ -23,6 +23,7 @@ export default function($ = window.jQuery) {
         handleSubjectChange($);
         loadCache();
         document.getElementById("support").addEventListener("change", saveCache)
+        document.getElementById("support").addEventListener("keypress", saveCache)
         document.getElementById("support").addEventListener("submit", clearCache)
 
       });
@@ -597,7 +598,8 @@ export const loadCache = ()=>{
   if(cacheData.time < Date.now()-86400000){return;}//Data is too old, bail
   cacheData.data.forEach(([id, value])=>{
     const elem = document.getElementById(id);
-    if(id && document.getElementById(id)){
+    if(id && elem){
+      if(elem.type == "file"){return;}
       if(value===true){
         elem.click();
       }else{

--- a/assets/js/support-form.js
+++ b/assets/js/support-form.js
@@ -585,7 +585,6 @@ export function handleSubjectChange($) {
 export const saveCache = ()=>{
   const { elements } = document.getElementById("support")
   const cacheString = JSON.stringify({time: Date.now(), data: Array.from(elements).map(elem => [elem.id, elem.checked || elem.value])})
-  console.log({cacheString})
   localStorage.setItem("support-form-cache", cacheString)
 
 }
@@ -593,21 +592,22 @@ export const saveCache = ()=>{
 export const loadCache = ()=>{
   const cacheString = localStorage.getItem("support-form-cache")
 
-  if(!cacheString || cacheString.length<10){console.log("No data");return;}//No data, bail
+  if(!cacheString || cacheString.length<10){return;}//No data, bail
   const cacheData = JSON.parse(cacheString)
-  if(cacheData.time < Date.now()-86400000){console.log("Old data");return;}//Data is too old, bail
+  if(cacheData.time < Date.now()-86400000){return;}//Data is too old, bail
   cacheData.data.forEach(([id, value])=>{
+    const elem = document.getElementById(id);
     if(id && document.getElementById(id)){
       if(value===true){
-        document.getElementById(id).click();
+        elem.click();
       }else{
-        document.getElementById(id).value = value;
+        elem.value = value;
+        elem.dispatchEvent(new Event("change"))
       }
     }
   });
 }
 
 export const clearCache = ()=>{
-  console.log("CLEAR");
   localStorage.setItem("support-form-cache","");
 }


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🙋 Investigate customer support form reloading issues](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216855140054434?focus=true)

## Implementation

As part of the above investigation I have written a stop-gap/band-aid fix that will make the experience less frustrating for users that experience page refreshes.

This JS code saves the state of the form in localStorage when any field is changed.  If the page is refreshed/loaded and the cached form data is <24h old, it will fill out the form and put the user back where they were.  

Unfortunately it is not allowed to set file inputs from JS, the user will have to manually re-select them. 

The Captcha will/should not be affected either.  Those clicks actually expire after a few minutes.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots


https://github.com/user-attachments/assets/61533828-5c0e-4a4c-a005-fab75de26304



## How to test

http://localhost:4001/customer-support

Play with the form, put it into various states, refresh and see if it behaves as expected.  Drop-downs, text fields, hidden/shown sections and checkboxes should all resume their previous state upon refresh.  If a user is typing when the form crashes/refreshes they should lose at most 1 character.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->

## Moving Forward

It appears that our DotcomWeb controllers import Phoenix.LiveView and that establishes a websocket connection and hearbeats.  However, on this page at least, no other data is being sent that way.  I think we should see if we can remove that requirement and see if the lack of a websocket connection will help.