### PR TITLE
refactor(SystemStatus.CommuterRail): use service check

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -127,7 +127,7 @@ defmodule Dotcom.Alerts do
   @spec subway_alert_groups() :: [{Route.t(), [Alert.t()]}]
   def subway_alert_groups() do
     alerts =
-      @alerts_repo_module.all(@date_time_module.now())
+      @alerts_repo_module.by_route_types([0, 1], @date_time_module.now())
       |> Enum.reject(&service_impacting_alert?/1)
 
     non_banner_alerts = excluding_banner(@alerts_repo_module.banner(), alerts)
@@ -143,7 +143,7 @@ defmodule Dotcom.Alerts do
     now = @date_time_module.now()
 
     alerts =
-      @alerts_repo_module.all(now)
+      @alerts_repo_module.by_route_types([2], now)
       |> Enum.reject(&SystemStatus.status_alert?(&1, now))
 
     non_banner_alerts = excluding_banner(@alerts_repo_module.banner(), alerts)

--- a/lib/dotcom/system_status/commuter_rail.ex
+++ b/lib/dotcom/system_status/commuter_rail.ex
@@ -18,7 +18,6 @@ defmodule Dotcom.SystemStatus.CommuterRail do
   @alerts_repo @repos_module[:alerts]
   @routes_repo @repos_module[:routes]
   @schedules_repo @repos_module[:schedules]
-  @schedules_condensed_repo @repos_module[:schedules_condensed]
 
   @type trip_info_t() ::
           {:trip,
@@ -81,7 +80,7 @@ defmodule Dotcom.SystemStatus.CommuterRail do
   """
   @spec commuter_rail_route_status(Route.id_t()) :: route_status_t()
   def commuter_rail_route_status(route_id) do
-    if service_today?(route_id) do
+    if Dotcom.ServicePatterns.has_service?(route: route_id) do
       route_id
       |> commuter_rail_route_alerts()
       |> group_by_impact()
@@ -294,14 +293,5 @@ defmodule Dotcom.SystemStatus.CommuterRail do
   defp commuter_rail_routes() do
     @routes_repo.all()
     |> Enum.filter(&Routes.Route.commuter_rail?/1)
-  end
-
-  # Returns a boolean indicating whether or not the route has a schedule
-  # for today. This is used to determine if the route is running service today.
-  @spec service_today?(String.t()) :: boolean()
-  defp service_today?(id) do
-    [id]
-    |> @schedules_condensed_repo.by_route_ids()
-    |> Enum.any?(fn %{time: time} -> Dotcom.Utils.ServiceDateTime.service_today?(time) end)
   end
 end

--- a/test/dotcom/alerts_test.exs
+++ b/test/dotcom/alerts_test.exs
@@ -147,9 +147,7 @@ defmodule Dotcom.AlertsTest do
 
   describe "subway_alert_groups/0" do
     setup do
-      stub(Alerts.Repo.Mock, :all, fn _ -> [] end)
       stub(Alerts.Repo.Mock, :banner, fn -> nil end)
-      stub(Routes.Repo.Mock, :by_type, fn _ -> [] end)
 
       :ok
     end
@@ -169,7 +167,10 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route_2.id, route_type: route_2.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> (alerts_1 ++ alerts_2) |> Enum.shuffle() end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ ->
+        (alerts_1 ++ alerts_2) |> Enum.shuffle()
+      end)
+
       expect(Routes.Repo.Mock, :by_type, fn [0, 1] -> [route_1, route_2] end)
 
       groups = subway_alert_groups()
@@ -196,7 +197,10 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: non_subway_route.id, route_type: non_subway_route.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> (alerts_1 ++ alerts_2) |> Enum.shuffle() end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ ->
+        (alerts_1 ++ alerts_2) |> Enum.shuffle()
+      end)
+
       expect(Routes.Repo.Mock, :by_type, fn [0, 1] -> [subway_route] end)
 
       refute subway_alert_groups() |> Enum.any?(fn {route, _} -> route == non_subway_route end)
@@ -211,7 +215,7 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route_with_alerts.id, route_type: route_with_alerts.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> alerts end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ -> alerts end)
 
       expect(Routes.Repo.Mock, :by_type, fn [0, 1] ->
         [route_with_alerts, route_without_alerts]
@@ -231,7 +235,7 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route.id, route_type: route.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> alerts end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ -> alerts end)
 
       expect(Alerts.Repo.Mock, :banner, fn ->
         Factories.Alerts.Banner.build(:banner, id: banner_alert.id)
@@ -263,7 +267,7 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route.id, route_type: route.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ ->
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ ->
         (service_alerts ++ non_service_alerts) |> Enum.shuffle()
       end)
 
@@ -292,7 +296,7 @@ defmodule Dotcom.AlertsTest do
         )
         |> Enum.map(&Factories.Alerts.Alert.active_upcoming/1)
 
-      expect(Alerts.Repo.Mock, :all, fn _ ->
+      expect(Alerts.Repo.Mock, :by_route_types, fn [0, 1], _ ->
         (service_alerts ++ non_service_alerts) |> Enum.shuffle()
       end)
 
@@ -307,9 +311,7 @@ defmodule Dotcom.AlertsTest do
 
   describe "commuter_rail_alert_groups/0" do
     setup do
-      stub(Alerts.Repo.Mock, :all, fn _ -> [] end)
       stub(Alerts.Repo.Mock, :banner, fn -> nil end)
-      stub(Routes.Repo.Mock, :by_type, fn _ -> [] end)
 
       :ok
     end
@@ -329,7 +331,10 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route_2.id, route_type: route_2.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> (alerts_1 ++ alerts_2) |> Enum.shuffle() end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ ->
+        (alerts_1 ++ alerts_2) |> Enum.shuffle()
+      end)
+
       expect(Routes.Repo.Mock, :by_type, fn 2 -> [route_1, route_2] end)
 
       groups = commuter_rail_alert_groups()
@@ -360,7 +365,10 @@ defmodule Dotcom.AlertsTest do
           }
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> (alerts_1 ++ alerts_2) |> Enum.shuffle() end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ ->
+        (alerts_1 ++ alerts_2) |> Enum.shuffle()
+      end)
+
       expect(Routes.Repo.Mock, :by_type, fn 2 -> [commuter_rail_route] end)
 
       refute commuter_rail_alert_groups()
@@ -376,7 +384,7 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route_with_alerts.id, route_type: route_with_alerts.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> alerts end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ -> alerts end)
 
       expect(Routes.Repo.Mock, :by_type, fn 2 ->
         [route_with_alerts, route_without_alerts]
@@ -396,7 +404,7 @@ defmodule Dotcom.AlertsTest do
           informed_entity: %{route: route.id, route_type: route.type}
         )
 
-      expect(Alerts.Repo.Mock, :all, fn _ -> alerts end)
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ -> alerts end)
 
       expect(Alerts.Repo.Mock, :banner, fn ->
         Factories.Alerts.Banner.build(:banner, id: banner_alert.id)
@@ -429,7 +437,7 @@ defmodule Dotcom.AlertsTest do
         )
         |> Enum.map(&Factories.Alerts.Alert.active_now/1)
 
-      expect(Alerts.Repo.Mock, :all, fn _ ->
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ ->
         (service_alerts ++ non_service_alerts) |> Enum.shuffle()
       end)
 
@@ -460,7 +468,7 @@ defmodule Dotcom.AlertsTest do
 
       all_alerts = service_alerts ++ non_service_alerts
 
-      expect(Alerts.Repo.Mock, :all, fn _ ->
+      expect(Alerts.Repo.Mock, :by_route_types, fn [2], _ ->
         all_alerts |> Enum.shuffle()
       end)
 

--- a/test/dotcom/system_status/commuter_rail_test.exs
+++ b/test/dotcom/system_status/commuter_rail_test.exs
@@ -29,16 +29,14 @@ defmodule Dotcom.SystemStatus.CommuterRailTest do
       ]
     end)
 
-    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-      [
-        %Schedules.ScheduleCondensed{
-          time: Dotcom.Utils.DateTime.now()
-        }
-      ]
-    end)
-
     stub(Schedules.Repo.Mock, :schedule_for_trip, fn _, "filter[stop_sequence]": "first,last" ->
       Factories.Schedules.Schedule.build_list(2, :schedule)
+    end)
+
+    current_date = Dotcom.Utils.ServiceDateTime.service_date()
+
+    stub(Services.Repo.Mock, :by_route_id, fn _ ->
+      [Factories.Services.Service.build(:service, date: current_date)]
     end)
 
     :ok
@@ -222,12 +220,8 @@ defmodule Dotcom.SystemStatus.CommuterRailTest do
         ]
       end)
 
-      expect(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-        [
-          %Schedules.ScheduleCondensed{
-            time: Dotcom.Utils.DateTime.now() |> Timex.shift(days: 1)
-          }
-        ]
+      expect(Services.Repo.Mock, :by_route_id, fn _ ->
+        []
       end)
 
       # EXERCISE
@@ -257,13 +251,17 @@ defmodule Dotcom.SystemStatus.CommuterRailTest do
     test "returns :no_scheduled_service if there's no scheduled service for today" do
       # SETUP
       commuter_rail_id = Faker.Color.fancy_name()
+      date = Faker.Date.forward(3)
 
-      expect(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-        [
-          %Schedules.ScheduleCondensed{
-            time: Dotcom.Utils.DateTime.now() |> Timex.shift(days: 1)
-          }
-        ]
+      other_date_attrs = %{
+        rating_end_date: Date.shift(date, day: 20),
+        rating_start_date: Date.shift(date, day: 1),
+        end_date: Date.shift(date, day: 10),
+        start_date: Date.shift(date, day: 5)
+      }
+
+      expect(Services.Repo.Mock, :by_route_id, fn _ ->
+        [Factories.Services.Service.build(:service, other_date_attrs)]
       end)
 
       # EXERCISE

--- a/test/dotcom_web/components/system_status/commuter_rail_route_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_route_status_test.exs
@@ -21,16 +21,14 @@ defmodule DotcomWeb.SystemStatus.CommuterRailRouteStatusTest do
       ]
     end)
 
-    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-      [
-        %Schedules.ScheduleCondensed{
-          time: Dotcom.Utils.DateTime.now()
-        }
-      ]
-    end)
-
     stub(Schedules.Repo.Mock, :schedule_for_trip, fn _, "filter[stop_sequence]": "first,last" ->
       Factories.Schedules.Schedule.build_list(2, :schedule)
+    end)
+
+    current_date = Dotcom.Utils.ServiceDateTime.service_date()
+
+    stub(Services.Repo.Mock, :by_route_id, fn _ ->
+      [Factories.Services.Service.build(:service, date: current_date)]
     end)
 
     :ok

--- a/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
@@ -27,16 +27,14 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
       ]
     end)
 
-    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-      [
-        %Schedules.ScheduleCondensed{
-          time: Dotcom.Utils.DateTime.now()
-        }
-      ]
-    end)
-
     stub(Schedules.Repo.Mock, :schedule_for_trip, fn _, "filter[stop_sequence]": "first,last" ->
       Factories.Schedules.Schedule.build_list(2, :schedule)
+    end)
+
+    current_date = Dotcom.Utils.ServiceDateTime.service_date()
+
+    stub(Services.Repo.Mock, :by_route_id, fn _ ->
+      [Factories.Services.Service.build(:service, date: current_date)]
     end)
 
     :ok
@@ -53,12 +51,8 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
         ]
       end)
 
-      expect(Schedules.RepoCondensed.Mock, :by_route_ids, 2, fn _ ->
-        [
-          %Schedules.ScheduleCondensed{
-            time: Dotcom.Utils.DateTime.now() |> Timex.shift(days: 1)
-          }
-        ]
+      expect(Services.Repo.Mock, :by_route_id, fn _ ->
+        []
       end)
 
       assigns = %{commuter_rail_status: commuter_rail_status()}

--- a/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
@@ -4,7 +4,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_status: 0]
 
   import DotcomWeb.Components.SystemStatus.CommuterRailStatus,
-    only: [alerts_commuter_rail_status: 1, rows_for_line: 1]
+    only: [alerts_commuter_rail_status: 1]
 
   import Mox
   import Phoenix.LiveViewTest

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -129,7 +129,7 @@ defmodule DotcomWeb.AlertControllerTest do
     route_id = Faker.Util.pick(Dotcom.Routes.subway_route_ids())
     route_type = Faker.Util.pick([0, 1])
 
-    expect(Alerts.Repo.Mock, :all, fn date ->
+    expect(Alerts.Repo.Mock, :by_route_types, 2, fn [0, 1], date ->
       Factories.Alerts.Alert.build_list(1, :alert, %{
         active_period: [Utils.ServiceDateTime.service_range_day(date)],
         banner: nil,

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -41,8 +41,10 @@ defmodule DotcomWeb.AlertControllerTest do
       Factories.Routes.Route.build_list(2, :route, %{type: route_type})
     end)
 
-    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _route_ids ->
-      []
+    current_date = Dotcom.Utils.ServiceDateTime.service_date()
+
+    stub(Services.Repo.Mock, :by_route_id, fn _ ->
+      [Factories.Services.Service.build(:service, date: current_date)]
     end)
 
     stub(Stops.Repo.Mock, :get, fn id ->

--- a/test/dotcom_web/live/commuter_rail_alerts_live_test.exs
+++ b/test/dotcom_web/live/commuter_rail_alerts_live_test.exs
@@ -23,7 +23,7 @@ defmodule DotcomWeb.CommuterRailAlertsLiveTest do
   setup _ do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
 
-    stub(Alerts.Repo.Mock, :all, fn _ -> [] end)
+    stub(Alerts.Repo.Mock, :by_route_types, fn _, _ -> [] end)
     stub(Alerts.Repo.Mock, :banner, fn -> nil end)
     stub(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
     stub(Routes.Repo.Mock, :by_type, fn _ -> [] end)
@@ -55,7 +55,7 @@ defmodule DotcomWeb.CommuterRailAlertsLiveTest do
     test "does not show a 'no alerts' message when an alert is present", %{conn: conn} do
       route = Factories.Routes.Route.build(:route, %{type: @cr_route_type})
 
-      stub(Alerts.Repo.Mock, :all, fn date ->
+      stub(Alerts.Repo.Mock, :by_route_types, fn [@cr_route_type], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{
           active_period: [Utils.ServiceDateTime.service_range_day(date)],
           effect: Faker.Util.pick(@non_service_effects),
@@ -113,7 +113,7 @@ defmodule DotcomWeb.CommuterRailAlertsLiveTest do
          %{conn: conn} do
       route = Factories.Routes.Route.build(:route, %{type: @cr_route_type})
 
-      stub(Alerts.Repo.Mock, :all, fn date ->
+      stub(Alerts.Repo.Mock, :by_route_types, fn [@cr_route_type], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{
           active_period: [
             date |> DateTime.shift(day: 2) |> Utils.ServiceDateTime.service_range_day()

--- a/test/dotcom_web/live/commuter_rail_alerts_live_test.exs
+++ b/test/dotcom_web/live/commuter_rail_alerts_live_test.exs
@@ -33,14 +33,6 @@ defmodule DotcomWeb.CommuterRailAlertsLiveTest do
       [Factories.Routes.Route.build(:route, type: @cr_route_type)]
     end)
 
-    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
-      [
-        %Schedules.ScheduleCondensed{
-          time: Dotcom.Utils.DateTime.now()
-        }
-      ]
-    end)
-
     Dotcom.SystemStatus.CommuterRailCache.Mock
     |> stub(:commuter_rail_status, fn ->
       []

--- a/test/dotcom_web/live/subway_alerts_live_test.exs
+++ b/test/dotcom_web/live/subway_alerts_live_test.exs
@@ -23,10 +23,11 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
   setup _ do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
 
-    stub(Alerts.Repo.Mock, :all, fn _ -> [] end)
+    stub(Alerts.Repo.Mock, :by_route_types, fn _, _ -> [] end)
     stub(Alerts.Repo.Mock, :banner, fn -> nil end)
     stub(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
     stub(Alerts.Repo.Mock, :by_route_types, fn _, _ -> [] end)
+    stub(Dotcom.Alerts.EndpointStops.Mock, :endpoint_stops, fn _, _ -> [] end)
     stub(Routes.Repo.Mock, :by_type, fn _ -> [] end)
 
     stub(Dotcom.SystemStatus.SubwayCache.Mock, :subway_status, fn ->
@@ -52,7 +53,7 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
       route_id = Faker.Util.pick(Subway.lines())
       route_type = Faker.Util.pick([0, 1])
 
-      stub(Alerts.Repo.Mock, :all, fn date ->
+      stub(Alerts.Repo.Mock, :by_route_types, fn [0, 1], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{
           active_period: [Utils.ServiceDateTime.service_range_day(date)],
           effect: Faker.Util.pick(@non_service_effects),
@@ -91,7 +92,7 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
       route_id = Faker.Util.pick(Subway.lines())
       route_type = Faker.Util.pick([0, 1])
 
-      stub(Alerts.Repo.Mock, :all, fn date ->
+      stub(Alerts.Repo.Mock, :by_route_types, fn [0, 1], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{
           active_period: [Utils.ServiceDateTime.service_range_day(date)],
           effect: Faker.Util.pick(@service_impacting_effects),
@@ -133,7 +134,7 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
         }
       end)
 
-      stub(Alerts.Repo.Mock, :all, fn date ->
+      stub(Alerts.Repo.Mock, :by_route_types, fn [0, 1], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{
           id: banner_id,
           active_period: [Utils.ServiceDateTime.service_range_day(date)],


### PR DESCRIPTION
## Scope

This PR covers a few things I noticed while analyzing the homepage. 

## Implementation

### Checking if a commuter rail route has service today

It's not directly related to the homepage, but as the system became overwhelmed and various things fell apart, one call that'd sometimes fail is this which feeds into the Commuter Rail Status widget:
```
  # Returns a boolean indicating whether or not the route has a schedule
  # for today. This is used to determine if the route is running service today.
  @spec service_today?(String.t()) :: boolean()
  defp service_today?(id) do
    [id]
    |> @schedules_condensed_repo.by_route_ids()
    |> Enum.any?(fn %{time: time} -> Dotcom.Utils.ServiceDateTime.service_today?(time) end)
  end
```

This PR replaces this with the existing `Dotcom.ServicePatterns.has_service?/1` function, which defaults to checking the current service date and uses a much simpler check (against V3 API `/service` result rather than checking times in each result from `/schedules`).

### Getting alerts for each status widget

Both `subway_alert_groups()` and `commuter_rail_alert_groups()` currently fetch alerts by fetching **all alerts** then filtering the result down to the relevant routes. I realized we could start with fewer alerts by using the existing `Alerts.Repo.by_route_types/2` function. So that's what the final commit does.

## Screenshots

No change!

## How to test

Compare with the current commuter rail status -- should work exactly the same way.
