### PR TITLE
feat: Enable/Disable the Earlier/Later buttons on scroll/resize

### DIFF
--- a/assets/ts/phoenix-hooks/index.ts
+++ b/assets/ts/phoenix-hooks/index.ts
@@ -3,6 +3,7 @@ import MBTAGoCTABanner from "./mbta-go-cta-banner";
 import PageVisibility from "./page-visibility";
 import ScrollIntoView from "./scroll-into-view";
 import TimetableScroll from "./timetable-scroll";
+import TimetableScrollBar from "./timetable-scroll-bar";
 import TripPlannerForm from "./trip-planner-form";
 import TripPlannerMap from "./trip-planner-map";
 import TripPlannerDatePicker from "../../js/trip-planner/datepicker";
@@ -21,6 +22,7 @@ const Hooks = {
   PageVisibility,
   ScrollIntoView,
   TimetableScroll,
+  TimetableScrollBar,
   TripPlannerDatePicker,
   TripPlannerForm,
   TripPlannerMap

--- a/assets/ts/phoenix-hooks/timetable-scroll-bar.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll-bar.ts
@@ -1,0 +1,79 @@
+import { ViewHook } from "phoenix_live_view";
+
+const TimetableScrollBar: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      const timetable = this.el;
+
+      const earlierButton =
+        (timetable.dataset.earlierButtonId &&
+          document.getElementById(timetable.dataset.earlierButtonId)) ||
+        undefined;
+      const laterButton =
+        (timetable.dataset.laterButtonId &&
+          document.getElementById(timetable.dataset.laterButtonId)) ||
+        undefined;
+
+      if (earlierButton && laterButton) {
+        const scrollButtonStateCallback = () => {
+          setScrollButtonState({ timetable, earlierButton, laterButton });
+        };
+
+        timetable.addEventListener("scroll", _ => {
+          scrollButtonStateCallback();
+        });
+
+        window.addEventListener("resize", _ => {
+          scrollButtonStateCallback();
+        });
+
+        scrollButtonStateCallback();
+      }
+    }
+  }
+};
+
+const setScrollButtonState = ({
+  earlierButton,
+  laterButton,
+  timetable
+}: {
+  earlierButton: HTMLElement;
+  laterButton: HTMLElement;
+  timetable: HTMLElement;
+}) => {
+  const maxScrollLeft = timetable.scrollWidth - timetable.clientWidth;
+
+  // The -1 is due to the fact that some browsers record the
+  // `scrollLeft` position as being 0.5px to the left of where it
+  // theoretically could be, which means that if the maximum
+  // scrollable width is, say 518px, the value of `scrollLeft` when
+  // it's scrolled all the way to the right will be, say, 517.5px. If
+  // we do straight comparison with no offset, then it'll never count
+  // as being scrolled all the way to the right, and we'll never
+  // disable the `Later` button.
+  const scrolledToLatest = timetable.scrollLeft >= maxScrollLeft - 1;
+  const scrolledToEarliest = timetable.scrollLeft === 0;
+
+  if (scrolledToEarliest && scrolledToLatest) {
+    earlierButton.classList.add("hidden");
+    laterButton.classList.add("hidden");
+  } else {
+    earlierButton.classList.remove("hidden");
+    laterButton.classList.remove("hidden");
+
+    if (scrolledToEarliest) {
+      earlierButton.setAttribute("disabled", "");
+    } else {
+      earlierButton.removeAttribute("disabled");
+    }
+
+    if (scrolledToLatest) {
+      laterButton.setAttribute("disabled", "");
+    } else {
+      laterButton.removeAttribute("disabled");
+    }
+  }
+};
+
+export default TimetableScrollBar;

--- a/assets/ts/phoenix-hooks/timetable-scroll-bar.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll-bar.ts
@@ -1,38 +1,5 @@
 import { ViewHook } from "phoenix_live_view";
 
-const TimetableScrollBar: Partial<ViewHook> = {
-  mounted() {
-    if (this.el) {
-      const timetable = this.el;
-
-      const earlierButton =
-        (timetable.dataset.earlierButtonId &&
-          document.getElementById(timetable.dataset.earlierButtonId)) ||
-        undefined;
-      const laterButton =
-        (timetable.dataset.laterButtonId &&
-          document.getElementById(timetable.dataset.laterButtonId)) ||
-        undefined;
-
-      if (earlierButton && laterButton) {
-        const scrollButtonStateCallback = () => {
-          setScrollButtonState({ timetable, earlierButton, laterButton });
-        };
-
-        timetable.addEventListener("scroll", _ => {
-          scrollButtonStateCallback();
-        });
-
-        window.addEventListener("resize", _ => {
-          scrollButtonStateCallback();
-        });
-
-        scrollButtonStateCallback();
-      }
-    }
-  }
-};
-
 const setScrollButtonState = ({
   earlierButton,
   laterButton,
@@ -41,7 +8,7 @@ const setScrollButtonState = ({
   earlierButton: HTMLElement;
   laterButton: HTMLElement;
   timetable: HTMLElement;
-}) => {
+}): void => {
   const maxScrollLeft = timetable.scrollWidth - timetable.clientWidth;
 
   // The -1 is due to the fact that some browsers record the
@@ -72,6 +39,39 @@ const setScrollButtonState = ({
       laterButton.setAttribute("disabled", "");
     } else {
       laterButton.removeAttribute("disabled");
+    }
+  }
+};
+
+const TimetableScrollBar: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      const timetable = this.el;
+
+      const earlierButton =
+        (timetable.dataset.earlierButtonId &&
+          document.getElementById(timetable.dataset.earlierButtonId)) ||
+        undefined;
+      const laterButton =
+        (timetable.dataset.laterButtonId &&
+          document.getElementById(timetable.dataset.laterButtonId)) ||
+        undefined;
+
+      if (earlierButton && laterButton) {
+        const scrollButtonStateCallback = (): void => {
+          setScrollButtonState({ timetable, earlierButton, laterButton });
+        };
+
+        timetable.addEventListener("scroll", _ => {
+          scrollButtonStateCallback();
+        });
+
+        window.addEventListener("resize", _ => {
+          scrollButtonStateCallback();
+        });
+
+        scrollButtonStateCallback();
+      }
     }
   }
 };

--- a/assets/ts/phoenix-hooks/timetable-scroll.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll.ts
@@ -7,13 +7,6 @@ const TimetableScroll: Partial<ViewHook> = {
     if (this.el) {
       const element = this.el;
 
-      // These buttons default to hidden because they rely on
-      // Javascript, which means that if Javascript is disabled, it
-      // doesn't make sense to show them. If Javascript is enabled,
-      // then we remove the `hidden` class so that they can do their
-      // thing.
-      element.classList.remove("hidden");
-
       element.addEventListener("click", _event => {
         const scrollDirection =
           (element.dataset.scrollDirection &&

--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -14,9 +14,17 @@ defmodule DotcomWeb.Components.NewTimetable do
     assigns =
       assigns
       |> assign(:offset, Timetables.first_unfinished_trip_index(assigns.timetable, assigns.now))
+      |> assign(:earlier_button_id, "#{assigns.id}-button-earlier")
+      |> assign(:later_button_id, "#{assigns.id}-button-later")
 
     ~H"""
-    <div class="w-full overflow-x-auto border-xs border-gray-lighter" id={@id}>
+    <div
+      class="w-full overflow-x-auto border-xs border-gray-lighter"
+      id={@id}
+      phx-hook="TimetableScrollBar"
+      data-earlier-button-id={@earlier_button_id}
+      data-later-button-id={@later_button_id}
+    >
       <div class="w-full flex sticky left-0" aria-hidden="true">
         <div class={"bg-gray-bordered-background #{header_column_classes()} shrink-0 border-r-xs border-gray-lighter relative"}>
           <.shadow class="translate-x-[0.0625rem]" />
@@ -24,7 +32,7 @@ defmodule DotcomWeb.Components.NewTimetable do
 
         <div class="grow bg-brand-primary-lightest-contrast p-2 grid grid-cols-[max-content,_auto,max-content]">
           <div class="justify-self-start">
-            <.scroll_button id={"#{@id}-button-earlier"} scroll_direction={-1} timetable_id={@id}>
+            <.scroll_button id={@earlier_button_id} scroll_direction={-1} timetable_id={@id}>
               <.icon class="size-3.5" name="angle-left" />
               <span class="hidden sm:block">
                 {gettext("Earlier %{vehicle_name}", vehicle_name: vehicle_name(@route))}
@@ -33,7 +41,7 @@ defmodule DotcomWeb.Components.NewTimetable do
           </div>
           <div class="justify-self-center self-center font-bold">{vehicle_name(@route)}</div>
           <div class="justify-self-end">
-            <.scroll_button id={"#{@id}-button-later"} scroll_direction={1} timetable_id={@id}>
+            <.scroll_button id={@later_button_id} scroll_direction={1} timetable_id={@id}>
               <span class="hidden sm:block">
                 {gettext("Later %{vehicle_name}", vehicle_name: vehicle_name(@route))}
               </span>
@@ -105,13 +113,13 @@ defmodule DotcomWeb.Components.NewTimetable do
     -->
     <button
       aria-hidden="true"
-      class="border-xs border-brand-primary bg-white px-2 py-1 rounded hidden"
+      class="border-xs border-brand-primary bg-white px-2 py-1 rounded hidden disabled:opacity-50"
       id={@id}
       data-timetable-id={@timetable_id}
       data-scroll-direction={@scroll_direction}
       phx-hook="TimetableScroll"
     >
-      <div class="flex items-center font-bold text-sm text-brand-primary fill-brand-primary border-brand-primary hover:cursor hover:text-brand-primary-darkest hover:fill-brand-primary-darkest hover:border-brand-primary-darkest">
+      <div class="flex items-center font-bold text-sm text-brand-primary fill-brand-primary border-brand-primary enabled:hover:cursor enabled:hover:text-brand-primary-darkest enabled:hover:fill-brand-primary-darkest enabled:hover:border-brand-primary-darkest">
         {render_slot(@inner_block)}
       </div>
     </button>


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⛴️ Disable Earlier/Later Boats buttons at the right scroll positions](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216965272523309?focus=true)

## Implementation

Yet another Phoenix hook.

> [!NOTE]
> This is my first real foray into Phoenix hooks, and I'm not sure that I put them in the right place. We've now got two different hooks attached to different parts of the timetable... maybe that's the way to do it? Maybe not?

## Screenshots

https://github.com/user-attachments/assets/649932dd-31f8-41be-8945-2d90faa31faa

## How to test

[Enable new timetables](http://localhost:4001/_flags), and then visit [any](http://localhost:4001/schedules/Boat-F10/timetable) [timetable](http://localhost:4001/schedules/CR-Greenbush/timetable) [page](http://localhost:4001/schedules/Boat-F6/timetable) and play around with the buttons. Try shrinking the window when scrolled all the way to the right - that nudges some of the trips off the edge of the screen, which re-enables the `Later Trips` button.

Given special attention to [the Lynn ferry page](http://localhost:4001/schedules/Boat-F6/timetable) (which has few enough trips that it doesn't need the buttons at typical desktop browser widths). Try resizing the window so that it's too narrow for its five trips and note that the buttons reappear.

Try other things I didn't think of - have fun!
