### PR TITLE
fix: Use `<input type="email" />` for email addresses

### DIFF
--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -120,7 +120,7 @@
       <div class="form-group <%= class_for_error("email", @errors, "has-danger", "has-success") %>">
         <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
         <%= support_error_tag @errors, "email" %>
-        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-input support-form-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}", autocomplete: "email", id: "email" %>
+        <%= email_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-input support-form-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}", autocomplete: "email", id: "email" %>
         <div class="error-indicator hidden">
           <span aria-hidden="true" class="fa fa-exclamation-circle error-icon"></span> Required
         </div>


### PR DESCRIPTION
## Scope

No ticket, but while discussing other tickets related to email address validity in customer support submissions, we realized that the input here was `type="text"`. This fixes that.

## Screenshots

Inspected element.
<img width="638" height="136" alt="Screenshot 2026-08-05 at 12 53 37 PM" src="https://github.com/user-attachments/assets/7804e934-7cc1-45bb-aef2-766ce4cd96ea" />

Side-by-side of phone keyboard's interaction with the input element. Notice that the dev-green one has the `@` and `.com` buttons to make it easier to type in an email address.
<img width="2042" height="1710" alt="Screenshot 2026-08-05 at 1 31 32 PM" src="https://github.com/user-attachments/assets/9ee2a69a-928e-44da-a735-70a8e44f8907" />

## How to test

Go to the [customer support form](http://localhost:4001/customer-support) and inspect-element on the email address input. Observe that it now says `type="email"`.

Navigate to the [customer support form on dev-green](https://dev-green.mbtace.com/customer-support) on mobile. See if your keyboard also treats it like an email input, as opposed to a regular text field.