### PR TITLE
chore(Dotcom.Alerts): compute now outside loop

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -94,9 +94,8 @@ defmodule Dotcom.Alerts do
   """
   @spec in_effect_now?(Alerts.Alert.t()) :: boolean()
   def in_effect_now?(%Alerts.Alert{active_period: active_period}) do
-    Enum.any?(active_period, fn {start, stop} ->
-      in_range?({start, stop}, @date_time_module.now())
-    end)
+    now = @date_time_module.now()
+    Enum.any?(active_period, &in_range?(&1, now))
   end
 
   @doc """

--- a/lib/dotcom/utils/date_time.ex
+++ b/lib/dotcom/utils/date_time.ex
@@ -75,11 +75,11 @@ defmodule Dotcom.Utils.DateTime do
   def in_range?({nil, nil}, _), do: false
 
   def in_range?({nil, %DateTime{} = stop}, %DateTime{} = date_time) do
-    Timex.before?(date_time, stop) || Timex.equal?(date_time, stop, :microsecond)
+    DateTime.compare(date_time, stop) in [:lt, :eq]
   end
 
   def in_range?({%DateTime{} = start, nil}, %DateTime{} = date_time) do
-    Timex.after?(date_time, start) || Timex.equal?(date_time, start, :microsecond)
+    DateTime.compare(date_time, start) in [:gt, :eq]
   end
 
   def in_range?({%DateTime{} = start, %DateTime{} = stop}, %DateTime{} = date_time) do


### PR DESCRIPTION
Should be a no-op change here. 
- `Dotcom.Alerts.in_effect_now?/1` is adjusted to not recompute the current datetime in each active period iteration
- `Dotcom.Utils.DateTime.in_range?/2` is adjusted to use standard library code