### PR TITLE
QF | FunctionClauseError: no function clause matching in List.last/2

### DIFF
--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -224,12 +224,12 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
         date: date
       )
 
-    if is_nil(schedules) do
-      nil
-    else
+    if is_list(schedules) do
       schedules
       |> List.last(%{})
       |> Map.get(:time)
+    else
+      nil
     end
   end
 

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -215,15 +215,22 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
   end
 
-  defp get_last_trip_time(assigns, date) do
-    [assigns.route_id]
-    |> @schedules_repo.by_route_ids(
-      direction_id: assigns.direction_id,
-      stop_ids: [assigns.stop_id],
-      date: date
-    )
-    |> List.last(%{})
-    |> Map.get(:time)
+  def get_last_trip_time(assigns, date) do
+    schedules =
+      [assigns.route_id]
+      |> @schedules_repo.by_route_ids(
+        direction_id: assigns.direction_id,
+        stop_ids: [assigns.stop_id],
+        date: date
+      )
+
+    if is_nil(schedules) do
+      nil
+    else
+      schedules
+      |> List.last(%{})
+      |> Map.get(:time)
+    end
   end
 
   attr :upcoming_departures, :any,

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -215,7 +215,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
   end
 
-  def get_last_trip_time(assigns, date) do
+  defp get_last_trip_time(assigns, date) do
     schedules =
       [assigns.route_id]
       |> @schedules_repo.by_route_ids(

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -86,6 +86,10 @@ defmodule PredictedSchedule.Collection do
   @doc """
   Constructs a new `Collection` from a list of schedules.
   """
+  def new(nil) do
+    %{base: %{}, populated: %{}}
+  end
+
   def new(schedules) do
     predicted_schedule_map =
       schedules

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -86,11 +86,8 @@ defmodule PredictedSchedule.Collection do
   @doc """
   Constructs a new `Collection` from a list of schedules.
   """
-  def new(nil) do
-    %{base: %{}, populated: %{}}
-  end
 
-  def new(schedules) do
+  def new(schedules) when is_list(schedules) do
     predicted_schedule_map =
       schedules
       |> Map.new(fn schedule ->
@@ -98,6 +95,10 @@ defmodule PredictedSchedule.Collection do
       end)
 
     %{base: predicted_schedule_map, populated: predicted_schedule_map}
+  end
+
+  def new(_) do
+    %{base: %{}, populated: %{}}
   end
 
   @spec put_prediction(t(), Predictions.Prediction.t()) :: t()

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -266,11 +266,8 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     end)
 
     {:ok, view, _} = start_live_view(conn, route_id_param, direction_id, stop_id_param)
-    pid = view.pid
-    :erlang.trace(pid, true, [:receive])
 
-    assert_receive {:trace, ^pid, :receive,
-                    %Phoenix.Socket.Broadcast{event: "upcoming_departures"}}
+    assert render(view) =~ "There was a problem loading upcoming departures"
   end
 
   defp start_live_view(conn, route_id \\ nil, direction_id \\ nil, stop_id \\ nil) do

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -248,6 +248,31 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     assert render(view) =~ "There was a problem loading upcoming departures"
   end
 
+  test "doesn't crash if schedules are nil", %{conn: conn} do
+    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> nil end)
+
+    route_id_param = FactoryHelpers.build(:id)
+    stop_id_param = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+
+    expect(Routes.Repo.Mock, :get, 3, fn route_id ->
+      assert route_id == route_id_param
+      Factories.Routes.Route.build(:route)
+    end)
+
+    expect(Stops.Repo.Mock, :get, 2, fn stop_id ->
+      assert stop_id == stop_id_param
+      Factories.Stops.Stop.build(:stop, %{id: stop_id})
+    end)
+
+    {:ok, view, _} = start_live_view(conn, route_id_param, direction_id, stop_id_param)
+    pid = view.pid
+    :erlang.trace(pid, true, [:receive])
+
+    assert_receive {:trace, ^pid, :receive,
+                    %Phoenix.Socket.Broadcast{event: "upcoming_departures"}}
+  end
+
   defp start_live_view(conn, route_id \\ nil, direction_id \\ nil, stop_id \\ nil) do
     route_id = route_id || FactoryHelpers.build(:id)
     direction_id = direction_id || FactoryHelpers.build(:direction_id)


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | FunctionClauseError: no function clause matching in List.last/2](https://app.asana.com/1/15492006741476/project/385363666817452/task/1216670419144279?focus=true)

## Implementation
In the error logs above I found that the `get_last_trip_time` function was complaining that `Enum.last/2` doesn't exist for the arguments specified.  The function assumes that it will always get a list from `@schedules_repo.by_route_ids` but apparently this isn't always the case.  I assume it's getting a `nil` rarely?  I added code to detect `not a list` and handle it appropriately.  In my tests I found one other place that also assumed `schedules` was always a list and added a fix for that too.



<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

Unit test?  I am not sure how to reproduce this error manually.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
