### PR TITLE
feat: Make vehicle names translatable

### DIFF
--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -139,5 +139,5 @@ defmodule DotcomWeb.Components.NewTimetable do
   defp format!(nil), do: ""
   defp format!(time), do: Dotcom.Utils.Time.format!(time, :hour_12_minutes)
 
-  defp vehicle_name(route), do: Routes.Route.vehicle_name(route) <> "s"
+  defp vehicle_name(route), do: Routes.Route.vehicle_name(route, plural: true)
 end

--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -26,23 +26,21 @@ defmodule DotcomWeb.Components.Timetable do
         <% # only show scroll controllers if we have 2 or more schedules %>
         <%= if @trip_count >= 2 do %>
           <span class="m-timetable__trains-label">
-            {Routes.Route.vehicle_name(@route) <> "s"}
+            {vehicle_name(@route)}
           </span>
           <button
             class="m-timetable__scroll-btn m-timetable__scroll-btn--left btn btn-outline-primary btn-sm"
             data-scroll="earlier"
           >
-            {fa("angle-left m-timetable__scroll-btn-arrow")} {~t(Earlier)} {Routes.Route.vehicle_name(
-              @route
-            ) <> "s"}
+            {fa("angle-left m-timetable__scroll-btn-arrow")}
+            {gettext("Earlier %{vehicle_name}", vehicle_name: vehicle_name(@route))}
           </button>
           <button
             class="m-timetable__scroll-btn m-timetable__scroll-btn--right btn btn-outline-primary btn-sm"
             data-scroll="later"
           >
-            {~t(Later)} {Routes.Route.vehicle_name(@route) <> "s"} {fa(
-              "angle-right m-timetable__scroll-btn-arrow"
-            )}
+            {gettext("Later %{vehicle_name}", vehicle_name: vehicle_name(@route))}
+            {fa("angle-right m-timetable__scroll-btn-arrow")}
           </button>
         <% end %>
       </div>
@@ -167,23 +165,21 @@ defmodule DotcomWeb.Components.Timetable do
         <% # only show scroll controllers if we have 2 or more schedules %>
         <%= if @trip_count >= 2 do %>
           <span class="m-timetable__trains-label">
-            {Routes.Route.vehicle_name(@route) <> "s"}
+            {vehicle_name(@route)}
           </span>
           <button
             class="m-timetable__scroll-btn m-timetable__scroll-btn--left btn btn-outline-primary btn-sm"
             data-scroll="earlier"
           >
-            {fa("angle-left m-timetable__scroll-btn-arrow")} {~t(Earlier)} {Routes.Route.vehicle_name(
-              @route
-            ) <> "s"}
+            {fa("angle-left m-timetable__scroll-btn-arrow")}
+            {gettext("Earlier %{vehicle_name}", vehicle_name: vehicle_name(@route))}
           </button>
           <button
             class="m-timetable__scroll-btn m-timetable__scroll-btn--right btn btn-outline-primary btn-sm"
             data-scroll="later"
           >
-            {~t(Later)} {Routes.Route.vehicle_name(@route) <> "s"} {fa(
-              "angle-right m-timetable__scroll-btn-arrow"
-            )}
+            {gettext("Later %{vehicle_name}", vehicle_name: vehicle_name(@route))}
+            {fa("angle-right m-timetable__scroll-btn-arrow")}
           </button>
         <% end %>
       </div>
@@ -362,4 +358,6 @@ defmodule DotcomWeb.Components.Timetable do
 
   defp format!(nil), do: ""
   defp format!(time), do: Dotcom.Utils.Time.format!(time, :hour_12_minutes)
+
+  defp vehicle_name(route), do: Routes.Route.vehicle_name(route, plural: true)
 end

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -223,6 +223,8 @@ defmodule Routes.Route do
   def vehicle_name(%__MODULE__{type: 3}, plural: true), do: ~t"Buses"
   def vehicle_name(%__MODULE__{type: 4}, plural: true), do: ~t"Boats"
 
+  def vehicle_name(%__MODULE__{} = route, _opts), do: vehicle_name(route)
+
   def vehicle_name(%__MODULE__{type: type}) when type in [0, 1, 2], do: ~t"Train"
   def vehicle_name(%__MODULE__{type: 3}), do: ~t"Bus"
   def vehicle_name(%__MODULE__{type: 4}), do: ~t"Boat"

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -1,6 +1,8 @@
 defmodule Routes.Route do
   @moduledoc "Data model and helpers corresponding to the V3 API Route resource."
 
+  use Dotcom.Gettext.Sigils
+
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
   @derive Jason.Encoder
@@ -215,18 +217,15 @@ defmodule Routes.Route do
     Map.get(destinations, direction_id)
   end
 
+  @spec vehicle_name(t, Keyword.t()) :: String.t()
   @spec vehicle_name(t) :: String.t()
-  def vehicle_name(%__MODULE__{type: type}) when type in [0, 1, 2] do
-    "Train"
-  end
+  def vehicle_name(%__MODULE__{type: type}, plural: true) when type in [0, 1, 2], do: ~t"Trains"
+  def vehicle_name(%__MODULE__{type: 3}, plural: true), do: ~t"Buses"
+  def vehicle_name(%__MODULE__{type: 4}, plural: true), do: ~t"Boats"
 
-  def vehicle_name(%__MODULE__{type: 3}) do
-    "Bus"
-  end
-
-  def vehicle_name(%__MODULE__{type: 4}) do
-    "Boat"
-  end
+  def vehicle_name(%__MODULE__{type: type}) when type in [0, 1, 2], do: ~t"Train"
+  def vehicle_name(%__MODULE__{type: 3}), do: ~t"Bus"
+  def vehicle_name(%__MODULE__{type: 4}), do: ~t"Boat"
 
   @spec vehicle_atom(0..4) :: atom
   def vehicle_atom(0), do: :trolley

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -699,6 +699,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr ""
@@ -1260,11 +1261,6 @@ msgstr ""
 #: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
-msgstr ""
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
 msgstr ""
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
@@ -2084,7 +2080,6 @@ msgid "Last %{vehicle}"
 msgstr ""
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr ""
@@ -4413,6 +4408,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr ""
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr ""
@@ -5380,11 +5376,33 @@ msgid "Weekend schedules"
 msgstr ""
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr ""
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -699,6 +699,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr ""
@@ -1260,11 +1261,6 @@ msgstr ""
 #: lib/fares/retail_locations_data.ex
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
-msgstr ""
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
 msgstr ""
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
@@ -2084,7 +2080,6 @@ msgid "Last %{vehicle}"
 msgstr ""
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr ""
@@ -4413,6 +4408,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr ""
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr ""
@@ -5380,11 +5376,33 @@ msgid "Weekend schedules"
 msgstr ""
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr ""
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -701,6 +701,7 @@ msgstr "Llevar tu auto o bicicleta"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "autobús"
@@ -1264,11 +1265,6 @@ msgstr "Tarjeta EBT"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ pase"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "Antes"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2089,7 +2085,6 @@ msgid "Last %{vehicle}"
 msgstr "Último %{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Más tarde"
@@ -4431,6 +4426,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "Sigue tu viaje de %{route_type_text} en directo con la app <strong>MBTA Go</strong>"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Tren"
@@ -5403,11 +5399,33 @@ msgid "Weekend schedules"
 msgstr "Fin de semana horario"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "Antes %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "Más tarde %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5413,19 +5413,19 @@ msgstr "Más tarde %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "Barco"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "Barcos"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "Autobuses"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "Trenes"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5414,19 +5414,19 @@ msgstr "Plus tard %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "Bateau"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "Bateaux"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "Bus"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "Trains"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -701,6 +701,7 @@ msgstr "Emmener votre voiture ou votre vélo"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "bus"
@@ -1264,11 +1265,6 @@ msgstr "Carte EBT"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ titre de transport"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "Plus tôt"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2089,7 +2085,6 @@ msgid "Last %{vehicle}"
 msgstr "Dernier %{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Plus tard"
@@ -4433,6 +4428,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "Suivez votre %{route_type_text} voyage en direct avec l’application <strong>MBTA Go</strong>"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Train"
@@ -5404,11 +5400,33 @@ msgid "Weekend schedules"
 msgstr "Horaire week-end"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "Plus tôt %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "Plus tard %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5400,19 +5400,19 @@ msgstr "Pita %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "Bato"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "Bato"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "Bis yo"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "Tren yo"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -701,6 +701,7 @@ msgstr "Pote machin ou oswa bisiklèt ou"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "bis"
@@ -1264,11 +1265,6 @@ msgstr "Kat EBT"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "Pase fasil"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "Pi bonè"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2088,7 +2084,6 @@ msgid "Last %{vehicle}"
 msgstr "Dènye %{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Pita"
@@ -4421,6 +4416,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "Swiv vwayaj %{route_type_text} ou an dirèk avèk aplikasyon <strong>MBTA Go</strong> a"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Tren"
@@ -5390,11 +5386,33 @@ msgid "Weekend schedules"
 msgstr "Wikenn orè"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "Pi bonè %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "Pita %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -701,6 +701,7 @@ msgstr "Traga seu carro ou bicicleta."
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "ônibus"
@@ -1264,11 +1265,6 @@ msgstr "Cartão EBT"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "Passe fácil"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "Mais cedo"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2089,7 +2085,6 @@ msgid "Last %{vehicle}"
 msgstr "Último %{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Mais tarde"
@@ -4428,6 +4423,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "Acompanhe sua viagem %{route_type_text} em tempo real com o aplicativo <strong>MBTA Go.</strong>"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Trem"
@@ -5399,11 +5395,33 @@ msgid "Weekend schedules"
 msgstr "Horário de fim de semana"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "Anteriormente %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "Mais tarde %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5409,19 +5409,19 @@ msgstr "Mais tarde %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "Barco"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "Barcos"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "ônibus"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "Trens"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5405,19 +5405,19 @@ msgstr "Sau đó %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "Thuyền"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "Thuyền"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "Xe buýt"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "Tàu hỏa"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -695,6 +695,7 @@ msgstr "Mang theo ô tô hoặc xe đạp của bạn"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "xe buýt"
@@ -1258,11 +1259,6 @@ msgstr "Thẻ EBT"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ vé"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "Trước đó"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2083,7 +2079,6 @@ msgid "Last %{vehicle}"
 msgstr "Chuyến cuối cùng %{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "Sau đó"
@@ -4424,6 +4419,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "Theo dõi hành trình %{route_type_text} của bạn trực tiếp với ứng dụng <strong>MBTA Go</strong>"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "Xe lửa"
@@ -5395,11 +5391,33 @@ msgid "Weekend schedules"
 msgstr "Ngày cuối tuần lịch trình"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "Trước đó %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "Sau đó %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5384,19 +5384,19 @@ msgstr "稍后 %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "船"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "船"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "巴士"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "火车"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -693,6 +693,7 @@ msgstr "开车或骑自行车"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "巴士"
@@ -1255,11 +1256,6 @@ msgstr "EBT卡"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ 通票"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "早些时候"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2078,7 +2074,6 @@ msgid "Last %{vehicle}"
 msgstr "末班车%{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "之后"
@@ -4407,6 +4402,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "使用<strong>MBTA Go</strong>应用程序实时追踪您的%{route_type_text}行程"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "火车"
@@ -5374,11 +5370,33 @@ msgid "Weekend schedules"
 msgstr "周末时刻表"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "较早 %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "稍后 %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5384,19 +5384,19 @@ msgstr "稍後 %{vehicle_name}"
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boat"
-msgstr ""
+msgstr "船"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Boats"
-msgstr ""
+msgstr "船"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Buses"
-msgstr ""
+msgstr "巴士"
 
 #: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Trains"
-msgstr ""
+msgstr "火車"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -693,6 +693,7 @@ msgstr "開車或騎自行車"
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
 #: lib/dotcom_web/views/helpers.ex
 #: lib/dotcom_web/views/layout_view.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Bus"
 msgstr "巴士"
@@ -1255,11 +1256,6 @@ msgstr "EBT卡"
 #, elixir-autogen, elixir-format
 msgid "EZ Pass"
 msgstr "EZ 通票"
-
-#: lib/dotcom_web/components/timetable.ex
-#, elixir-autogen, elixir-format
-msgid "Earlier"
-msgstr "早些時候"
 
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
@@ -2078,7 +2074,6 @@ msgid "Last %{vehicle}"
 msgstr "末班車%{vehicle}"
 
 #: lib/dotcom/utils/service_date_time.ex
-#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later"
 msgstr "之後"
@@ -4407,6 +4402,7 @@ msgid "Track your %{route_type_text} trip live with the <strong>MBTA Go</strong>
 msgstr "使用<strong>MBTA Go</strong>應用程式即時追蹤您的%{route_type_text}行程"
 
 #: lib/dotcom_web/live/schedule_finder_live.ex
+#: lib/routes/route.ex
 #, elixir-autogen, elixir-format
 msgid "Train"
 msgstr "火車"
@@ -5374,11 +5370,33 @@ msgid "Weekend schedules"
 msgstr "週末時刻表"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Earlier %{vehicle_name}"
 msgstr "較早 %{vehicle_name}"
 
 #: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Later %{vehicle_name}"
 msgstr "稍後 %{vehicle_name}"
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boat"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Boats"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/routes/route.ex
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""

--- a/test/routes/route_test.exs
+++ b/test/routes/route_test.exs
@@ -157,7 +157,7 @@ defmodule Routes.RouteTest do
   end
 
   describe "vehicle_name/2" do
-    test "returns the appropriate type of vehicle when plural is specified" do
+    test "returns the appropriate type of vehicle when plural: true is specified" do
       for {type, name} <- [
             {0, "Trains"},
             {1, "Trains"},
@@ -166,6 +166,18 @@ defmodule Routes.RouteTest do
             {4, "Boats"}
           ] do
         assert vehicle_name(%Route{type: type}, plural: true) == name
+      end
+    end
+
+    test "returns the appropriate type of vehicle when plural: false is specified" do
+      for {type, name} <- [
+            {0, "Train"},
+            {1, "Train"},
+            {2, "Train"},
+            {3, "Bus"},
+            {4, "Boat"}
+          ] do
+        assert vehicle_name(%Route{type: type}, plural: false) == name
       end
     end
   end

--- a/test/routes/route_test.exs
+++ b/test/routes/route_test.exs
@@ -156,6 +156,20 @@ defmodule Routes.RouteTest do
     end
   end
 
+  describe "vehicle_name/2" do
+    test "returns the appropriate type of vehicle when plural is specified" do
+      for {type, name} <- [
+            {0, "Trains"},
+            {1, "Trains"},
+            {2, "Trains"},
+            {3, "Buses"},
+            {4, "Boats"}
+          ] do
+        assert vehicle_name(%Route{type: type}, plural: true) == name
+      end
+    end
+  end
+
   describe "frequent_route?" do
     test "true if rapid transit or key bus route" do
       assert frequent_route?(%Route{description: :frequent_bus_route})


### PR DESCRIPTION
## Scope

No ticket, but it turns out that appending `s` to a vehicle name does not reliably pluralize it

<img width="779" height="69" alt="Screenshot 2026-07-22 at 9 36 51 AM" src="https://github.com/user-attachments/assets/b0ccc40e-7a00-4376-88ef-6b9cdb2bfd85" />