### PR TITLE
feat: Restore the non-prod environment banner

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -65,19 +65,13 @@
   </head>
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
     <div class="body-wrapper" id="body-wrapper">
-      <%= if !Application.get_env(:dotcom, :is_prod_env?) && !Laboratory.enabled?(@conn, :use_smartling_translations) do %>
+      <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
         <% language =
           Dotcom.Gettext |> Gettext.get_locale() |> Dotcom.Locales.locale() |> Map.get(:endonym) %>
         <div class={["w-full py-2 text-center leading-sm", banner_color_classes()]}>
           <i class="fa fa-globe"></i>
           You are viewing <em>{Map.get(@conn, :host)}</em>
           in <strong>{language}</strong>.
-          <a
-            class="mx-sm btn btn-outline btn-sm leading-sm text-current border-current hover:opacity-50"
-            href={@conn.request_path <> "?locale=#{if(language == "English", do: "es", else: "en")}"}
-          >
-            Toggle {if(language == "English", do: "Spanish", else: "English")}
-          </a>
           <a
             :for={%{href: href, name: name, color_classes: color_classes} <- env_links(@conn)}
             class={[


### PR DESCRIPTION
## Scope

No ticket, but I figured the banner would be helpful even when the new navbar is enabled!

## Screenshots

<img width="2132" height="640" alt="Screenshot 2026-07-29 at 4 23 16 PM" src="https://github.com/user-attachments/assets/1b65b05f-c7a1-4586-9999-bc873d0fd292" />


I was originally worried that this might create problems with expanded-menu positioning (which is definitely true when the flag is disabled), but these menus actually work a lot better!

<img width="2070" height="934" alt="Screenshot 2026-07-29 at 4 25 47 PM" src="https://github.com/user-attachments/assets/2ec4f77d-dc52-402c-8871-7ea37c61f2a7" />
<img width="1002" height="798" alt="Screenshot 2026-07-29 at 4 25 38 PM" src="https://github.com/user-attachments/assets/2ab77bf0-6451-49e9-99fb-1fc725f45e8d" />

## How to test

Enabled the "Smartling translations" flag on [the flags page](http://localhost:4001/_flags), and see how the menus work!