### PR TITLE
refactor(DotcomWeb.ModeView): simpler has_alert?

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -319,14 +319,6 @@ defmodule Alerts.Alert do
 
   def image_alternative_text(_), do: nil
 
-  @spec high_severity_or_high_priority?(t) :: boolean()
-  def high_severity_or_high_priority?(%{priority: :high}), do: true
-
-  def high_severity_or_high_priority?(%{severity: severity}) when severity >= 7,
-    do: true
-
-  def high_severity_or_high_priority?(_), do: false
-
   @spec municipality(t) :: String.t() | nil
   def municipality(alert) do
     alert

--- a/lib/alerts/cache/store.ex
+++ b/lib/alerts/cache/store.ex
@@ -17,6 +17,8 @@ defmodule Alerts.Cache.Store do
   occur via client functions that query the ETS tables directly.
   """
 
+  alias Alerts.{Alert, Priority}
+
   use GenServer
 
   @pubsub_topic "alerts"
@@ -80,6 +82,19 @@ defmodule Alerts.Cache.Store do
   def alert_ids_for_stop_id(stop_id) do
     keys = [{{stop_id, :"$1"}, [], [:"$1"]}]
     :ets.select(:stop_id_to_alert_ids, keys)
+  end
+
+  @doc """
+  Retrieves all the alerts of a given priority for the given list of alert ids.
+  """
+  @spec priority_alerts_from_alert_ids([Alert.id_t()], Priority.priority_level()) :: [Alert.t()]
+  def priority_alerts_from_alert_ids(alert_ids, priority) do
+    selectors =
+      for key <- alert_ids do
+        {{key, :"$1"}, [{:==, {:map_get, :priority, :"$1"}, priority}], [:"$1"]}
+      end
+
+    :ets.select(:alert_id_to_alert, selectors)
   end
 
   @doc """

--- a/lib/alerts/repo.ex
+++ b/lib/alerts/repo.ex
@@ -4,6 +4,7 @@ defmodule Alerts.Repo do
   alias Alerts.{Alert, Banner, Priority}
   alias Alerts.Cache.Store
   alias Alerts.Repo.Behaviour
+  alias Routes.Route
 
   @behaviour Behaviour
 
@@ -78,5 +79,13 @@ defmodule Alerts.Repo do
     now
     |> Store.all_alerts()
     |> Enum.filter(&(&1.priority == priority))
+  end
+
+  @impl Behaviour
+  @spec by_route_id_and_priority(Route.id_t(), Priority.priority_level()) :: [Alert.t()]
+  def by_route_id_and_priority(route_id, priority) do
+    [route_id]
+    |> Store.alert_ids_for_routes()
+    |> Store.priority_alerts_from_alert_ids(priority)
   end
 end

--- a/lib/alerts/repo/behaviour.ex
+++ b/lib/alerts/repo/behaviour.ex
@@ -3,7 +3,7 @@ defmodule Alerts.Repo.Behaviour do
   Behaviour for the Alerts repo.
   """
 
-  alias Alerts.{Alert, Banner}
+  alias Alerts.{Alert, Banner, Priority}
 
   @doc """
   Return all alerts applicable to the given datetime.
@@ -41,4 +41,11 @@ defmodule Alerts.Repo.Behaviour do
   Sort them so that earlier alerts are displayed first.
   """
   @callback planned_service_impacts_by_routes([String.t()], DateTime.t()) :: [Alert.t()]
+
+  @doc """
+  Return all alerts for the given route id and given priority level.
+  """
+  @callback by_route_id_and_priority(Routes.Route.id_t(), Priority.priority_level()) :: [
+              Alert.t()
+            ]
 end

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -5,7 +5,7 @@
       route: route,
       show_icon?: @show_icons?,
       link_path: grid_button_path(route, @conn),
-      has_alert?: has_alert?(route, @alerts, @date_time),
+      has_alert?: has_alert?(route.id),
       id_prefix: assigns[:id_prefix],
       index: idx
     )}
@@ -19,7 +19,7 @@
           route: route,
           show_icon?: @show_icons?,
           link_path: grid_button_path(route, @conn),
-          has_alert?: has_alert?(route, @alerts, @date_time),
+          has_alert?: has_alert?(route.id),
           id_prefix: assigns[:id_prefix],
           index: idx
         )}

--- a/lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons_ferry.html.heex
@@ -8,7 +8,7 @@
       route: route,
       show_icon?: @show_icons?,
       link_path: grid_button_path(route, @conn),
-      has_alert?: has_alert?(route, @alerts, @date_time),
+      has_alert?: has_alert?(route.id),
       id_prefix: assigns[:id_prefix],
       index: idx
     )}
@@ -25,7 +25,7 @@
       route: route,
       show_icon?: @show_icons?,
       link_path: grid_button_path(route, @conn),
-      has_alert?: has_alert?(route, @alerts, @date_time),
+      has_alert?: has_alert?(route.id),
       id_prefix: assigns[:id_prefix],
       index: idx
     )}

--- a/lib/dotcom_web/templates/mode/hub.html.heex
+++ b/lib/dotcom_web/templates/mode/hub.html.heex
@@ -13,9 +13,7 @@
         <div class="m-mode__recently-visited">
           {render(DotcomWeb.PartialView, "_recently_visited.html",
             conn: @conn,
-            routes: @recently_visited,
-            alerts: @alerts,
-            date_time: @date_time
+            routes: @recently_visited
           )}
         </div>
         <h2>{~t(Schedules)}</h2>

--- a/lib/dotcom_web/templates/mode/index.html.heex
+++ b/lib/dotcom_web/templates/mode/index.html.heex
@@ -10,9 +10,7 @@
         <div class="m-mode__recently-visited">
           {render(DotcomWeb.PartialView, "_recently_visited.html",
             conn: @conn,
-            routes: Map.get(assigns, :recently_visited, []),
-            alerts: @alerts,
-            date_time: @date_time
+            routes: Map.get(assigns, :recently_visited, [])
           )}
         </div>
         <%= for {route_type, mode_page} <- route_types ++ the_ride do %>
@@ -25,8 +23,6 @@
               routes: Keyword.get(@grouped_routes, route_type, [:the_ride]),
               show_icons?: false,
               conn: @conn,
-              date_time: @date_time,
-              alerts: @alerts,
               sub_routes: if(route_type == :subway, do: @green_routes, else: [])
             )}
           </div>

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -60,8 +60,6 @@
       {render(DotcomWeb.PartialView, "_recently_visited.html",
         conn: @conn,
         routes: Map.get(assigns, :recently_visited, []),
-        alerts: @alerts,
-        date_time: @date_time,
         header_class: "h3"
       )}
       <%= unless Enum.empty?(Map.get(assigns, :recently_visited, [])) do %>

--- a/lib/dotcom_web/templates/partial/_recently_visited.html.heex
+++ b/lib/dotcom_web/templates/partial/_recently_visited.html.heex
@@ -4,8 +4,6 @@
     {render(DotcomWeb.ModeView, "_grid_buttons.html",
       conn: @conn,
       routes: @routes,
-      alerts: @alerts,
-      date_time: @date_time,
       id_prefix: "recently-visited",
       show_icons?: true
     )}

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -3,12 +3,13 @@ defmodule DotcomWeb.ModeView do
 
   use DotcomWeb, :view
 
-  alias Alerts.Match
   alias Dotcom.MapHelpers
   alias DotcomWeb.PartialView
   alias DotcomWeb.PartialView.SvgIconWithCircle
   alias Plug.Conn
   alias Routes.Route
+
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
 
   def get_route_group(:commuter_rail = route_type, route_groups) do
     # Note that we do not sort the commuter rail routes by name as we
@@ -137,19 +138,14 @@ defmodule DotcomWeb.ModeView do
   end
 
   # Returns true if there is a non-notice alert for the given route on `date`
-  @spec has_alert?(Route.t() | :the_ride, [Alerts.Alert.t()], DateTime.t() | nil) :: boolean
-  def has_alert?(:the_ride, _, _) do
+  @spec has_alert?(Route.id_t() | :the_ride) :: boolean
+  def has_alert?(:the_ride) do
     false
   end
 
-  def has_alert?(%Route{} = route, alerts, date) do
-    date = date || Util.now()
-    entity = %Alerts.InformedEntity{route_type: route.type, route: route.id}
-
-    Enum.any?(alerts, fn alert ->
-      Alerts.Alert.high_severity_or_high_priority?(alert) and
-        Match.match([alert], entity, date) == [alert]
-    end)
+  def has_alert?(route_id) do
+    @alerts_repo.by_route_id_and_priority(route_id, :high)
+    |> Enum.any?(&Dotcom.Alerts.in_effect_now?/1)
   end
 
   def map_buttons(types) do

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -185,26 +185,6 @@ defmodule AlertsTest do
     end
   end
 
-  describe "high_severity_or_high_priority?/1" do
-    test "returns true for severity >= 7" do
-      assert high_severity_or_high_priority?(%Alert{severity: 8})
-      assert high_severity_or_high_priority?(%Alert{severity: 8, priority: :low})
-    end
-
-    test "returns true for priority == :high" do
-      assert high_severity_or_high_priority?(%Alert{priority: :high})
-      assert high_severity_or_high_priority?(%Alert{severity: 2, priority: :high})
-    end
-
-    test "returns true for high severity and high priority" do
-      assert high_severity_or_high_priority?(%Alert{severity: 7, priority: :high})
-    end
-
-    test "returns false otherwise" do
-      refute high_severity_or_high_priority?(%Alert{severity: 3, priority: :low})
-    end
-  end
-
   describe "municipality/1" do
     test "gets municipality from an alert's stops" do
       alert_with_muni = Alert.new(informed_entity: [%InformedEntity{stop: "some-stop"}])

--- a/test/alerts/cache/store_test.exs
+++ b/test/alerts/cache/store_test.exs
@@ -1,6 +1,8 @@
 defmodule Alerts.Cache.StoreTest do
   use ExUnit.Case
 
+  import Test.Support.Factories.Alerts.Alert
+
   alias Alerts.Cache.Store
 
   @now Timex.parse!("2017-06-08T10:00:00-05:00", "{ISO:Extended}")
@@ -86,5 +88,18 @@ defmodule Alerts.Cache.StoreTest do
     Store.update([alert1, alert2, alert3, alert4], nil)
 
     assert Enum.sort(Store.alert_ids_for_stop_id("543")) == Enum.sort(["123", "124"])
+  end
+
+  test "priority_alerts_from_alert_ids/2 gets alerts for priority" do
+    priority = Alerts.Priority.priority_levels() |> Faker.Util.pick()
+    alerts = build_list(50, :alert)
+    alert_ids = Enum.map(alerts, & &1.id)
+
+    :ok = Store.update(alerts, nil)
+
+    priority_alerts = Store.priority_alerts_from_alert_ids(alert_ids, priority)
+
+    assert [%Alerts.Alert{} | _] = priority_alerts
+    assert Enum.all?(priority_alerts, &(&1.priority == priority))
   end
 end

--- a/test/alerts/repo_test.exs
+++ b/test/alerts/repo_test.exs
@@ -157,4 +157,34 @@ defmodule Alerts.RepoTest do
       assert [%Alert{id: "system"}] = Repo.by_priority(@now, :system)
     end
   end
+
+  describe "by_route_id_and_priority/2" do
+    test "returns the list of alerts for a route filtered by priority from the store" do
+      route_id = Faker.Internet.slug()
+      priority = Alerts.Priority.priority_levels() |> Faker.Util.pick()
+
+      alerts =
+        Factories.Alerts.Alert.build_list(20, :alert_for_route, route_id: route_id) ++
+          Factories.Alerts.Alert.build_list(20, :alert, priority: priority) ++
+          Factories.Alerts.Alert.build_list(20, :alert_for_route,
+            route_id: route_id,
+            priority: priority
+          )
+
+      :ok =
+        alerts
+        |> Enum.with_index(fn alert, index -> %{alert | id: "alert-#{index}"} end)
+        |> Store.update(nil)
+
+      matched_alerts = Repo.by_route_id_and_priority(route_id, priority)
+      assert [%Alert{} | _] = matched_alerts
+      assert Enum.all?(matched_alerts, &(&1.priority == priority))
+
+      matched_routes =
+        Enum.flat_map(matched_alerts, &(&1.informed_entity.route |> MapSet.to_list()))
+        |> Enum.uniq()
+
+      assert matched_routes == [route_id]
+    end
+  end
 end

--- a/test/dotcom_web/views/mode_view_test.exs
+++ b/test/dotcom_web/views/mode_view_test.exs
@@ -3,11 +3,13 @@ defmodule DotcomWeb.ModeViewTest do
 
   use ExUnit.Case, async: true
 
+  import Mox
   import Phoenix.HTML, only: [safe_to_string: 1]
 
-  alias Alerts.Alert
   alias DotcomWeb.ModeView
   alias Routes.Route
+
+  setup :verify_on_exit!
 
   describe "mode_group_header/3" do
     test "renders an h2 if is_homepage? == false" do
@@ -71,39 +73,49 @@ defmodule DotcomWeb.ModeViewTest do
     end
   end
 
-  describe "has_alert?/3" do
-    test "returns true if route has an alert" do
-      now = Util.now()
-      entity = %Alerts.InformedEntity{route_type: 0, route: "Pink"}
+  describe "has_alert?/1" do
+    setup _ do
+      stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+      :ok
+    end
 
-      alert =
-        Alert.new(
-          active_period: [{Timex.shift(now, hours: -3), Timex.shift(now, hours: 3)}],
-          effect: :delay,
-          informed_entity: [entity],
+    test "returns true if route has a current high-priority alert" do
+      route_id = Faker.Internet.slug()
+
+      expect(Alerts.Repo.Mock, :by_route_id_and_priority, fn ^route_id, :high ->
+        Test.Support.Factories.Alerts.Alert.build_list(1, :alert_for_route,
+          route_id: route_id,
           priority: :high
         )
+        |> Enum.map(&Test.Support.Factories.Alerts.Alert.active_now/1)
+      end)
 
-      assert Alerts.Match.match([alert], entity, now) == [alert]
-
-      assert ModeView.has_alert?(%Route{id: "Pink", type: 0}, [alert], now) == true
+      assert ModeView.has_alert?(route_id)
     end
-  end
 
-  test "returns false if route does not have an alert" do
-    now = Util.now()
-    entity = %Alerts.InformedEntity{route_type: 0, route: "Pink"}
+    test "returns false if route has a future high-priority alert" do
+      route_id = Faker.Internet.slug()
 
-    alert =
-      Alert.new(
-        active_period: [{Timex.shift(now, days: 5), Timex.shift(now, days: 9)}],
-        effect: :service_change,
-        informed_entity: [entity]
-      )
+      expect(Alerts.Repo.Mock, :by_route_id_and_priority, fn ^route_id, :high ->
+        Test.Support.Factories.Alerts.Alert.build_list(1, :alert_for_route,
+          route_id: route_id,
+          priority: :high
+        )
+        |> Enum.map(&Test.Support.Factories.Alerts.Alert.active_upcoming/1)
+      end)
 
-    assert Alerts.Match.match([alert], entity, now) == []
+      refute ModeView.has_alert?(route_id)
+    end
 
-    assert ModeView.has_alert?(%Route{id: "Pink", type: 0}, [alert], now) == false
+    test "returns false if route does not have such alert" do
+      route_id = Faker.Internet.slug()
+
+      expect(Alerts.Repo.Mock, :by_route_id_and_priority, fn ^route_id, :high ->
+        []
+      end)
+
+      refute ModeView.has_alert?(route_id)
+    end
   end
 
   describe "bus_filter_atom/1 and bus_filter_range/2" do


### PR DESCRIPTION
## Scope

The homepage's "Recently Visited" section shows routes. If a route has an important alert, we show our familiar triangle warning icon.

<img width="995" height="430" alt="image" src="https://github.com/user-attachments/assets/9b8159ac-6e8a-4f30-b322-1b880a6fe4f7" />

My local load testing on the homepage has found that fetching and processing alerts is by far the most computationally intensive part of the homepage. The "Recently Visited" buttons are a small part of what we do with homepage alerts, but I wanted to see if I could make it a bit more performant.

## Implementation

Instead of having the homepage fetch _every alert_ and then having the view check the list of all alerts for whether a given route is present, I wrote a helper function to more directly assess whether a route has a high priority alert.

The first two commits assemble the needed queries:

[feat(Alerts.Cache.Store): get from ids + priority](https://github.com/mbta/dotcom/commit/3cd29edf902c7e5cfff98205eb1b6ba73e30b5cf)

We already have functions to easily and performantly get a list of alert IDs associated with a route ID. I wanted to build upon that by making it just as easy to find which of those alerts have high priority.

[feat(Alerts.Repo): get by route ID + priority](https://github.com/mbta/dotcom/commit/5194f83cf6cb0ae7f29ed3dbaf6c97cff548fcb0)

This uses the helper function from the last commit to make it easy to fetch all alerts for a given route ID & priority.

[refactor(DotcomWeb.ModeView): simpler has_alert?](https://github.com/mbta/dotcom/commit/4750f32a4aa3b842ae2bb561fec351e87ab066b2)

Using the new `Alerts.Repo` function in place of the existing logic. We still have to narrow it down to the currently active ones.

Since this changes the signature of `DotcomWeb.ModeView.has_alert?/3` a bunch, I got to adjust a bunch of code calling it! As an aside... I have a near-term goal of having the homepage not need a huge list of all `@alerts` at all, and this'll help a lot 😃 

> [!NOTE]
> I changed the underlying logic slightly -- the previous version used `Alerts.Alert.high_severity_or_high_priority?/1`, which is actually inconsistent with the rest of the website. 

It also struck me as extraneous, as the logic which sets `priority` to `:high` _already incorporates_ high severity through this block...
```elixir
def priority(%{severity: severity} = params, time) when severity >= 7 do
   if urgent?(params, time), do: :high, else: :low
end
``` 

That was also the only place `Alerts.Alert.high_severity_or_high_priority?/1` was invoked, so removing that call means I could delete that function too.

## Screenshots

No changes!

## How to test

I extracted some flamegraphs... the middle section changed a lot 😅

<details><summary>Click to see them yourself</summary>
<em>*note these flamegraphs omit the extra work done to render the alerts tab, because `FlameOn` kept timing out</em>
<table>
<thead><th>Before</th><th>After</th></thead>
<tbody>
<tr>
<td><img width="1276" height="7050" alt="recentlyvisitedbefore" src="https://github.com/user-attachments/assets/5a35ff81-1eb4-4af2-800f-7acd6d59bbbb" /> </td>
<td><img width="1276" height="7050" alt="recentlyvisitedafter" src="https://github.com/user-attachments/assets/0a0b683c-b455-45bf-a27c-b64c8967b0ae" /> </td>
</tr>
</tbody>
</table>
</details> 

<details><summary>Click here to see Claude's interpretation of them</summary>
<h2>The big finding: <code>_grid_buttons.html</code> was spawning Tasks per render</h2>
<p>In the <strong>before</strong> flamegraph, <code>DotcomWeb.ModeView</code> rendering the grid buttons partial goes through this call chain:</p>
<pre><code>_grid_buttons.html → Enum.with_index → Enum.map_reduce → Task.Supervised.stream (x6 instances)
                                                              ├─ Task.Supervised.stream_reduce/7  (~58ms each)
                                                              └─ Task.Supervised.stream_deliver/7  (~58ms each)
</code></pre>
<p>That's <strong>Task.async_stream (or similar)</strong> being used inside a template partial — spawning and supervising a separate BEAM process per grid button just to do (presumably) small, cheap work like resolving an icon or route link. In the <strong>after</strong> version, that entire code path is gone: the same partial now costs <strong>~250µs</strong> total instead of tens of milliseconds per task. This alone accounts for roughly <strong>58ms</strong> of the total <strong>65ms</strong> improvement.</p>

<h2>Overall numbers</h2>
<table>
<thead><td></td><th>Before</th><th>After</th></thead>
<tbody>
<tr>
<th scope="row">Total render time</th> <td>262.6ms</td><td>197.0ms</td></tr>
<tr>
<th scope="row">Improvement</th> <td></td><td>~25% faster (-65.6ms)</td>
</tr>
</tbody>
</table>
</details> 





