### PR TITLE
Update timetable date picker to support selecting the current date

### DIFF
--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -196,10 +196,6 @@ defmodule BuildCalendar do
   end
 
   @spec build_url(url_fn, Date.t(), Date.t()) :: String.t()
-  defp build_url(url_fn, today, today) do
-    url_fn.(date: nil, date_select: nil, shift: nil)
-  end
-
   defp build_url(url_fn, date, _) do
     url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil)
   end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Update timetable date picker to support selecting the current date](https://app.asana.com/1/15492006741476/project/385363666817452/task/1215567127775712?focus=true)

## Implementation

Removed the special case that handled "today" and returned a nil URL.  Now "today" is treated like any other day.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="484" height="112" alt="Screenshot 2026-07-27 at 1 21 06 PM" src="https://github.com/user-attachments/assets/3fa1f92f-91b8-42f2-a456-958ba7ceb65d" />


## How to test

Open any timetable (http://localhost:4001/schedules/CR-NewBedford), open the datepicker and select Today (while already viewing Today's timetable).  Confirm that clicking on Today behaves the same as clicking on any other valid date.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
