### PR TITLE
feat: Add `Dockerfile` that defines a load testing container

### DIFF
--- a/.github/workflows/push-load-test.yml
+++ b/.github/workflows/push-load-test.yml
@@ -1,0 +1,61 @@
+name: Push Load Test
+
+on:
+  # Invoked via another workflow, value passed in by string
+  workflow_call:
+    inputs:
+      deployment-env:
+        description: "Environment to deploy to (dev-green or dev-blue only)"
+        required: true
+        type: string
+        options:
+          - dev-green
+          - dev-blue
+    secrets:
+      aws-role-arn:
+        required: true
+        description: "AWS_ROLE_ARN value"
+      aws-account-id:
+        required: true
+        description: "TID_AWS_ACCOUNT_ID value"
+
+concurrency:
+  group: deploy-load-test-${{ inputs.deployment-env }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check for changes in load test setup
+    runs-on: ubuntu-latest
+    needs: validate
+    outputs:
+      changed: ${{ steps.changes.outputs.load_test == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            load_test:
+              - 'deploy/load_test/**'
+              - 'integration/load_tests/**'
+
+  push:
+    name: Deploy new version
+    runs-on: ubuntu-latest
+    needs: check
+    if: ${{ needs.check.outputs.changed }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Build, tag, and push image to Amazon ECR
+        id: ecr
+        uses: mbta/actions/build-push-ecr@v2
+        with:
+          docker-repo: "${{ secrets.aws-account-id || secrets.TID_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/dotcom-load-test"
+          dockerfile-path: "-f ./deploy/load_test/Dockerfile ."
+          role-to-assume: ${{ secrets.aws-role-arn || secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/push-load-test.yml
+++ b/.github/workflows/push-load-test.yml
@@ -56,6 +56,6 @@ jobs:
         id: ecr
         uses: mbta/actions/build-push-ecr@v2
         with:
-          docker-repo: "${{ secrets.aws-account-id || secrets.TID_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/dotcom-load-test"
+          docker-repo: "${{ secrets.aws-account-id || secrets.TID_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/dotcom-load-tests"
           dockerfile-path: "-f ./deploy/load_test/Dockerfile ."
           role-to-assume: ${{ secrets.aws-role-arn || secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -179,3 +179,11 @@ jobs:
     secrets:
       aws-account-id: ${{ secrets.aws-account-id }}
       aws-role-arn: ${{ secrets.aws-role-arn }}
+  load-test:
+    uses: ./.github/workflows/push-load-test.yml
+    if: ${{ inputs.deployment-env == 'dev-green' || inputs.deployment-env == 'dev-blue' }}
+    with:
+      deployment-env: ${{ inputs.deployment-env }}
+    secrets:
+      aws-account-id: ${{ secrets.aws-account-id }}
+      aws-role-arn: ${{ secrets.aws-role-arn }}

--- a/deploy/load_test/Dockerfile
+++ b/deploy/load_test/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:trixie-20260223-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl git make build-essential inotify-tools nodejs npm
+
+RUN npm install -g artillery@2.0.30
+COPY ../../integration/load_tests/homepage-heavy-load.yml ./test.yml
+
+CMD npx artillery run -e ${ENVIRONMENT} ./test.yml

--- a/deploy/load_test/Dockerfile
+++ b/deploy/load_test/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl git make build-essential inotify-tools nodejs npm
 
-RUN npm install -g artillery@2.0.30
+RUN npm install -g artillery@2.0.33
 COPY ../../integration/load_tests/homepage-heavy-load.yml ./test.yml
 
 CMD npx artillery run -e ${ENVIRONMENT} ./test.yml

--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -8,10 +8,10 @@ config:
       duration: 300
       arrivalRate: 100
   environments:
-    green:
-      target: "http://dev-green.mbtace.com"
-    blue:
-      target: "http://dev-blue.mbtace.com"
+    dev-green:
+      target: "https://dev-green.mbtace.com"
+    dev-blue:
+      target: "https://dev-blue.mbtace.com"
 scenarios:
   - name: "Stress test single page"
     flow:

--- a/integration/load_tests/homepage-light-load.yml
+++ b/integration/load_tests/homepage-light-load.yml
@@ -11,10 +11,10 @@ config:
       duration: 60
       arrivalRate: 3
   environments:
-    green:
-      target: "http://dev-green.mbtace.com"
-    blue:
-      target: "http://dev-blue.mbtace.com"
+    dev-green:
+      target: "https://dev-green.mbtace.com"
+    dev-blue:
+      target: "https://dev-blue.mbtace.com"
 scenarios:
   - name: "Stress test single page"
     flow:


### PR DESCRIPTION
## Scope

**Asana Ticket:** [📈 Set up load testing container in Dotcom](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217118437317839?focus=true)

Related to:
- https://github.com/mbta/terraform_modules/pull/953

## Implementation

Two things:
- A new Dockerfile that builds an image whose container runs a load test and then exits.
- A Github Action that uploads that image to AWS.

## How to test

I wouldn't recommend testing this locally exactly as-is - it is a load test, which means sending lots of traffic, which means possibly getting your ISP mad at you.

In `deploy/load_test/Dockerfile`, change `homepage-heavy-load.yml` to `homepage-light-load.yml` and then do 👇.

Build the image with

```bash
docker build . -f deploy/load_test/Dockerfile -t load_test
```

And run it with

```bash
docker run --rm -ti -e ENVIRONMENT=dev-green load_test
```

It's not immediately obvious that it's hitting the right environment, but there are a few things you can do to see for sure:
- Run ☝️ when you don't have the site running locally - that should prove that it's not testing locally.
- Change the `dev-green` URL in `homepage-light-load.yml` from `https://dev-green.mbtace.com` to `http://dev-green.mbtace.com` - you should see that the test output now says that it got a bunch of `301` responses.
  - You'll have to re-run the `docker build` command, since otherwise the docker image will still have the old `homepage-light-load.yml` file in it. 
- Change the `dev-green` URL in `homepage-light-load.yml` from `https://dev-green.mbtace.com` to something silly like `https://dev-gree.mbtace.com` - this should have the predictable output.
