### PR TITLE
fix(AssignFromParam): avoid recomputing known atom

### DIFF
--- a/lib/dotcom_web/plugs/assign_from_param.ex
+++ b/lib/dotcom_web/plugs/assign_from_param.ex
@@ -38,21 +38,29 @@ defmodule DotcomWeb.Plugs.AssignFromParam do
   @behaviour Plug
 
   @impl true
-  def init(opts), do: opts
+  def init(opts) do
+    opts
+    |> Keyword.put(:param_atom, Keyword.fetch!(opts, :param) |> String.to_atom())
+  end
 
   @impl true
   def call(conn, opts) do
     param = Keyword.fetch!(opts, :param)
+    param_atom = Keyword.fetch!(opts, :param_atom)
     fallback_fn = Keyword.fetch!(opts, :fallback_fn)
     validator_fn = Keyword.get(opts, :validator_fn, fn value -> {:ok, value} end)
 
-    validate_call(conn, param, validator_fn, fallback_fn)
+    validate_call(conn, {param, param_atom}, validator_fn, fallback_fn)
   end
 
-  defp validate_call(%{query_params: query_params} = conn, param, validator_fn, fallback_fn)
+  defp validate_call(
+         %{query_params: query_params} = conn,
+         {param, param_atom},
+         validator_fn,
+         fallback_fn
+       )
        when is_map_key(query_params, param) do
     param_value = Map.get(query_params, param)
-    param_atom = String.to_atom(param)
 
     case validator_fn.(param_value) do
       {:ok, value} ->
@@ -61,11 +69,11 @@ defmodule DotcomWeb.Plugs.AssignFromParam do
       _ ->
         conn
         |> DotcomWeb.ControllerHelpers.redirect_sans_param(param)
-        |> validate_call(param, validator_fn, fallback_fn)
+        |> validate_call({param, param_atom}, validator_fn, fallback_fn)
     end
   end
 
-  defp validate_call(conn, param, _, fallback_fn) do
-    assign(conn, String.to_atom(param), fallback_fn.())
+  defp validate_call(conn, {_, param_atom}, _, fallback_fn) do
+    assign(conn, param_atom, fallback_fn.())
   end
 end

--- a/test/dotcom_web/plugs/assign_from_param_test.exs
+++ b/test/dotcom_web/plugs/assign_from_param_test.exs
@@ -8,7 +8,7 @@ defmodule DotcomWeb.Plugs.AssignFromParamTest do
       opts = [fallback_fn: fn -> "fallback value" end]
 
       assert_raise KeyError, fn ->
-        AssignFromParam.call(conn, opts)
+        AssignFromParam.call(conn, AssignFromParam.init(opts))
       end
     end
 
@@ -16,7 +16,7 @@ defmodule DotcomWeb.Plugs.AssignFromParamTest do
       opts = [param: "param", validator_fn: fn _ -> {:ok, "validated value"} end]
 
       assert_raise KeyError, fn ->
-        AssignFromParam.call(conn, opts)
+        AssignFromParam.call(conn, AssignFromParam.init(opts))
       end
     end
 
@@ -29,7 +29,7 @@ defmodule DotcomWeb.Plugs.AssignFromParamTest do
         fallback_fn: fn -> "fallback value" end
       ]
 
-      conn = AssignFromParam.call(conn, opts)
+      conn = AssignFromParam.call(conn, AssignFromParam.init(opts))
       assigned_value = conn.assigns[String.to_atom(param_name)]
       assert assigned_value == "fallback value"
     end
@@ -44,7 +44,7 @@ defmodule DotcomWeb.Plugs.AssignFromParamTest do
       ]
 
       conn = with_query_params(conn, %{param_name => "value"})
-      redirected_conn = AssignFromParam.call(conn, opts)
+      redirected_conn = AssignFromParam.call(conn, AssignFromParam.init(opts))
       assert redirected_conn.status == 302
       assigned_value = redirected_conn.assigns[String.to_atom(param_name)]
       assert assigned_value == "fallback value"
@@ -64,7 +64,7 @@ defmodule DotcomWeb.Plugs.AssignFromParamTest do
       param_value = Faker.Pokemon.name()
 
       conn = with_query_params(conn, %{param_name => param_value})
-      conn = AssignFromParam.call(conn, opts)
+      conn = AssignFromParam.call(conn, AssignFromParam.init(opts))
       assigned_value = conn.assigns[String.to_atom(param_name)]
       {:ok, expected_value} = opts[:validator_fn].(param_value)
       assert assigned_value == expected_value


### PR DESCRIPTION
Instead of re-doing `String.to_atom()` for the configured param from `AssignFromParam` on **every** single request, we can do it once by doing it in the plug `init/1`. This feels a bit clunky but should do the trick.

This plug was added in [#3325](https://github.com/mbta/dotcom/pull/3325) and all the criteria from the "How to test" section there should still hold.