### PR TITLE
fix(Plugs.Cookies): avoid using other paths

### DIFF
--- a/lib/dotcom_web/plugs/cookies.ex
+++ b/lib/dotcom_web/plugs/cookies.ex
@@ -76,7 +76,7 @@ defmodule DotcomWeb.Plugs.Cookies do
   routes, separated by a pipe ("|"), in order of most recently visited.
   """
   @spec set_route_cookie(Conn.t()) :: Conn.t()
-  def set_route_cookie(%Conn{path_info: ["schedules", route | _]} = conn)
+  def set_route_cookie(%Conn{path_info: ["schedules", route, _]} = conn)
       when route not in @modes do
     conn.cookies
     |> Map.get(@route_cookie_name, "")

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -83,13 +83,15 @@ defmodule Routes.Repo do
 
   defp update_direction_names(route), do: route
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-
+  @decorate cacheable(cache: @cache, on_error: :nothing, match: &match_route/1)
   defp cached_get(id, opts) do
     with %{data: [route]} <- MBTA.Api.Routes.get(id, opts) do
       {:ok, parse_route(route)}
     end
   end
+
+  defp match_route({:error, _}), do: {true, nil, ttl: :timer.seconds(30)}
+  defp match_route(route), do: {true, route, ttl: @ttl}
 
   @impl Routes.Repo.Behaviour
   def get_shapes(route_id, opts) do

--- a/test/dotcom_web/plugs/cookies_test.exs
+++ b/test/dotcom_web/plugs/cookies_test.exs
@@ -19,85 +19,86 @@ defmodule DotcomWeb.Plugs.CookiesTest do
       assert conn.cookies[id_cookie_name()] == "123"
     end
 
-    @tag :external
     test "adds route to cookie if user visits a schedule page", %{conn: conn} do
-      # needed by DotcomWeb.ScheduleController.VehicleLocations plug
-      _ = start_supervised({Phoenix.PubSub, name: Vehicles.PubSub})
-      _ = start_supervised(Vehicles.Repo)
-      with_cookie = get(conn, schedule_path(conn, :show, %Routes.Route{id: "Red"}))
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+
+      with_cookie = get(conn, "/schedules/Red/line")
       assert Map.get(with_cookie.cookies, route_cookie_name()) == "Red"
 
-      timetable_path =
-        conn
-        |> schedule_path(:show, %Routes.Route{id: "CR-Lowell"})
-        |> Path.join("timetable")
-
-      assert timetable_path == "/schedules/CR-Lowell/timetable"
-
-      with_cookie = get(conn, timetable_path)
+      with_cookie = get(conn, "/schedules/CR-Lowell/timetable")
       assert Map.get(with_cookie.cookies, route_cookie_name()) == "CR-Lowell"
     end
 
-    @tag :external
     test "sets green line branch cookies correctly", %{conn: conn} do
-      green_b_path = schedule_path(conn, :show, "Green-B")
-      assert green_b_path == "/schedules/Green-B"
-      with_cookie = get(conn, green_b_path)
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+
+      with_cookie = get(conn, "/schedules/Green-B/line")
       assert Map.get(with_cookie.cookies, route_cookie_name()) == "Green-B"
     end
 
-    @tag :external
     test "appends new route to cookie if user visits another schedule page", %{conn: conn} do
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+
       conn =
         conn
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Red"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Orange"}))
+        |> get("/schedules/Red/line")
+        |> get("/schedules/Orange/line")
 
       assert conn.cookies
              |> Map.get(route_cookie_name())
              |> URI.decode() == "Orange|Red"
     end
 
-    @tag :external
     test "route cookie is sorted by most recently visited", %{conn: conn} do
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+
       conn =
         conn
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Red"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Blue"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Orange"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Red"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Blue"}))
+        |> get("/schedules/Red/line")
+        |> get("/schedules/Blue/line")
+        |> get("/schedules/Orange/line")
+        |> get("/schedules/Red/line")
+        |> get("/schedules/Blue/line")
 
       assert conn.cookies
              |> Map.get(route_cookie_name())
              |> URI.decode() == "Blue|Red|Orange"
     end
 
-    @tag :external
     test "only saves 4 most recent cookies", %{conn: conn} do
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+
       conn =
         conn
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Red"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Blue"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Orange"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "CR-Lowell"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "1"}))
-        |> get(schedule_path(conn, :show, %Routes.Route{id: "Boat-F4"}))
+        |> get("/schedules/Red/line")
+        |> get("/schedules/Blue/line")
+        |> get("/schedules/Orange/line")
+        |> get("/schedules/CR-Lowell/timetable")
+        |> get("/schedules/1/line")
+        |> get("/schedules/Boat-F4/timetable")
 
       assert conn.cookies
              |> Map.get(route_cookie_name())
              |> URI.decode() == "Boat-F4|1|CR-Lowell|Orange"
     end
 
-    @tag :external
     test "route cookie is not set when user visits a non-schedule page", %{conn: conn} do
+      Mox.stub(MBTA.Api.Mock, :get_json, fn _, _ -> {:error, nil} end)
+      Mox.stub(Routes.Repo.Mock, :get, fn _ -> nil end)
+      Mox.stub(Routes.Repo.Mock, :by_type, fn _ -> [] end)
+
       assert conn
-             |> get(schedule_path(conn, :show, "bus"))
+             |> get("/schedules/bus")
              |> Map.get(:cookies)
              |> Map.get(route_cookie_name()) == nil
 
       assert conn
-             |> get("/")
+             |> get("/fares")
+             |> Map.get(:cookies)
+             |> Map.get(route_cookie_name()) == nil
+
+      assert conn
+             |> get("/schedules/map_api")
              |> Map.get(:cookies)
              |> Map.get(route_cookie_name()) == nil
     end


### PR DESCRIPTION
## Scope

Just happened to discover a few other "routes" stored in the cookie. :( 

## Implementation

It was thanks to poor path parsing. We have, for example, `/schedules/map_api` which one could hit. This would store "map_api" as a "route", which would eventually be looked up in `Routes.Repo` when rendering "Recently Visited" routes. Not great, and a waste of resources.

The other aspect of this I wanted to raise is that, if you happen to have a nonsensical route in your cookie, this is going to be requested from the V3 API over and over and [over](https://api-dev.mbtace.com/routes/nonsense). This is because we don't cache error responses. Normally that's a good thing, but in light of recognizing our website gets hammered with excess requests.... this creates a suboptimal situation. So I added an extra change in `Routes.Repo` which caches errors, but only for 30 seconds. Curious what folks think of that.

## Screenshots

No change!

## How to test

The final test I added in the test file fails on `main` but passes here!
