### PR TITLE
cleanup: Remove `eslint-disable-next-line no-unused-vars` invocations

### DIFF
--- a/assets/js/test/datepicker-input_test.js
+++ b/assets/js/test/datepicker-input_test.js
@@ -79,6 +79,10 @@ describe("datepicker-input", () => {
   });
 
   it("displays date picker", () => {
+    new DatePickerInput({
+      selectors: { dateEl, month, day, year }
+    });
+
     assert.notEqual($("#test").html(), initial_markup);
 
     const datepicker_calendar = document.getElementById(

--- a/assets/js/test/datepicker-input_test.js
+++ b/assets/js/test/datepicker-input_test.js
@@ -79,11 +79,6 @@ describe("datepicker-input", () => {
   });
 
   it("displays date picker", () => {
-    // eslint-disable-next-line no-unused-vars
-    const input = new DatePickerInput({
-      selectors: { dateEl, month, day, year }
-    });
-
     assert.notEqual($("#test").html(), initial_markup);
 
     const datepicker_calendar = document.getElementById(

--- a/assets/js/trip-planner-form.js
+++ b/assets/js/trip-planner-form.js
@@ -1,5 +1,3 @@
-/* eslint no-unused-vars: ["error", { "args": "none" }] */
-
 import flatpickr from "flatpickr";
 import { addMinutes, format, getMinutes } from "date-fns";
 

--- a/assets/ts/components/FilterButton.tsx
+++ b/assets/ts/components/FilterButton.tsx
@@ -15,7 +15,6 @@ interface Props<T> {
 // in angle brackets like <TypeName>, the compiler will try to interpret that
 // as an opening "TypeName" TSX tag. The dummy type parameter keeps the compiler
 // from trying to interpret the type params as a tag.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const FilterButton = <T, _>({
   identifier,
   icon,


### PR DESCRIPTION
## Scope

No ticket, but I noticed that there were a few references to `no-unused-vars`. We should generally not be in the habit of disabling lint-checkers, and these no longer need to be disabled, so 👋 