### PR TITLE
 [Fix]: Recently Visited adds Boston Stadium Trains for any CR line

### DIFF
--- a/lib/dotcom_web/plugs/cookies.ex
+++ b/lib/dotcom_web/plugs/cookies.ex
@@ -78,11 +78,19 @@ defmodule DotcomWeb.Plugs.Cookies do
   @spec set_route_cookie(Conn.t()) :: Conn.t()
   def set_route_cookie(%Conn{path_info: ["schedules", route, _]} = conn)
       when route not in @modes do
-    conn.cookies
-    |> Map.get(@route_cookie_name, "")
-    |> String.split("|")
-    |> build_route_cookie(route)
-    |> do_set_route_cookie(conn)
+    if String.contains?(route, "api") do
+      conn
+    else
+      conn.cookies
+      |> Map.get(@route_cookie_name, "")
+      |> String.split("|")
+      |> build_route_cookie(route)
+      |> do_set_route_cookie(conn)
+    end
+  end
+
+  def set_route_cookie(%Conn{path_info: ["schedules", "Green"]} = conn) do
+    set_route_cookie(%{conn | path_info: ["schedules", "Green", "line"]})
   end
 
   def set_route_cookie(%Conn{} = conn) do


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️ Fix: Recently Visited adds Boston Stadium Trains for any CR line](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216321763554242?focus=true)

## Implementation

While the bug described in the ticket went away when the World Cup did, I still noticed odd behavior in the recently visited section.  Mostly it's indecision whether the max length is 3 or 4 entries.

There were two basic problems I found:  

1. Visiting the "Green" line schedule page didn't add an entry to the list.  (The link goes to `/schedules/Green` instead of `/schedules/Green/line` like the other subway links)
2. API calls made through `.fetch()` in JS code would trigger the `RecentlyVisited` plug as well

So I added logic to include "Green" line and to exclude api calls.  

TODO/Thoughts: 

- Fix the `/schedules/Green` link once I can find where it's defined....
- Consider a better way of excluding unexpected `/schedules/route` calls.  Whitelist of all routes?  A more comprehensive blacklist?
- Consider a better way of detecting those page visits?  The previous URL match wasn't specific enough sometimes, and too specific other times.  Is there a better way to trigger this code?
- I'm not a fan of cookies, especially now that localStorage et al are a thing.  It would be nice if this used `localStorage` or something instead.  I'm a bit surprised Phoenix doesn't support that out of the box.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Problematic cookie entries on PROD
<img width="247" height="46" alt="Screenshot 2026-08-04 at 4 53 35 PM" src="https://github.com/user-attachments/assets/9872e888-6ab2-420a-9240-2c35c2c58480" />

### Nice clean entries locally
<img width="234" height="46" alt="Screenshot 2026-08-04 at 4 53 47 PM" src="https://github.com/user-attachments/assets/26b6a06c-ffb9-4fb4-b006-f08eda75f5f1" />



## How to test

On prod: Visit three or four lines with "Green" being the first observe the weird behavior.  
On local: Confirm everything works as expected


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
