### PR TITLE
[Fix]: Search tool breaks when you hit "enter" too soon

### DIFF
--- a/lib/dotcom_web/live/search_page_live.ex
+++ b/lib/dotcom_web/live/search_page_live.ex
@@ -59,7 +59,27 @@ defmodule DotcomWeb.SearchPageLive do
     end
   end
 
-  def handle_event(_, _, socket), do: {:noreply, socket}
+  def handle_event("find", %{"category" => category, "query" => query}, socket) do
+    enabled_categories =
+      category
+      |> Map.filter(fn {_key, v} -> v == "on" end)
+
+    {:noreply,
+     assign(socket, :query, query)
+     |> push_patch(query_patch_opts(query))
+     |> assign(
+       :chosen_categories,
+       if Enum.empty?(enabled_categories) do
+         nil
+       else
+         enabled_categories
+       end
+     )}
+  end
+
+  def handle_event(_event, _params, socket) do
+    {:noreply, socket}
+  end
 
   # Hide the open search filters
   def hide_filters(js \\ %JS{}), do: JS.hide(js, to: "#search-page-filters")


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞🔎 Search tool breaks when you hit "enter" too soon](https://app.asana.com/1/15492006741476/project/385363666817452/task/1213972909607100?focus=true)

## Implementation

Added event handler to handle the case where the user presses enter before the debounce period expires


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

https://github.com/user-attachments/assets/364e345f-a36e-4ac6-8445-b21d73429052


## How to test

http://localhost:4001/search

Enter a search term and press enter very quickly (<300ms after the last keystroke) and confirm that results now show.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
