### PR TITLE
[Fix]: Update timetable date picker to support selecting the current date

### DIFF
--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -201,7 +201,7 @@ defmodule BuildCalendar do
   end
 
   defp build_url(url_fn, date, _) do
-    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil)
+    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil, random: :rand.uniform())
   end
 
   @spec month_relation(Date.t(), Date.t(), Date.t()) :: __MODULE__.Day.month_relation()

--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -169,7 +169,7 @@ defmodule BuildCalendar do
     for date <- Date.range(first_day(shifted), last_day(shifted)) do
       %BuildCalendar.Day{
         date: date,
-        url: build_url(url_fn, date, today),
+        url: build_url(url_fn, date, today, selected),
         month_relation: month_relation(date, last_day_of_previous_month, last_day_of_this_month),
         selected?: date == selected,
         holiday?: MapSet.member?(holiday_set, date),
@@ -195,13 +195,26 @@ defmodule BuildCalendar do
     |> Date.end_of_week(:sunday)
   end
 
-  @spec build_url(url_fn, Date.t(), Date.t()) :: String.t()
-  defp build_url(url_fn, today, today) do
+  @spec build_url(url_fn, Date.t(), Date.t(), Date.t()) :: String.t()
+
+  defp build_url(url_fn, today, today, _) do
     url_fn.(date: nil, date_select: nil, shift: nil)
   end
 
-  defp build_url(url_fn, date, _) do
-    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil, random: :rand.uniform())
+  defp build_url(url_fn, date, _today, date) do
+    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil, r: rand_string(3))
+  end
+
+  defp build_url(url_fn, date, _, _) do
+    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil)
+  end
+
+  defp rand_string(length) do
+    0..(length - 1) |> Enum.to_list() |> Enum.map(fn _ -> rand_char() end) |> Enum.join()
+  end
+
+  defp rand_char() do
+    <<Enum.random(?a..?z)>>
   end
 
   @spec month_relation(Date.t(), Date.t(), Date.t()) :: __MODULE__.Day.month_relation()

--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -170,7 +170,7 @@ defmodule BuildCalendar do
     for date <- Date.range(first_day(shifted), last_day(shifted)) do
       %BuildCalendar.Day{
         date: date,
-        url: build_url(url_fn, date, today, selected),
+        url: build_url(url_fn, date, today),
         month_relation: month_relation(date, last_day_of_previous_month, last_day_of_this_month),
         selected?: date == selected,
         holiday?: MapSet.member?(holiday_set, date),
@@ -196,13 +196,13 @@ defmodule BuildCalendar do
     |> Date.end_of_week(:sunday)
   end
 
-  @spec build_url(url_fn, Date.t(), Date.t(), Date.t()) :: String.t()
+  @spec build_url(url_fn, Date.t(), Date.t()) :: String.t()
 
-  defp build_url(url_fn, today, today, _) do
+  defp build_url(url_fn, today, today) do
     url_fn.(date: nil, date_select: nil, shift: nil)
   end
 
-  defp build_url(url_fn, date, _, _) do
+  defp build_url(url_fn, date, _) do
     url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil)
   end
 

--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -89,7 +89,8 @@ defmodule BuildCalendar do
           {day.holiday?, "schedule-holiday"},
           {day.selected? && day.month_relation == :current, "schedule-selected"},
           {day.month_relation == :next, "schedule-next-month"},
-          {day.today?, "schedule-today"}
+          {day.today?, "schedule-today"},
+          {day.selected?, "date-picker-toggle"}
         ]
         |> Enum.filter(&match?({true, _}, &1))
         |> Enum.map(&elem(&1, 1))
@@ -201,20 +202,8 @@ defmodule BuildCalendar do
     url_fn.(date: nil, date_select: nil, shift: nil)
   end
 
-  defp build_url(url_fn, date, _today, date) do
-    url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil, r: rand_string(3))
-  end
-
   defp build_url(url_fn, date, _, _) do
     url_fn.(date: Date.to_iso8601(date), date_select: nil, shift: nil)
-  end
-
-  defp rand_string(length) do
-    0..(length - 1) |> Enum.to_list() |> Enum.map(fn _ -> rand_char() end) |> Enum.join()
-  end
-
-  defp rand_char() do
-    <<Enum.random(?a..?z)>>
   end
 
   @spec month_relation(Date.t(), Date.t(), Date.t()) :: __MODULE__.Day.month_relation()

--- a/test/build_calendar_test.exs
+++ b/test/build_calendar_test.exs
@@ -214,7 +214,8 @@ defmodule BuildCalendarTest do
           url: ""
         })
 
-      assert safe_to_string(actual) =~ ~s(class="schedule-selected")
+      assert safe_to_string(actual) =~ ~s(schedule-selected)
+      assert safe_to_string(actual) =~ ~s(date-picker-toggle)
     end
 
     test "if the day is selected but in the past, does not add a class" do
@@ -265,7 +266,7 @@ defmodule BuildCalendarTest do
           url: ""
         })
 
-      assert safe_to_string(actual) =~ ~s(class="schedule-weekend schedule-selected")
+      assert safe_to_string(actual) =~ ~s(schedule-weekend schedule-selected)
     end
 
     test "upcoming holidays includes today and future but not past" do


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Update timetable date picker to support selecting the current date](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215567127775712?focus=true)

## Implementation

It appears that our problem is that the URL is identical to the one w…e're on, and so the browser treats it as an anchor link (which it is) and scrolls to that anchor (which it's already on).  I added a random parameter to the URL to disable this behavior.  It works, and is not the first time I've used this trick, but I'm not sure it is the cleanest solution.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots


https://github.com/user-attachments/assets/e53d5e6a-c55c-4095-9ddf-d44fe5e557ad



## How to test

http://localhost:4001/schedules/CR-NewBedford/timetable

Confirm that re-selecting the currently selected date closes the calendar and refreshes the page.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
