### PR TITLE
QF | [WC Cleanup]: Revert these intercepts

### DIFF
--- a/assets/css/_descriptive-link.scss
+++ b/assets/css/_descriptive-link.scss
@@ -109,10 +109,6 @@
   }
 }
 
-.c-descriptive-link:has(.c-descriptive-link__boston-stadium) {
-  background-color: #d0e0f3;
-}
-
 .c-callout-link {
   background-color: var(--colors-cobalt-80);
   border-radius: $space-6;

--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -355,59 +355,6 @@ defmodule DotcomWeb.Components do
     """
   end
 
-  attr(:rest, :global, include: ~w(disabled))
-  attr(:class, :string, default: "")
-
-  @doc """
-  Same as above, but links to the timetable instead
-  """
-  def boston_stadium_intercept(assigns) do
-    ~H"""
-    <.descriptive_link
-      href="/schedules/bostonstadium"
-      class={@class}
-      {@rest}
-    >
-      <:title>
-        {~t(Taking the train to a World Cup match?)}
-      </:title>
-      <p class="c-descriptive-link__world-cup c-descriptive-link__boston-stadium">
-        {gettext("View %{timetable_link} for departure information.",
-          timetable_link: "<span class='underline font-medium'>Boston Stadium Train timetables</span>"
-        )
-        |> Phoenix.HTML.raw()}
-      </p>
-    </.descriptive_link>
-    """
-  end
-
-  attr(:rest, :global, include: ~w(disabled))
-  attr(:class, :string, default: "")
-
-  @doc """
-  Callout for commuter rail alerts during the world cup
-  """
-  def cr_alert_intercept(assigns) do
-    ~H"""
-    <.descriptive_link
-      href="/schedules/commuter-rail"
-      class={@class}
-      {@rest}
-    >
-      <:title>
-        {~t(Your Commuter Rail trip will be affected by the World Cup.)}
-      </:title>
-      <p class="c-descriptive-link__world-cup">
-        {gettext(
-          "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule.",
-          timetable_link: "<span class='underline font-medium'>timetable</span>"
-        )
-        |> Phoenix.HTML.raw()}
-      </p>
-    </.descriptive_link>
-    """
-  end
-
   attr(:rest, :global)
   slot :inner_block, required: true
 

--- a/lib/dotcom_web/live/commuter_rail_alerts_live.ex
+++ b/lib/dotcom_web/live/commuter_rail_alerts_live.ex
@@ -67,7 +67,6 @@ defmodule DotcomWeb.CommuterRailAlertsLive do
           {DotcomWeb.AlertView.render("_t-alerts.html")}
         </:sidebar_bottom>
         <:main_section>
-          <.cr_alert_intercept class="mb-3" />
           <section id="current_status">
             <.alerts_commuter_rail_status commuter_rail_status={@commuter_rail_status} />
           </section>

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -12,10 +12,6 @@
 
 <div class="container">
   <div class="page-section">
-    <.boston_stadium_intercept
-      :if={@stop.name == "South Station"}
-      class="mb-3"
-    />
     {DotcomWeb.AlertView.render(
       "group.html",
       alerts: @banner_alerts,

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -3699,11 +3699,6 @@ msgstr ""
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr ""
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4102,11 +4097,6 @@ msgstr ""
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
@@ -4595,11 +4585,6 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr ""
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4892,11 +4877,6 @@ msgstr ""
 #: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr ""
 
 #: lib/dotcom_web/templates/vote/show.html.heex

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -3699,11 +3699,6 @@ msgstr ""
 msgid "Service Inquiry"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr ""
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4102,11 +4097,6 @@ msgstr ""
 #: lib/dotcom_web/components/trip_planner/helpers.ex
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
@@ -4595,11 +4585,6 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr ""
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4892,11 +4877,6 @@ msgstr ""
 #: lib/dotcom_web/views/customer_support_view.ex
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
-msgstr ""
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
 msgstr ""
 
 #: lib/dotcom_web/templates/vote/show.html.heex

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -3716,11 +3716,6 @@ msgstr "Quejas de servicio"
 msgid "Service Inquiry"
 msgstr "Consulta de servicio"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "El cambio de servicio está en vigor del 6 de junio al 12 de julio. Consulta cada día de tu %{timetable_link} de línea para encontrar el horario más actualizado."
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4120,11 +4115,6 @@ msgstr "Lleva a Subterráneo a votar"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Toma el ascensor"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "¿Vas en tren a un partido de la Copa del Mundo?"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4613,11 +4603,6 @@ msgstr "Vía"
 msgid "View"
 msgstr "Vista"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "Consulta %{timetable_link} para información sobre las salidas."
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4914,11 +4899,6 @@ msgstr "Debes aceptar nuestra Política de Privacidad antes de enviar tus coment
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Debes completar el reCAPTCHA antes de enviar tu feedback."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "Tu viaje al Tren de cercanías se verá afectado por el Mundial."
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -3717,12 +3717,6 @@ msgstr "Service Réclamations"
 msgid "Service Inquiry"
 msgstr "Demande de service"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "changement de service est en vigueur du 6 juin au 12 juillet. Vérifiez chaque jour de la %{timetable_link} de votre ligne pour trouver l’horaire le plus"
-" récent."
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4122,11 +4116,6 @@ msgstr "Prenez le métro pour voter"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Prends l’ascenseur"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "Prendre le train pour un match de Coupe du Monde ?"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4615,11 +4604,6 @@ msgstr "Via"
 msgid "View"
 msgstr "Vue"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "Consultez %{timetable_link} pour les informations sur les départs."
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4915,11 +4899,6 @@ msgstr "Vous devez accepter notre Politique de confidentialité avant de soumett
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Vous devez remplir le reCAPTCHA avant de soumettre vos retours."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "Votre voyage au Train de banlieue sera affecté par la Coupe du Monde."
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -3706,11 +3706,6 @@ msgstr "Plent Sèvis"
 msgid "Service Inquiry"
 msgstr "Demann Sèvis"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "Chanjman sèvis yo an vigè soti 6 jen rive 12 jiyè. Tcheke chak jou nan %{timetable_link} liy ou a pou jwenn dènye enfòmasyon yo."
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4110,11 +4105,6 @@ msgstr "Pran métro a pou ale vote"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Pran asansè a"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "Pran tren pou ale nan yon match koup di mond lan?"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4603,11 +4593,6 @@ msgstr "Via"
 msgid "View"
 msgstr "Gade"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "Gade %{timetable_link} pou enfòmasyon sou depa."
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4902,11 +4887,6 @@ msgstr "Ou dwe dakò ak Règleman sou enfòmasyon prive nou an anvan ou soumèt 
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Ou dwe ranpli reCAPTCHA a anvan ou soumèt fidbak ou a."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "Koup di mond lan pral afekte vwayaj Tren banlye ou a."
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -3713,11 +3713,6 @@ msgstr "Reclamações de serviço"
 msgid "Service Inquiry"
 msgstr "Consulta de serviço"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "As alterações de serviço estão em vigor de 6 de junho a 12 de julho. Verifique cada dia da %{timetable_link} da sua linha para obter o horário mais atualizado."
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4117,11 +4112,6 @@ msgstr "Pegue o metrô para votar."
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Pegue o elevador."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "Vai de trem para um jogo da Copa do Mundo?"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4610,11 +4600,6 @@ msgstr "Via"
 msgid "View"
 msgstr "Visualizar"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "Veja %{timetable_link} para informações de partida."
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4910,11 +4895,6 @@ msgstr "Você precisa concordar com nossa Política de Privacidade antes de envi
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Você precisa completar o reCAPTCHA antes de enviar seu feedback."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "Sua viagem de Trem Suburbano será afetada pela Copa do Mundo."
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -3708,12 +3708,6 @@ msgstr "Khiếu nại dịch vụ"
 msgid "Service Inquiry"
 msgstr "Yêu cầu dịch vụ"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "thay đổi dịch vụ có hiệu lực từ ngày 6 tháng 6 đến ngày 12 tháng 7. Kiểm tra từng ngày trong %{timetable_link} của dây chuyền của bạn để biết lịch trình"
-" cập nhật nhất."
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4113,11 +4107,6 @@ msgstr "Đi tàu điện ngầm để bỏ phiếu"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "Đi thang máy"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "Đi tàu đến xem một trận đấu World Cup?"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4606,11 +4595,6 @@ msgstr "Thông qua"
 msgid "View"
 msgstr "Xem"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "Xem %{timetable_link} để biết thông tin khởi hành."
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4906,11 +4890,6 @@ msgstr "Bạn phải đồng ý với Chính sách Bảo mật của chúng tôi
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "Bạn phải hoàn thành xác minh reCAPTCHA trước khi gửi phản hồi."
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "Chuyến đi Đường sắt ngoại ô của bạn sẽ bị ảnh hưởng bởi World Cup."
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -3693,11 +3693,6 @@ msgstr "服务投诉"
 msgid "Service Inquiry"
 msgstr "服务查询"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "服务变更将于 6 月 6 日至 7 月 12 日生效。请查看您线路的%{timetable_link}以获取最新的时刻表。"
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4097,11 +4092,6 @@ msgstr "乘坐地铁去投票"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "乘电梯"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "坐火车去看世界杯比赛？"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4589,11 +4579,6 @@ msgstr "通过"
 msgid "View"
 msgstr "看法"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "查看%{timetable_link}以获取出发信息。"
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4887,11 +4872,6 @@ msgstr "您必须同意我们的隐私政策才能提交反馈。"
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "您必须先完成 reCAPTCHA 验证才能提交反馈。"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "世界杯将影响您的通勤铁路行程。"
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -3693,11 +3693,6 @@ msgstr "服務投訴"
 msgid "Service Inquiry"
 msgstr "服務查詢"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule."
-msgstr "服務變更於 6 月 6 日至 7 月 12 日生效。檢查您線路的每一天的%{timetable_link}以獲取最新的時間表。"
-
 #: lib/dotcom_web/live/upcoming_departures_live.ex
 #, elixir-autogen, elixir-format
 msgid "Service ended"
@@ -4097,11 +4092,6 @@ msgstr "搭乘地鐵去投票"
 #, elixir-autogen, elixir-format
 msgid "Take the elevator"
 msgstr "搭乘電梯"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Taking the train to a World Cup match?"
-msgstr "坐火車去看世界盃比賽？"
 
 #: lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -4589,11 +4579,6 @@ msgstr "透過"
 msgid "View"
 msgstr "看法"
 
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "View %{timetable_link} for departure information."
-msgstr "查看%{timetable_link}以獲取出發資訊。"
-
 #: lib/dotcom_web/components/trip_planner/results.ex
 #, elixir-autogen, elixir-format
 msgid "View Alerts"
@@ -4887,11 +4872,6 @@ msgstr "您必須同意我們的隱私權政策才能提交回饋。"
 #, elixir-autogen, elixir-format
 msgid "You must complete the reCAPTCHA before submitting your feedback."
 msgstr "您必須先完成 reCAPTCHA 驗證才能提交回饋。"
-
-#: lib/dotcom_web/components/components.ex
-#, elixir-autogen, elixir-format
-msgid "Your Commuter Rail trip will be affected by the World Cup."
-msgstr "世界盃將影響您的通勤鐵路行程。"
 
 #: lib/dotcom_web/templates/vote/show.html.heex
 #, elixir-autogen, elixir-format


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️❌ Revert these intercepts](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216627005869433?focus=true)

## Implementation

Removed the world cup intercepts/callouts on the south station stop page and the commuter rail alerts page.  Removed those components and some associated CSS.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Local    vs    Dev
<img width="1499" height="645" alt="Screenshot 2026-07-30 at 3 41 25 PM" src="https://github.com/user-attachments/assets/114b2105-dc42-4a9f-a412-85cb652e022a" />

### Local    vs    Dev
<img width="1488" height="624" alt="Screenshot 2026-07-30 at 3 43 03 PM" src="https://github.com/user-attachments/assets/4cf3b8cc-0492-41ad-a896-6f0f2489cd22" />



## How to test

http://localhost:4001/alerts/commuter-rail
http://localhost:4001/stops/place-sstat

Confirm that the World Cup intercepts are gone

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
