### PR TITLE
QF | FunctionClauseError: no function clause matching in Services.Repo.handle_response/1

### DIFF
--- a/lib/mbta/api/services.ex
+++ b/lib/mbta/api/services.ex
@@ -5,6 +5,11 @@ defmodule MBTA.Api.Services do
 
   import MBTA.Api, only: [is_valid_potential_id: 1]
 
+  @type api_response_t() :: JsonApi.t() | {:error, any}
+
+  @callback all() :: api_response_t()
+  @callback get(String.t(), List.t()) :: api_response_t()
+
   @mbta_api Application.compile_env!(:dotcom, :mbta_api_module)
 
   def all(params \\ []) do

--- a/lib/mbta/api/services.ex
+++ b/lib/mbta/api/services.ex
@@ -8,7 +8,7 @@ defmodule MBTA.Api.Services do
   @type api_response_t() :: JsonApi.t() | {:error, any}
 
   @callback all() :: api_response_t()
-  @callback get(String.t(), List.t()) :: api_response_t()
+  @callback get(String.t(), [String.t()]) :: api_response_t()
 
   @mbta_api Application.compile_env!(:dotcom, :mbta_api_module)
 

--- a/lib/services/repo.ex
+++ b/lib/services/repo.ex
@@ -49,4 +49,11 @@ defmodule Services.Repo do
 
     []
   end
+
+  # {:error, %Finch.TransportError{reason: :timeout, source: %Mint.TransportError{reason: :timeout}}}
+  defp handle_response({:error, %{reason: reason}}) do
+    Logger.warning("services_repo_handle_response_error=#{reason}")
+
+    []
+  end
 end

--- a/lib/services/repo.ex
+++ b/lib/services/repo.ex
@@ -44,13 +44,6 @@ defmodule Services.Repo do
     []
   end
 
-  defp handle_response({:error, %Req.TransportError{reason: reason}}) do
-    Logger.warning("services_repo_handle_response_error=#{reason}")
-
-    []
-  end
-
-  # {:error, %Finch.TransportError{reason: :timeout, source: %Mint.TransportError{reason: :timeout}}}
   defp handle_response({:error, %{reason: reason}}) do
     Logger.warning("services_repo_handle_response_error=#{reason}")
 

--- a/test/services/repo_test.exs
+++ b/test/services/repo_test.exs
@@ -1,8 +1,10 @@
 defmodule Services.RepoTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   @moduletag :external
-
+  import Mox
   alias Services.{Repo, Service}
+  alias MBTA.Api.Services, as: ServicesApi
 
   test "by_route_id fetches services for a route" do
     assert [%Service{} | _] = Repo.by_route_id("Red")
@@ -14,5 +16,17 @@ defmodule Services.RepoTest do
 
   test "by_route_id fetches services for the green line" do
     assert Repo.by_route_id("Green") == Repo.by_route_id("Green-B,Green-C,Green-D,Green-E")
+  end
+
+  test "by_route_id handles errors by logging them and returning an empty list" do
+    stub(ServicesApi.Mock, :all, fn -> {:error, %{reason: "testing"}} end)
+    stub(MBTA.Api.Mock, :get_json, fn _, _ -> {:error, %{reason: "testing"}} end)
+
+    log =
+      capture_log(fn ->
+        assert [] = Repo.by_route_id("Red")
+      end)
+
+    assert log =~ "services_repo_handle_response_error"
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -16,6 +16,8 @@ Mox.defmock(Dotcom.Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)
 Mox.defmock(Dotcom.Utils.DateTime.Mock, for: Dotcom.Utils.DateTime.Behaviour)
 Mox.defmock(LocationService.Mock, for: LocationService.Behaviour)
 Mox.defmock(MBTA.Api.Mock, for: MBTA.Api.Behaviour)
+Mox.defmock(MBTA.Api.Services.Mock, for: MBTA.Api.Services)
+
 Mox.defmock(OpenTripPlannerClient.Mock, for: OpenTripPlannerClient.Behaviour)
 Mox.defmock(Predictions.Phoenix.PubSub.Mock, for: Phoenix.Channel)
 Mox.defmock(Predictions.PubSub.Mock, for: [GenServer, Predictions.PubSub.Behaviour])


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | FunctionClauseError: no function clause matching in Services.Repo.handle_response/1](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216925348362498?focus=true)

## Implementation

Made one of the error handling versions this functions a bit more generic so that it can handle any type of error with a reason.  Sentry saw `{:error, %Finch.TransportError{reason: :timeout, source: %Mint.TransportError{reason: :timeout}}}` which didn't quite match the existing pattern.  I don't see any reason to be overly specific about what kind error it is, just that is has a reason that we can show.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

Unit tests


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
