### PR TITLE
Resolve iOS issue w/ new two-tiered header

### DIFF
--- a/assets/css/_global-navigation.scss
+++ b/assets/css/_global-navigation.scss
@@ -1,4 +1,4 @@
-// Navigation bar on both desktop and mobile
+// Navigation bar on both dropdown and fullscreen
 // Eventually we can phase out _header.scss file, and all relevant styling will be here
 
 header {
@@ -47,7 +47,7 @@ header {
   }
 }
 
-nav.m-menu--desktop {
+nav.m-menu--dropdown {
   @include base-font__new();
 
   display: flex;
@@ -61,7 +61,7 @@ nav.m-menu--desktop {
   }
 }
 
-nav.m-top-tier-menu--mobile {
+nav.m-top-tier-menu--dropdown {
   @include base-font__new();
 
   display: flex;
@@ -105,8 +105,8 @@ nav.m-top-tier-menu--mobile {
   }
 }
 
-// Buttons to open/close desktop menu
-.m-menu--desktop__toggle {
+// Buttons to open/close dropdown menu
+.m-menu--dropdown__toggle {
   align-items: center;
   color: inherit;
   display: flex;
@@ -142,8 +142,8 @@ nav.m-top-tier-menu--mobile {
 .m-menu--top-tier__toggle {
   margin-right: 0px;
 }
-// Desktop menu expanded area
-.m-menu--desktop__menu {
+// dropdown menu expanded area
+.m-menu--dropdown__menu {
   background-color: $brand-primary-lightest-contrast;
   box-shadow: 0 7px 14px 0 $gray-shadow;
   display: none; // start off closed
@@ -155,7 +155,7 @@ nav.m-top-tier-menu--mobile {
   z-index: 102;
 
   // opened
-  .m-menu--desktop__toggle[aria-expanded='true'] + & {
+  .m-menu--dropdown__toggle[aria-expanded='true'] + & {
     display: initial;
   }
 }
@@ -173,8 +173,8 @@ nav.m-top-tier-menu--mobile {
   }
 }
 
-// Layout the headers & links in the desktop menu
-.m-menu-desktop__section {
+// Layout the headers & links in the dropdown menu
+.m-menu-dropdown__section {
   color: $body-color;
   column-gap: $base-spacing;
   display: grid;
@@ -188,11 +188,11 @@ nav.m-top-tier-menu--mobile {
     line-height: unset; // smaller heading spacing
   }
 
-  .m-menu-desktop__submenu-section {
+  .m-menu-dropdown__submenu-section {
     grid-row: 2;
   }
 
-  .m-menu-desktop__section-feature {
+  .m-menu-dropdown__section-feature {
     grid-row: 1 / 3;
 
     .m-menu__feature {
@@ -210,17 +210,17 @@ nav.m-top-tier-menu--mobile {
     grid-template-columns: repeat(3, 1fr); // 3 columns
     grid-template-rows: repeat(3, auto); // 3 rows
 
-    .m-menu-desktop__submenu-section:first-of-type {
+    .m-menu-dropdown__submenu-section:first-of-type {
       grid-row: 2 / 4;
     }
 
-    .m-menu-feature.emergency-contacts.desktop {
+    .m-menu-feature.emergency-contacts.dropdown {
       border-radius: 0 .5rem .5rem;
       grid-row: 3 / 4;
       width: unset;
     }
 
-    .m-menu-desktop__section-feature {
+    .m-menu-dropdown__section-feature {
       grid-column: 3 / 4;
       grid-row: 1 / 4;
     }
@@ -238,11 +238,11 @@ nav.m-top-tier-menu--mobile {
   text-transform: uppercase;
   white-space: normal;
 
-  .m-menu--mobile & {
+  .m-menu--fullscreen & {
     font-size: $font-size-base-xs;
   }
 
-  .m-menu--desktop & {
+  .m-menu--dropdown & {
     margin: 0;
   }
 
@@ -335,7 +335,7 @@ nav.m-top-tier-menu--mobile {
   }
 
   &.emergency-contacts {
-    &.mobile {
+    &.fullscreen {
       border-radius: 0;
       margin-bottom: .125rem;
       margin-top: 0;

--- a/assets/css/_global-navigation.scss
+++ b/assets/css/_global-navigation.scss
@@ -33,8 +33,6 @@ header {
 .top-tier-header {
   background-color: $brand-primary-darkest;
   color: $white;
-  // position: relative;
-  // z-index: 1;
 }
 
 
@@ -143,7 +141,6 @@ nav.m-top-tier-menu--dropdown {
 
 .m-menu--top-tier__toggle {
   margin-right: 0px;
-  // transform: translateZ(0);
   position: relative;
   z-index: 1;
 }

--- a/assets/css/_global-navigation.scss
+++ b/assets/css/_global-navigation.scss
@@ -33,6 +33,8 @@ header {
 .top-tier-header {
   background-color: $brand-primary-darkest;
   color: $white;
+  // position: relative;
+  // z-index: 1;
 }
 
 
@@ -141,6 +143,9 @@ nav.m-top-tier-menu--dropdown {
 
 .m-menu--top-tier__toggle {
   margin-right: 0px;
+  // transform: translateZ(0);
+  position: relative;
+  z-index: 1;
 }
 // dropdown menu expanded area
 .m-menu--dropdown__menu {
@@ -256,14 +261,6 @@ nav.m-top-tier-menu--dropdown {
 // Reusing the veil component
 .m-menu--cover {
   display: none;
-
-  @include media-breakpoint-only(xs) {
-    top: $header-navbar-height-xs;
-  }
-
-  @include media-breakpoint-up(sm) {
-    top: $header-navbar-height-new;
-  }
 }
 
 // Contact numbers & Popular fares sections

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -439,7 +439,7 @@ nav.m-menu--mobile {
 }
 
 .m-menu__toggle,
-.m-menu--desktop__toggle,
+.m-menu--dropdown__toggle,
 .header-search__toggle {
   background-color: unset;
   border: 2px solid $brand-primary-light-contrast;
@@ -471,7 +471,7 @@ nav.m-menu--mobile {
 }
 
 .m-menu__toggle,
-.m-menu--desktop__toggle {
+.m-menu--dropdown__toggle {
   padding: .375rem .75rem .31rem;
 
   // this button is a link when JS is disabled

--- a/assets/ts/app/global-navigation.ts
+++ b/assets/ts/app/global-navigation.ts
@@ -23,9 +23,9 @@ function toggleMenu(el: Element): void {
 }
 
 const TOGGLE_NAMES = {
-  mobile: "toggle-mobile-nav",
+  fullscreen: "toggle-fullscreen-nav",
   search: "toggle-nav-search",
-  desktop: "toggle-desktop-nav"
+  dropdown: "toggle-dropdown-nav"
 };
 
 const TOGGLE_SELECTORS = Object.fromEntries(
@@ -44,13 +44,13 @@ export function setHeaderElementPositions(
   const bottomPx = `${bottom}px`;
   const heightPx = `${height}px`;
 
-  header.querySelectorAll("[data-nav='desktop-section']").forEach(el => {
+  header.querySelectorAll("[data-nav='dropdown-section']").forEach(el => {
     // eslint-disable-next-line no-param-reassign
     (el as HTMLElement).style.top = heightPx;
   });
 
   const content = header.querySelector(
-    "[data-nav='mobile-content']"
+    "[data-nav='fullscreen-menu-content']"
   ) as HTMLElement | null;
   if (content) {
     content.style.top = bottomPx;
@@ -78,14 +78,14 @@ export function setup(rootElement: HTMLElement): void {
     h.querySelector(TOGGLE_SELECTORS.search)
   );
 
-  // HEADERS THAT CONTAIN MOBILE MENU TOGGLES
-  const mobileMenuHeaders = headers.filter(h =>
-    h.querySelector(TOGGLE_SELECTORS.mobile)
+  // HEADERS THAT CONTAIN FULLSCREEN MENU TOGGLES, MOSTLY USED ON MOBILE
+  const fullscreenMenuHeaders = headers.filter(h =>
+    h.querySelector(TOGGLE_SELECTORS.fullscreen)
   );
 
-  // HEADERS WITH DESKTOP MENU TOGGLES
-  const desktopHeaders = headers.filter(h =>
-    h.querySelector(TOGGLE_SELECTORS.desktop)
+  // HEADERS WITH DROPDOWN MENU TOGGLES (OFTEN BUT NOT EXCLUSIVELY USED ON DESKTOP)
+  const dropdownHeaders = headers.filter(h =>
+    h.querySelector(TOGGLE_SELECTORS.dropdown)
   );
 
   //
@@ -102,10 +102,10 @@ export function setup(rootElement: HTMLElement): void {
   // CLICK HANDLERS
   //
 
-  // MOBILE MENU CLICK HANDLERS
-  mobileMenuHeaders.forEach(header => {
+  // FULLSCREEN MENU CLICK HANDLERS
+  fullscreenMenuHeaders.forEach(header => {
     header
-      .querySelectorAll(`button${TOGGLE_SELECTORS.mobile}`)
+      .querySelectorAll(`button${TOGGLE_SELECTORS.fullscreen}`)
       .forEach(toggle => {
         toggle.addEventListener("click", event => {
           event.preventDefault();
@@ -128,9 +128,9 @@ export function setup(rootElement: HTMLElement): void {
       });
   });
 
-  // DESKTOP CLICK HANDLERS
-  desktopHeaders.forEach(header => {
-    header.querySelectorAll(`a${TOGGLE_SELECTORS.desktop}`).forEach(toggle => {
+  // DROPDOWN CLICK HANDLERS
+  dropdownHeaders.forEach(header => {
+    header.querySelectorAll(`a${TOGGLE_SELECTORS.dropdown}`).forEach(toggle => {
       toggle.addEventListener("click", event => {
         event.preventDefault();
         toggleMenu(event.currentTarget as Element);
@@ -140,31 +140,33 @@ export function setup(rootElement: HTMLElement): void {
 
   // removes focus outline in Safari from open accordions
   rootElement
-    .querySelectorAll("[data-nav='mobile-content'] .js-focus-on-expand")
+    .querySelectorAll(
+      "[data-nav='fullscreen-menu-content'] .js-focus-on-expand"
+    )
     .forEach(openAccordion => {
       openAccordion.addEventListener("focus", undoOutline);
     });
 
   //
-  // MOBILE MENU OBSERVER (handles menu-open, search-open, focus)
+  // FULLSCREEN MENU OBSERVER (handles menu-open, search-open, focus)
   //
-  const toggledMobileMenuObserver = new MutationObserver(() => {
-    mobileMenuHeaders.forEach(header => {
-      const mobileToggle = header.querySelector(
-        `button${TOGGLE_SELECTORS.mobile}`
+  const toggledFullscreenMenuObserver = new MutationObserver(() => {
+    fullscreenMenuHeaders.forEach(header => {
+      const fullscreenToggle = header.querySelector(
+        `button${TOGGLE_SELECTORS.fullscreen}`
       );
 
-      if (!mobileToggle) return;
+      if (!fullscreenToggle) return;
 
       // Toggle Menu text
       if ("navOpen" in header.dataset) {
         const content = header.querySelector(
-          "[data-nav='mobile-content']"
+          "[data-nav='fullscreen-menu-content']"
         ) as HTMLElement;
         if (content) content.scrollTop = 0;
-        mobileToggle.innerHTML = "Close";
+        fullscreenToggle.innerHTML = "Close";
       } else {
-        mobileToggle.innerHTML = "Menu";
+        fullscreenToggle.innerHTML = "Menu";
       }
     });
 
@@ -181,7 +183,7 @@ export function setup(rootElement: HTMLElement): void {
 
   // OBSERVE changes on EVERY header
   headers.forEach(header => {
-    toggledMobileMenuObserver.observe(header, {
+    toggledFullscreenMenuObserver.observe(header, {
       attributes: true,
       attributeFilter: ["data-nav-open", "data-search-open"]
     });
@@ -215,27 +217,23 @@ export function setup(rootElement: HTMLElement): void {
       // eslint-disable-next-line no-param-reassign
       rootElement.dataset.navOpen = "true";
 
-      // MOBILE MENU EXPANDING
-      if (observedNames.includes(TOGGLE_NAMES.mobile)) {
-        mobileMenuHeaders.forEach(header => {
+      // FULLSCREEN MENU EXPANDING
+      if (observedNames.includes(TOGGLE_NAMES.fullscreen)) {
+        fullscreenMenuHeaders.forEach(header => {
           const content = header.querySelector(
-            "[data-nav='mobile-content']"
+            "[data-nav='fullscreen-menu-content']"
           ) as HTMLElement;
           if (content) disableBodyScroll(content);
           // eslint-disable-next-line no-param-reassign
           header.dataset.navOpen = "true";
         });
 
-
-        rootElement
-          .querySelectorAll(TOGGLE_SELECTORS.desktop)
-          .forEach(el => {
-            if (el.getAttribute("aria-expanded") === "true") {
-              toggleAriaExpanded(el)
-            }
-          })
+        rootElement.querySelectorAll(TOGGLE_SELECTORS.dropdown).forEach(el => {
+          if (el.getAttribute("aria-expanded") === "true") {
+            toggleAriaExpanded(el);
+          }
+        });
       }
-
 
       // SEARCH EXPANDING
       if (observedNames.includes(TOGGLE_NAMES.search)) {
@@ -245,16 +243,13 @@ export function setup(rootElement: HTMLElement): void {
           disableBodyScroll(header);
         });
 
-
-        rootElement
-          .querySelectorAll(TOGGLE_SELECTORS.desktop)
-          .forEach(el => {
-            if (el.getAttribute("aria-expanded") === "true") {
-              toggleAriaExpanded(el)
-            }
-          })
+        rootElement.querySelectorAll(TOGGLE_SELECTORS.dropdown).forEach(el => {
+          if (el.getAttribute("aria-expanded") === "true") {
+            toggleAriaExpanded(el);
+          }
+        });
       }
-      } else {
+    } else {
       // only do this if no other menu is expanded
       const anyOpen = Array.from(
         rootElement.querySelectorAll(allTogglesSelector)
@@ -265,7 +260,7 @@ export function setup(rootElement: HTMLElement): void {
         // eslint-disable-next-line no-param-reassign
         delete rootElement.dataset.navOpen;
 
-        mobileMenuHeaders.forEach(header => {
+        fullscreenMenuHeaders.forEach(header => {
           // eslint-disable-next-line no-param-reassign
           delete header.dataset.navOpen;
         });
@@ -278,20 +273,20 @@ export function setup(rootElement: HTMLElement): void {
     }
 
     //
-    // DESKTOP: close other desktop menus
+    // DROPDOWN (often but not exclusively used on desktop): close other dropdown menus
     //
-    const expandingDesktop =
-      aMenuIsBeingExpanded && observedNames.includes(TOGGLE_NAMES.desktop);
+    const expandingDropdown =
+      aMenuIsBeingExpanded && observedNames.includes(TOGGLE_NAMES.dropdown);
 
-    if (expandingDesktop) {
+    if (expandingDropdown) {
       const expandingToggle = mutations[0].target as Element;
-      const owningHeader = expandingToggle.closest("header");
+      const closestHeader = expandingToggle.closest("header");
 
       if (
-        owningHeader &&
-        owningHeader.querySelector("[data-nav='mobile-content']")
+        closestHeader &&
+        closestHeader.querySelector("[data-nav='fullscreen-menu-content']") // for fullscreen bottom-tier menu used on mobile
       ) {
-        disableBodyScroll(owningHeader, { reserveScrollBarGap: true });
+        disableBodyScroll(closestHeader, { reserveScrollBarGap: true });
       }
 
       const veil = rootElement.querySelector<HTMLElement>("[data-nav='veil']");
@@ -312,11 +307,11 @@ export function setup(rootElement: HTMLElement): void {
         "aria-controls"
       );
 
-      const desktopToggles = Array.from(
-        rootElement.querySelectorAll(TOGGLE_SELECTORS.desktop)
+      const dropdownToggles = Array.from(
+        rootElement.querySelectorAll(TOGGLE_SELECTORS.dropdown)
       );
 
-      desktopToggles
+      dropdownToggles
         .filter(
           (el: Element) =>
             el.getAttribute("aria-controls") !== controls &&
@@ -326,14 +321,14 @@ export function setup(rootElement: HTMLElement): void {
 
       rootElement
         .querySelectorAll(
-          TOGGLE_SELECTORS.mobile, TOGGLE_SELECTORS.search
+          `${TOGGLE_SELECTORS.fullscreen}, ${TOGGLE_SELECTORS.search}`
         )
         .forEach(el => {
           if (el.getAttribute("aria-expanded") === "true") {
             toggleAriaExpanded(el);
           }
         });
-      }
+    }
   });
 
   // Observe aria-expanded on every toggle everywhere
@@ -349,8 +344,10 @@ export function setup(rootElement: HTMLElement): void {
   // Note: we can't use `scrollIntoView`, Safari doesn't support it as of
   // 2022-02-28, and even if it did, the opening/closing animations of the
   // accordions makes the behavior janky on other browsers
-  mobileMenuHeaders.forEach(header => {
-    const menuContent = header.querySelector("[data-nav='mobile-content']");
+  fullscreenMenuHeaders.forEach(header => {
+    const menuContent = header.querySelector(
+      "[data-nav='fullscreen-menu-content']"
+    );
     if (!menuContent) return;
 
     if (window.matchMedia("(prefers-reduced-motion: no-preference)").matches) {
@@ -435,17 +432,17 @@ export function setup(rootElement: HTMLElement): void {
   // autocomplete closes all
   document.addEventListener("autocomplete:selected", closeAllMenus);
 
-  desktopHeaders.forEach(header => {
+  dropdownHeaders.forEach(header => {
     header.addEventListener("keydown", e => {
       const activeSection = document.activeElement?.closest(
-        "[data-nav='desktop-section']"
+        "[data-nav='dropdown-section']"
       );
       if (!activeSection) return;
 
       const openSectionId = activeSection.parentElement!.id;
 
       const activeButton = header.querySelector(
-        `${TOGGLE_SELECTORS.desktop}[aria-controls="${openSectionId}"]`
+        `${TOGGLE_SELECTORS.dropdown}[aria-controls="${openSectionId}"]`
       ) as HTMLButtonElement | null;
 
       handleNativeEscapeKeyPress(e, () => {

--- a/assets/ts/app/global-navigation.ts
+++ b/assets/ts/app/global-navigation.ts
@@ -225,7 +225,17 @@ export function setup(rootElement: HTMLElement): void {
           // eslint-disable-next-line no-param-reassign
           header.dataset.navOpen = "true";
         });
+
+
+        rootElement
+          .querySelectorAll(TOGGLE_SELECTORS.desktop)
+          .forEach(el => {
+            if (el.getAttribute("aria-expanded") === "true") {
+              toggleAriaExpanded(el)
+            }
+          })
       }
+
 
       // SEARCH EXPANDING
       if (observedNames.includes(TOGGLE_NAMES.search)) {
@@ -234,8 +244,17 @@ export function setup(rootElement: HTMLElement): void {
           header.dataset.searchOpen = "true";
           disableBodyScroll(header);
         });
+
+
+        rootElement
+          .querySelectorAll(TOGGLE_SELECTORS.desktop)
+          .forEach(el => {
+            if (el.getAttribute("aria-expanded") === "true") {
+              toggleAriaExpanded(el)
+            }
+          })
       }
-    } else {
+      } else {
       // only do this if no other menu is expanded
       const anyOpen = Array.from(
         rootElement.querySelectorAll(allTogglesSelector)
@@ -265,9 +284,15 @@ export function setup(rootElement: HTMLElement): void {
       aMenuIsBeingExpanded && observedNames.includes(TOGGLE_NAMES.desktop);
 
     if (expandingDesktop) {
-      desktopHeaders.forEach(header => {
-        disableBodyScroll(header, { reserveScrollBarGap: true });
-      });
+      const expandingToggle = mutations[0].target as Element;
+      const owningHeader = expandingToggle.closest("header");
+
+      if (
+        owningHeader &&
+        owningHeader.querySelector("[data-nav='mobile-content']")
+      ) {
+        disableBodyScroll(owningHeader, { reserveScrollBarGap: true });
+      }
 
       const veil = rootElement.querySelector<HTMLElement>("[data-nav='veil']");
       if (
@@ -298,7 +323,17 @@ export function setup(rootElement: HTMLElement): void {
             el.getAttribute("aria-expanded") === "true"
         )
         .forEach(toggleAriaExpanded);
-    }
+
+      rootElement
+        .querySelectorAll(
+          TOGGLE_SELECTORS.mobile, TOGGLE_SELECTORS.search
+        )
+        .forEach(el => {
+          if (el.getAttribute("aria-expanded") === "true") {
+            toggleAriaExpanded(el);
+          }
+        });
+      }
   });
 
   // Observe aria-expanded on every toggle everywhere

--- a/cypress/e2e/global_navigation.cy.js
+++ b/cypress/e2e/global_navigation.cy.js
@@ -9,10 +9,10 @@ const searchPlaceholderText = "Search for routes, info, and more";
 
 const SELECTORS = {
   veil: "[data-nav='veil']",
-  desktopMenu: "[data-nav='desktop-section']",
-  desktopMenuButton: "[data-nav='toggle-desktop-nav']",
-  mobileMenu: "[data-nav='mobile-content']",
-  mobileMenuButton: "button[data-nav='toggle-mobile-nav']",
+  desktopMenu: "[data-nav='dropdown-section']",
+  desktopMenuButton: "[data-nav='toggle-dropdown-nav']",
+  mobileMenu: "[data-nav='fullscreen-menu-content']",
+  mobileMenuButton: "button[data-nav='toggle-fullscreen-nav']",
   searchButton: "[data-nav='toggle-nav-search']",
   searchBarDesktop: "#header-desktop .aa-Autocomplete",
   searchInputDesktop: "#header-desktop .aa-Input",

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -9,14 +9,14 @@
     <div class="header-navbar new">
       <a
         class="font-white m-menu__toggle font-bold hidden-js"
-        data-nav="toggle-mobile-nav"
+        data-nav="toggle-fullscreen-nav"
         href={~p"/menu"}
       >
         {~t(Menu)}
       </a>
       <button
         class="m-menu__toggle font-bold hidden-no-js"
-        data-nav="toggle-mobile-nav"
+        data-nav="toggle-fullscreen-nav"
         type="button"
         aria-expanded="false"
         aria-controls="navmenu"

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -1,9 +1,7 @@
 <%= if Laboratory.enabled?(@conn, :use_smartling_translations) do %>
   {render("_top_tier_nav.html", assigns)}
 <% end %>
-<%= if not Laboratory.enabled?(@conn, :use_smartling_translations) do %>
-  <aside class="c-modal__cover m-menu--cover" aria-hidden="true" data-nav="veil"></aside>
-<% end %>
+<aside class="c-modal__cover m-menu--cover" aria-hidden="true" data-nav="veil"></aside>
 <header class="header--new" id="header-with-search">
   <div class="container new">
     <div class="header-navbar new">

--- a/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
@@ -1,9 +1,9 @@
-<nav id="navmenu-desktop" class="m-menu--desktop" aria-label="Main">
+<nav id="navmenu-dropdown" class="m-menu--dropdown" aria-label="Main">
   <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- DotcomWeb.LayoutView.nav_link_content do %>
     <a
-      class="m-menu--desktop__toggle"
+      class="m-menu--dropdown__toggle"
       href={"#{ href }"}
-      data-nav="toggle-desktop-nav"
+      data-nav="toggle-dropdown-nav"
       role="button"
       aria-expanded="false"
       aria-controls={"#{ to_camelcase(name) }"}
@@ -12,18 +12,18 @@
       <span class="c-indicator--angle"></span>
     </a>
 
-    <div class="m-menu--desktop__menu">
+    <div class="m-menu--dropdown__menu">
       <div class="container">
         <div id={"#{ to_camelcase(name) }"}>
           <div
-            class={"m-menu-desktop__section #{ to_camelcase(name) }"}
-            data-nav="desktop-section"
+            class={"m-menu-dropdown__section #{ to_camelcase(name) }"}
+            data-nav="dropdown-section"
           >
             <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
               <div class="m-menu__section-heading">
                 {section_name}
               </div>
-              <div class="m-menu-desktop__submenu-section" aria-label={"#{ section_name }"}>
+              <div class="m-menu-dropdown__submenu-section" aria-label={"#{ section_name }"}>
                 {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
                 <%= if section_name == "Transit Police" do %>
                   <div class="m-menu__feature emergency-contacts desktop">
@@ -41,13 +41,13 @@
             <% end %>
             <%= for %{sub_menu_section: special_section} <- sub_menus do %>
               <%= if special_section == "Most popular fares" do %>
-                <div class="m-menu-desktop__section-feature">
+                <div class="m-menu-dropdown__section-feature">
                   {render("_new_nav_popular_fares.html")}
                 </div>
               <% end %>
 
               <%= if special_section == "Contact numbers" do %>
-                <div class="m-menu-desktop__section-feature">
+                <div class="m-menu-dropdown__section-feature">
                   {render("_new_nav_contact_numbers.html")}
                 </div>
               <% end %>

--- a/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
@@ -1,5 +1,5 @@
 <nav class="m-menu--mobile" id="navmenu" aria-label={~t(Navigation Menu)}>
-  <div class="m-menu__content" data-nav="mobile-content">
+  <div class="m-menu__content" data-nav="fullscreen-menu-content">
     <h1 class="m-menu__title h2">{~t(Main Menu)}</h1>
     <%= for {%{menu_section: menu_section, sub_menus: sub_menus}, index} <- Enum.with_index(nav_link_content()) do %>
       <nav aria-labelledby={"section-heading-#{menu_section}"} class="m-menu__section">

--- a/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
+++ b/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
@@ -7,7 +7,7 @@
     </style>
   </noscript>
   <div class="container top-tier-nav-container">
-    <nav id="languages-menu" class="top-tier-header-navbar new m-top-tier-menu--dropdown">
+    <nav id="languages-menu" class="header--new top-tier-header-navbar new m-top-tier-menu--dropdown">
       <a class="navbar-logo" href="/" data-nav="logo">
         <span class="sr-only">{~t(MBTA Home Page)}</span>
         <div class="svg-container" aria-hidden="true">

--- a/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
+++ b/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
@@ -7,7 +7,10 @@
     </style>
   </noscript>
   <div class="container top-tier-nav-container">
-    <nav id="languages-menu" class="header--new top-tier-header-navbar new m-top-tier-menu--dropdown">
+    <nav
+      id="languages-menu"
+      class="header--new top-tier-header-navbar new m-top-tier-menu--dropdown"
+    >
       <a class="navbar-logo" href="/" data-nav="logo">
         <span class="sr-only">{~t(MBTA Home Page)}</span>
         <div class="svg-container" aria-hidden="true">

--- a/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
+++ b/lib/dotcom_web/templates/layout/_top_tier_nav.html.heex
@@ -7,7 +7,7 @@
     </style>
   </noscript>
   <div class="container top-tier-nav-container">
-    <nav id="languages-menu" class="top-tier-header-navbar new m-top-tier-menu--mobile">
+    <nav id="languages-menu" class="top-tier-header-navbar new m-top-tier-menu--dropdown">
       <a class="navbar-logo" href="/" data-nav="logo">
         <span class="sr-only">{~t(MBTA Home Page)}</span>
         <div class="svg-container" aria-hidden="true">
@@ -18,9 +18,9 @@
       <div id="languages-toggle">
         <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- DotcomWeb.LayoutView.language_nav_link_content do %>
           <a
-            class="m-menu--desktop__toggle m-menu--top-tier__toggle"
+            class="m-menu--dropdown__toggle m-menu--top-tier__toggle"
             href={"#{ href }"}
-            data-nav="toggle-desktop-nav"
+            data-nav="toggle-dropdown-nav"
             role="button"
             aria-expanded="false"
             aria-controls={"#{ to_camelcase(name) }"}
@@ -29,18 +29,18 @@
             <span class="c-indicator--angle"></span>
           </a>
 
-          <div class="m-menu--desktop__menu m-top-tier-menu__menu rounded-sm">
+          <div class="m-menu--dropdown__menu m-top-tier-menu__menu rounded-sm">
             <div class="top-tier-nav-container">
               <div id={"#{ to_camelcase(name) }"}>
                 <div
-                  class={"m-menu-desktop__section #{ to_camelcase(name) }"}
-                  data-nav="desktop-section"
+                  class={"m-menu-dropdown__section #{ to_camelcase(name) }"}
+                  data-nav="dropdown-section"
                 >
                   <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
                     <div class="m-menu__section-heading">
                       {section_name}
                     </div>
-                    <div class="m-menu-desktop__submenu-section" aria-label={"#{ section_name }"}>
+                    <div class="m-menu-dropdown__submenu-section" aria-label={"#{ section_name }"}>
                       {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
                     </div>
                   <% end %>

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -65,7 +65,7 @@
   </head>
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
     <div class="body-wrapper" id="body-wrapper">
-      <%!-- <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
+      <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
         <% language =
           Dotcom.Gettext |> Gettext.get_locale() |> Dotcom.Locales.locale() |> Map.get(:endonym) %>
         <div class={["w-full py-2 text-center leading-sm", banner_color_classes()]}>
@@ -84,7 +84,7 @@
             {name}
           </a>
         </div>
-      <% end %> --%>
+      <% end %>
       <a href="#main" class="sr-only sr-only-focusable">{~t(Skip to main content)}</a>
       {DotcomWeb.PartialView.render("_hidden_icons.html", conn: @conn)}
       {render("_new_header.html", conn: @conn)}

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -65,7 +65,7 @@
   </head>
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
     <div class="body-wrapper" id="body-wrapper">
-      <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
+      <%!-- <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
         <% language =
           Dotcom.Gettext |> Gettext.get_locale() |> Dotcom.Locales.locale() |> Map.get(:endonym) %>
         <div class={["w-full py-2 text-center leading-sm", banner_color_classes()]}>
@@ -84,7 +84,7 @@
             {name}
           </a>
         </div>
-      <% end %>
+      <% end %> --%>
       <a href="#main" class="sr-only sr-only-focusable">{~t(Skip to main content)}</a>
       {DotcomWeb.PartialView.render("_hidden_icons.html", conn: @conn)}
       {render("_new_header.html", conn: @conn)}


### PR DESCRIPTION
This solves an iOS bug as part of https://app.asana.com/1/15492006741476/project/1213994587940653/task/1216860386844707?focus=true

## Scope

The bug was tricky to troubleshoot since it did not appear when emulating iOS devices using browser dev tools -- only when  using an actual iOS device. Android was unaffected.

**Asana Ticket:**
https://app.asana.com/1/15492006741476/project/1213994587940653/task/1216860386844707?focus=true

## Implementation
* This was the result (in part) of trying to impose desktop-appropriate behaviors while on mobile.
* This PR fixes that ^ and also renames some variables used in the header logic/styling.

## Screenshots

## How to test
To repro the bug:
* Navigate to Dotcom prod on a mobile device and enable the flag
* Click on the languages menu
* This will 1) not actually show the languages menu, and 2) freeze the page

To test the fix:
* Navigate to Dotcom dev-blue on a mobile device and enable the flag
* Click on the languages menu, the bottom menu, etc. Everything should work as expected. Please let me know if I've missed anything glaring! 
