### PR TITLE
[Fix]: Calendar links breaking status

### DIFF
--- a/assets/ts/components/Alerts.tsx
+++ b/assets/ts/components/Alerts.tsx
@@ -91,7 +91,7 @@ const htmlInsertFormatting = (str: string): string => {
   return str
     .replace(/^(.*:)\s/, "<strong>$1</strong>\n")
     .replace(/\n(.*:)\s/, "<br /><strong>$1</strong>\n")
-    .replace(/\s*\n/g, "<br />");
+    .replace(/\s*\n/g, " <br />");
 };
 
 // Strips off trailing periods of URLs (i guess the regex above matches the period if the URL is at the end of the sentence.)

--- a/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -76,8 +76,8 @@ exports[`it renders 1`] = `
                     <div
                       dangerouslySetInnerHTML={
                         Object {
-                          "__html": "<strong>Affected direction:</strong><br />Inbound<br />
-<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St",
+                          "__html": "<strong>Affected direction:</strong> <br />Inbound <br />
+<br /><strong>Affected stops:</strong> <br />Meridian St @ West Eagle St",
                         }
                       }
                     />

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -180,7 +180,7 @@ defmodule DotcomWeb.AlertView do
     |> String.replace(~r/^(.*:)(\r\n|\r|\n)/, "<strong>\\1</strong>\n")
     # all other start with a line break
     |> String.replace(~r/\n(.*:)(\r\n|\r|\n)/, "<br /><strong>\\1</strong>\n")
-    |> String.replace(~r/\s*\n/s, "<br />")
+    |> String.replace(~r/\s*\n/s, " <br />")
     |> replace_urls_with_links
   end
 

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -179,7 +179,7 @@ defmodule DotcomWeb.AlertView do
     # an initial header
     |> String.replace(~r/^(.*:)(\r\n|\r|\n)/, "<strong>\\1</strong>\n")
     # all other start with a line break
-    |> String.replace(~r/\n(.*:)(\r\n|\r|\n)/, "<br /><strong>\\1</strong>\n")
+    |> String.replace(~r/\n(.*:)(\r\n|\r|\n)/, " <br /><strong>\\1</strong>\n")
     |> String.replace(~r/\s*\n/s, " <br />")
     |> replace_urls_with_links
   end

--- a/test/dotcom_web/views/alert_view_test.exs
+++ b/test/dotcom_web/views/alert_view_test.exs
@@ -60,35 +60,35 @@ defmodule DotcomWeb.AlertViewTest do
     end
 
     test "replaces newlines with breaks" do
-      expected = {:safe, "hi<br />there"}
+      expected = {:safe, "hi <br />there"}
       actual = format_alert_description("hi\nthere")
 
       assert expected == actual
     end
 
     test "combines multiple newlines" do
-      expected = {:safe, "hi<br />there"}
+      expected = {:safe, "hi <br />there"}
       actual = format_alert_description("hi\n\n\nthere")
 
       assert expected == actual
     end
 
     test "combines multiple Windows newlines" do
-      expected = {:safe, "hi<br />there"}
+      expected = {:safe, "hi <br />there"}
       actual = format_alert_description("hi\r\n\r\nthere")
 
       assert expected == actual
     end
 
     test "<strong>ifies a header" do
-      expected = {:safe, "hi<br /><strong>Header:</strong><br />7:30"}
+      expected = {:safe, "hi <br /><strong>Header:</strong> <br />7:30"}
       actual = format_alert_description("hi\nHeader:\n7:30")
 
       assert expected == actual
     end
 
     test "<strong>ifies a starting long header" do
-      expected = {:safe, "<strong>Long Header:</strong><br />7:30"}
+      expected = {:safe, "<strong>Long Header:</strong> <br />7:30"}
       actual = format_alert_description("Long Header:\n7:30")
 
       assert expected == actual


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Investigate calendar links breaking status](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217027244535534?focus=true)

## Implementation

One of our alerts has a URL in the description that ends a line.  Our text->HTML conversion functions were not properly separating the URL from the \r\n that came after it.  Basically we split up everything by spaces and then parse each "token" to see if it's a URL.  Without a space after the URL (spaces before newlines were stripped and replaced with a `<br/>`) the URL detector got something like `http://example.com/path<br` and that caused all sorts of havok.

This theory is proven by putting a space and a non-whitespace character after the URL in the alert.  This forces the missing space before the newline to come and fixes the rest of the text->HTML flow

To fix this I tweaked our newline replacement rules to include a whitespace before the newline so that our "tokenizer" can actually separate the URL out.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Dev-green

<img width="767" height="188" alt="Screenshot 2026-07-30 at 12 43 37 PM" src="https://github.com/user-attachments/assets/37848e44-9555-471e-863b-a12b663ee113" />

### Local

<img width="765" height="184" alt="Screenshot 2026-07-30 at 1 22 02 PM" src="https://github.com/user-attachments/assets/5c109a19-c900-4388-b152-e5d39aa24cf8" />

Note:  Be sure to disable "Hide Whitespace" on github, this PR is nothing but whitespace.

## How to test

Point local at dev green

http://localhost:4001/
http://localhost:4001/alerts/subway
http://localhost:4001/schedules/Green-C/line

Confirm that alert #1003815 renders properly, and that the link works as expected.


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
