### PR TITLE
chore: enact a few minor code enhancements

### DIFF
--- a/lib/dotcom/alerts/endpoint_stops.ex
+++ b/lib/dotcom/alerts/endpoint_stops.ex
@@ -194,6 +194,7 @@ defmodule Dotcom.Alerts.EndpointStops do
   defp affected_stops_for_route_pattern(route_pattern, affected_stop_ids) do
     route_pattern.stop_ids
     |> Enum.map(&@stops_repo.get_parent/1)
+    |> Enum.reject(&Kernel.is_nil/1)
     |> Enum.filter(&MapSet.member?(affected_stop_ids, &1.id))
   end
 

--- a/lib/dotcom_web/plugs/recently_visited.ex
+++ b/lib/dotcom_web/plugs/recently_visited.ex
@@ -31,7 +31,7 @@ defmodule DotcomWeb.Plugs.RecentlyVisited do
       |> String.split("|")
       |> Task.async_stream(&@routes_repo.get/1, max_concurrency: 4, on_timeout: :kill_task)
       |> Stream.filter(&match?({:ok, %Route{listed?: true}}, &1))
-      |> Stream.map(fn {:ok, route} -> route end)
+      |> Enum.map(fn {:ok, route} -> route end)
 
     Conn.assign(conn, :recently_visited, route_list)
   end

--- a/lib/green_line.ex
+++ b/lib/green_line.ex
@@ -29,7 +29,10 @@ defmodule GreenLine do
           stop_routes_pair
   def calculate_stops_on_routes(direction_id, date \\ nil) do
     branch_ids()
-    |> Task.async_stream(&green_line_stops(&1, direction_id, date))
+    |> Task.async_stream(&green_line_stops(&1, direction_id, date),
+      max_concurrency: 4,
+      on_timeout: :kill_task
+    )
     |> Enum.reduce({[], %{}}, &merge_green_line_stops/2)
   end
 

--- a/lib/schedules/repo.ex
+++ b/lib/schedules/repo.ex
@@ -277,26 +277,28 @@ defmodule Schedules.Repo do
 
   defp load_from_other_repos(schedules) do
     schedules
-    |> Task.async_stream(fn {route_id, trip_id, stop_id, schedule_id, arrival_time,
-                             departure_time, time, flag?, early_departure?, last_stop?,
-                             stop_sequence, stop_headsign, pickup_type} ->
-      %Schedules.Schedule{
-        route: @routes_repo.get(route_id),
-        trip: trip(trip_id),
-        platform_stop_id: stop_id,
-        schedule_id: schedule_id,
-        stop: @stops_repo.get_parent(stop_id),
-        arrival_time: arrival_time,
-        departure_time: departure_time,
-        time: time,
-        flag?: flag?,
-        early_departure?: early_departure?,
-        last_stop?: last_stop?,
-        stop_sequence: stop_sequence,
-        stop_headsign: stop_headsign,
-        pickup_type: pickup_type
-      }
-    end)
+    |> Task.async_stream(
+      fn {route_id, trip_id, stop_id, schedule_id, arrival_time, departure_time, time, flag?,
+          early_departure?, last_stop?, stop_sequence, stop_headsign, pickup_type} ->
+        %Schedules.Schedule{
+          route: @routes_repo.get(route_id),
+          trip: trip(trip_id),
+          platform_stop_id: stop_id,
+          schedule_id: schedule_id,
+          stop: @stops_repo.get_parent(stop_id),
+          arrival_time: arrival_time,
+          departure_time: departure_time,
+          time: time,
+          flag?: flag?,
+          early_departure?: early_departure?,
+          last_stop?: last_stop?,
+          stop_sequence: stop_sequence,
+          stop_headsign: stop_headsign,
+          pickup_type: pickup_type
+        }
+      end,
+      on_timeout: :kill_task
+    )
     |> Enum.map(fn {:ok, schedule} -> schedule end)
   end
 

--- a/lib/schedules/repo_condensed.ex
+++ b/lib/schedules/repo_condensed.ex
@@ -51,26 +51,32 @@ defmodule Schedules.RepoCondensed do
       data
       |> Stream.map(&Parser.parse/1)
       |> Stream.filter(&has_trip?/1)
-      |> Task.async_stream(
-        fn {_, trip_id, stop_id, _, _, _, time, _, _, _, stop_sequence, _, _} ->
-          trip = Repo.trip(trip_id)
-          stop = @stops_repo.get!(stop_id)
-
-          %ScheduleCondensed{
-            time: time,
-            trip_id: trip_id,
-            headsign: trip.headsign,
-            route_pattern_id: trip.route_pattern_id,
-            stop_id: stop.parent_id || stop.id,
-            train_number: trip.name,
-            stop_sequence: stop_sequence
-          }
-        end,
-        timeout: @long_timeout
+      |> Task.async_stream(&to_condensed_schedule/1,
+        timeout: @long_timeout,
+        on_timeout: :kill_task
       )
-      |> Stream.filter(&match?({:ok, _}, &1))
+      |> Stream.filter(&match?({:ok, %ScheduleCondensed{}}, &1))
       |> Stream.map(fn {:ok, result} -> result end)
       |> Enum.to_list()
+    end
+  end
+
+  defp to_condensed_schedule({_, trip_id, stop_id, _, _, _, time, _, _, _, stop_sequence, _, _}) do
+    trip = Repo.trip(trip_id)
+    stop = @stops_repo.get(stop_id)
+
+    if is_nil(trip) or is_nil(stop) do
+      :error
+    else
+      %ScheduleCondensed{
+        time: time,
+        trip_id: trip_id,
+        headsign: trip.headsign,
+        route_pattern_id: trip.route_pattern_id,
+        stop_id: stop.parent_id || stop.id,
+        train_number: trip.name,
+        stop_sequence: stop_sequence
+      }
     end
   end
 

--- a/lib/stops/repo.ex
+++ b/lib/stops/repo.ex
@@ -115,7 +115,11 @@ defmodule Stops.Repo do
     # once the V3 API supports multiple route_ids in this field, we can do it
     # as a single lookup -ps
     route_ids
-    |> Task.async_stream(&by_route(&1, direction_id, opts))
+    |> Task.async_stream(&by_route(&1, direction_id, opts),
+      max_concurrency: 4,
+      on_timeout: :kill_task,
+      ordered: false
+    )
     |> Enum.flat_map(fn
       {:ok, stops} -> stops
       _ -> []


### PR DESCRIPTION
This PR is organized commit by commit. Each of these tweaks are so small it barely demands a PR. The changes fall into the following:

- `Task.async_stream/3` - adding `:on_timeout` to kill a task instead of raising an error when it times out.
- `Stops.Repo.get_parent/1` and `get/1` can return `nil`, so code reading its output should acknowledge this possibility
- We were assigning a `Stream` to `@recently_visited`, which seems to make the template do a lot more work - give it a regular list instead