### PR TITLE
hotfix(ContentSecurityPolicy): unblock Google Translate script

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -77,7 +77,9 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         snap.licdn.com
         translate.google.com/translate_a/element.js
         translate-pa.googleapis.com
+        translate.googleapis.com
         www.instagram.com
+        www.google.com/sorry/index
         https://cdn.jsdelivr.net/
         analytics.tiktok.com
       ],
@@ -109,8 +111,6 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
     websocket_url = "#{Keyword.get(endpoint_config, :url, [])[:host]}"
 
     [
-      {:connect_src, "ws://#{websocket_url}"},
-      {:connect_src, "wss://#{websocket_url}"},
       {:img_src, drupal_url}
     ]
     |> static_host(Keyword.get(endpoint_config, :static_url))

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -108,7 +108,6 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
   defp runtime_directives do
     drupal_url = Util.config(:dotcom, :cms_api)[:base_url]
     endpoint_config = Util.config(:dotcom, DotcomWeb.Endpoint)
-    websocket_url = "#{Keyword.get(endpoint_config, :url, [])[:host]}"
 
     [
       {:img_src, drupal_url}


### PR DESCRIPTION
## Scope

While in a meeting today we noticed the language picker in the navigation bar has stopped working. 😩 

<figure>
<img width="1372" height="201" alt="image" src="https://github.com/user-attachments/assets/2a6bb709-7d7c-4c48-a7ce-73ef1fbad112" />
<figcaption>Something is missing between the buttons and the search bar...</figcaption>
</figure>

## Implementation

It was getting blocked by our CSP. The fix is to add the (perhaps new) URLs to our Content Security Policy's `script-src` directive.

## Screenshots

<img width="1393" height="173" alt="image" src="https://github.com/user-attachments/assets/257bfce9-dced-4413-8a15-fdd72090c98e" />