### PR TITLE
QF [Fix]:  FunctionClauseError: no function clause matching in Date.compare/2

### DIFF
--- a/lib/dotcom_web/plugs/date_in_rating.ex
+++ b/lib/dotcom_web/plugs/date_in_rating.ex
@@ -17,8 +17,17 @@ defmodule DotcomWeb.Plugs.DateInRating do
   def call(%Conn{assigns: %{date: date}, query_params: %{"date" => _}} = conn, dates_fn: dates_fn) do
     in_rating? =
       case dates_fn.() do
+        %{start_date: nil, end_date: end_date} ->
+          Date.before?(date, end_date)
+
+        %{start_date: start_date, end_date: nil} ->
+          Date.after?(date, start_date)
+
         %{start_date: start_date, end_date: end_date} ->
           Date.compare(start_date, date) != :gt and Date.compare(end_date, date) != :lt
+
+        %{start_date: nil, end_date: nil} ->
+          true
 
         :error ->
           true

--- a/lib/dotcom_web/plugs/date_in_rating.ex
+++ b/lib/dotcom_web/plugs/date_in_rating.ex
@@ -21,10 +21,10 @@ defmodule DotcomWeb.Plugs.DateInRating do
           true
 
         %{start_date: nil, end_date: end_date} ->
-          Date.before?(date, end_date)
+          Date.before?(date, end_date) or Date.compare(date, end_date) == :eq
 
         %{start_date: start_date, end_date: nil} ->
-          Date.after?(date, start_date)
+          Date.after?(date, start_date) or Date.compare(date, start_date) == :eq
 
         %{start_date: start_date, end_date: end_date} ->
           Date.compare(start_date, date) != :gt and Date.compare(end_date, date) != :lt

--- a/lib/dotcom_web/plugs/date_in_rating.ex
+++ b/lib/dotcom_web/plugs/date_in_rating.ex
@@ -17,6 +17,9 @@ defmodule DotcomWeb.Plugs.DateInRating do
   def call(%Conn{assigns: %{date: date}, query_params: %{"date" => _}} = conn, dates_fn: dates_fn) do
     in_rating? =
       case dates_fn.() do
+        %{start_date: nil, end_date: nil} ->
+          true
+
         %{start_date: nil, end_date: end_date} ->
           Date.before?(date, end_date)
 
@@ -25,9 +28,6 @@ defmodule DotcomWeb.Plugs.DateInRating do
 
         %{start_date: start_date, end_date: end_date} ->
           Date.compare(start_date, date) != :gt and Date.compare(end_date, date) != :lt
-
-        %{start_date: nil, end_date: nil} ->
-          true
 
         :error ->
           true

--- a/test/dotcom_web/plugs/date_in_rating_test.exs
+++ b/test/dotcom_web/plugs/date_in_rating_test.exs
@@ -80,6 +80,28 @@ defmodule DotcomWeb.Plugs.DateInRatingTest do
       assert conn_with_params.assigns.date_in_rating? == false
     end
 
+    test "returns true when start_date is nil and date is same as end_date", %{conn: conn} do
+      conn = %{
+        conn
+        | assigns: %{date: @end_date},
+          query_params: %{"date" => @end_date |> Date.to_iso8601()}
+      }
+
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: nil, end_date: @end_date} end)
+      assert conn_with_params.assigns.date_in_rating? == true
+    end
+
+    test "returns true when end_date is nil and date is same as start_date", %{conn: conn} do
+      conn = %{
+        conn
+        | assigns: %{date: @start_date},
+          query_params: %{"date" => @start_date |> Date.to_iso8601()}
+      }
+
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: @start_date, end_date: nil} end)
+      assert conn_with_params.assigns.date_in_rating? == true
+    end
+
     test "returns true when start_date and end_date are both nil", %{conn: conn} do
       conn = %{conn | assigns: %{date: ~D[2020-01-01]}, query_params: %{"date" => "2020-01-01"}}
       conn_with_params = call(conn, dates_fn: fn -> %{start_date: nil, end_date: nil} end)

--- a/test/dotcom_web/plugs/date_in_rating_test.exs
+++ b/test/dotcom_web/plugs/date_in_rating_test.exs
@@ -55,5 +55,35 @@ defmodule DotcomWeb.Plugs.DateInRatingTest do
         assert conn_with_date.assigns.date_in_rating? === false
       end
     end
+
+    test "returns true when end_date is nil and date is valid", %{conn: conn} do
+      conn = %{conn | assigns: %{date: ~D[2016-12-12]}, query_params: %{"date" => "2016-12-12"}}
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: @start_date, end_date: nil} end)
+      assert conn_with_params.assigns.date_in_rating? == true
+    end
+
+    test "returns true when start_date is nil and date is valid", %{conn: conn} do
+      conn = %{conn | assigns: %{date: ~D[2016-12-12]}, query_params: %{"date" => "2016-12-12"}}
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: nil, end_date: @end_date} end)
+      assert conn_with_params.assigns.date_in_rating? == true
+    end
+
+    test "returns false when end_date is nil and date is before start_date", %{conn: conn} do
+      conn = %{conn | assigns: %{date: ~D[2015-01-01]}, query_params: %{"date" => "2015-01-01"}}
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: @start_date, end_date: nil} end)
+      assert conn_with_params.assigns.date_in_rating? == false
+    end
+
+    test "returns false when start_date is nil and date is valid", %{conn: conn} do
+      conn = %{conn | assigns: %{date: ~D[2020-01-01]}, query_params: %{"date" => "2020-01-01"}}
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: nil, end_date: @end_date} end)
+      assert conn_with_params.assigns.date_in_rating? == false
+    end
+
+    test "returns true when start_date and end_date are both nil", %{conn: conn} do
+      conn = %{conn | assigns: %{date: ~D[2020-01-01]}, query_params: %{"date" => "2020-01-01"}}
+      conn_with_params = call(conn, dates_fn: fn -> %{start_date: nil, end_date: nil} end)
+      assert conn_with_params.assigns.date_in_rating? == true
+    end
   end
 end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | FunctionClauseError: no function clause matching in Date.compare/2](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217022094152012?focus=true)

[Sentry Log](https://mbtace.sentry.io/issues/trace/aadfa8d3ce85490ab38ae6eb66d9facf/?groupId=7641114837&node=error-aadfa8d3ce85490ab38ae6eb66d9facf&pageEnd=2026-07-30T10%3A47%3A03.457&pageStart=2026-07-29T10%3A47%3A03.457&referrer=slack&source=issue_details&timestamp=1785365223.452)

## Implementation

Saw a nil passed into this function via error logs, added cases to handle if end_date or start_date (or both) are nil.

Is this the right logic to use for these edge cases?  The error condition returns true, so it seems we prefer false positives over false negatives.  I used that logic to give the partial data the best chance to pass a test that makes sense.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

Unit tests!

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
