### PR TITLE
chore(Routes.Repo): add sort_order to Green route

### DIFF
--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -197,7 +197,7 @@ defmodule Routes.Repo do
       type: 0,
       description: :rapid_transit,
       color: "00843D",
-      sort_order: 10030
+      sort_order: 10_030
     }
   end
 end

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -196,7 +196,8 @@ defmodule Routes.Repo do
       direction_destinations: %{0 => "All branches", 1 => "All branches"},
       type: 0,
       description: :rapid_transit,
-      color: "00843D"
+      color: "00843D",
+      sort_order: 10030
     }
   end
 end


### PR DESCRIPTION
We fake our own `%Route{}` for the consolidated "Green" line, but when we started parsing `sort_order` we forgot to add this for our custom Green Line route. 

This PR adds a `sort_order` to put it in line with those of the other [subway routes](https://api-dev.mbtace.com/routes?filter%5Btype%5D=0,1&fields%5Broute%5D=sort_order).

<img width="234" height="112" alt="image" src="https://github.com/user-attachments/assets/05f2c1b9-a549-40de-9fb1-597783b6e3d9" />

to 

<img width="207" height="105" alt="image" src="https://github.com/user-attachments/assets/158dc26a-ca1b-48c5-8806-12f0d04edf72" />

I forgot to take a before/after from when I actually came across it last week, which also involved a Blue Line alert. It was showing up with a Blue Line icon in between some Green Line icons and it looked pretty funky!