### PR TITLE
feat: Add accessibility and parking indicators to new timetable

### DIFF
--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -67,8 +67,38 @@ defmodule DotcomWeb.Components.NewTimetable do
               class="sticky left-0"
               style="background-color: inherit;"
             >
-              <div class={"#{header_column_classes()} px-2 py-1 font-medium #{font_size_classes()} border-r-xs border-gray-lighter"}>
-                <.link navigate={~p"/stops/#{row.stop.id}"}>{row.stop.name}</.link>
+              <div class={"#{header_column_classes()} px-2 py-1 font-medium #{font_size_classes()} border-r-xs border-gray-lighter flex gap-2"}>
+                <.link navigate={~p"/stops/#{row.stop.id}"} class="mr-auto">{row.stop.name}</.link>
+                <div class="flex items-center gap-0.5">
+                  <%= if length(row.stop.parking_lots) > 0 do %>
+                    <.tooltip title={~t(Parking available)} placement={:top}>
+                      <.icon
+                        name="square-parking"
+                        class="size-4 fill-gray-light"
+                        aria-hidden="true"
+                      />
+                    </.tooltip>
+                  <% else %>
+                    <span class="sr-only">{~t(No parking)}</span>
+                  <% end %>
+
+                  <%= if Stops.Stop.accessible?(row.stop) do %>
+                    <.tooltip title={~t(Accessible)} placement={:top}>
+                      <.icon
+                        type="icon-svg"
+                        name="icon-accessible-default"
+                        class="size-4 fill-brand-primary"
+                        aria-hidden="true"
+                      />
+                    </.tooltip>
+                  <% else %>
+                    <%= if Stops.Stop.accessibility_known?(row.stop) do %>
+                      <span class="sr-only">{~t(Not accessible)}</span>
+                    <% else %>
+                      <span class="sr-only">{~t(May not be accessible)}</span>
+                    <% end %>
+                  <% end %>
+                </div>
               </div>
               <.shadow />
             </th>

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -407,6 +407,7 @@ msgstr ""
 msgid "Accessibility at %{name}"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2526,6 +2527,7 @@ msgstr ""
 msgid "Mattapan Trolley"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2752,6 +2754,7 @@ msgstr ""
 msgid "No events"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2800,6 +2803,7 @@ msgstr ""
 msgid "Northbound"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3047,6 +3051,7 @@ msgstr ""
 msgid "Parking at %{name}"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -407,6 +407,7 @@ msgstr ""
 msgid "Accessibility at %{name}"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2526,6 +2527,7 @@ msgstr ""
 msgid "Mattapan Trolley"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2752,6 +2754,7 @@ msgstr ""
 msgid "No events"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2800,6 +2803,7 @@ msgstr ""
 msgid "Northbound"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3047,6 +3051,7 @@ msgstr ""
 msgid "Parking at %{name}"
 msgstr ""
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -407,6 +407,7 @@ msgstr "Recursos de accesibilidad"
 msgid "Accessibility at %{name}"
 msgstr "accesibilidad en %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2535,6 +2536,7 @@ msgstr "Massport enlace %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2764,6 +2766,7 @@ msgstr "No se publicaron cambios durante los próximos 7 días"
 msgid "No events"
 msgstr "Sin eventos"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2812,6 +2815,7 @@ msgstr "servicio normal"
 msgid "Northbound"
 msgstr "Dirección norte"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3060,6 +3064,7 @@ msgstr "Tarifas de parqueadero"
 msgid "Parking at %{name}"
 msgstr "Parqueadero en %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -407,6 +407,7 @@ msgstr "Ressources d’accessibilité"
 msgid "Accessibility at %{name}"
 msgstr "L’accessibilité chez %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2536,6 +2537,7 @@ msgstr "Massport navette %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2765,6 +2767,7 @@ msgstr "Aucun changement n’a été publié pour les 7 jours suivants"
 msgid "No events"
 msgstr "Aucun événement"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2813,6 +2816,7 @@ msgstr "service normal"
 msgid "Northbound"
 msgstr "Direction nord"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3062,6 +3066,7 @@ msgstr "Tarifs de stationnement"
 msgid "Parking at %{name}"
 msgstr "Parking à %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -407,6 +407,7 @@ msgstr "Resous Aksè"
 msgid "Accessibility at %{name}"
 msgstr "aksesiblite nan %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2532,6 +2533,7 @@ msgstr "Massport navèt %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2759,6 +2761,7 @@ msgstr "Pa gen okenn chanjman ki afiche pou 7 jou kap vini yo"
 msgid "No events"
 msgstr "Pa gen evènman"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2807,6 +2810,7 @@ msgstr "sèvis nòmal"
 msgid "Northbound"
 msgstr "Direksyon nò"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3054,6 +3058,7 @@ msgstr "Tarif Pakin"
 msgid "Parking at %{name}"
 msgstr "Pakin nan %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -407,6 +407,7 @@ msgstr "Recursos de acessibilidade"
 msgid "Accessibility at %{name}"
 msgstr "acesso em %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2534,6 +2535,7 @@ msgstr "Circular de transporte massport %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2762,6 +2764,7 @@ msgstr "Nenhuma alteração será publicada nos próximos 7 dias."
 msgid "No events"
 msgstr "Nenhum evento"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2810,6 +2813,7 @@ msgstr "serviço normal"
 msgid "Northbound"
 msgstr "Sentido norte"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3058,6 +3062,7 @@ msgstr "Tarifas de estacionamento"
 msgid "Parking at %{name}"
 msgstr "Estacionamento em %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -401,6 +401,7 @@ msgstr "khả năng tiếp cận Tài nguyên"
 msgid "Accessibility at %{name}"
 msgstr "khả năng tiếp cận at %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2529,6 +2530,7 @@ msgstr "Massport xe đưa đón %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2757,6 +2759,7 @@ msgstr "Không có thay đổi nào được đăng tải trong 7 ngày tới."
 msgid "No events"
 msgstr "Không có sự kiện nào"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2805,6 +2808,7 @@ msgstr "dịch vụ bình thường"
 msgid "Northbound"
 msgstr "Hướng Bắc"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3054,6 +3058,7 @@ msgstr "Giá phí đậu xe"
 msgid "Parking at %{name}"
 msgstr "Đỗ xe tại %{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -401,6 +401,7 @@ msgstr "无障碍资源"
 msgid "Accessibility at %{name}"
 msgstr "无障碍访问%{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2520,6 +2521,7 @@ msgstr "Massport 摆渡巴士%{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2746,6 +2748,7 @@ msgstr "未来7天内无任何变更发布"
 msgid "No events"
 msgstr "无事件"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2794,6 +2797,7 @@ msgstr "正常服务"
 msgid "Northbound"
 msgstr "北行"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3041,6 +3045,7 @@ msgstr "停车收费标准"
 msgid "Parking at %{name}"
 msgstr "停车场位于%{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -401,6 +401,7 @@ msgstr "無障礙資源"
 msgid "Accessibility at %{name}"
 msgstr "無障礙存取%{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -2520,6 +2521,7 @@ msgstr "Massport 擺渡巴士%{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
@@ -2746,6 +2748,7 @@ msgstr "未來7天內無任何變更發布"
 msgid "No events"
 msgstr "無事件"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
@@ -2794,6 +2797,7 @@ msgstr "正常服務"
 msgid "Northbound"
 msgstr "北行"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
 #: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -3041,6 +3045,7 @@ msgstr "停車收費標準"
 msgid "Parking at %{name}"
 msgstr "停車場位於%{name}"
 
+#: lib/dotcom_web/components/new_timetable.ex
 #: lib/dotcom_web/components/timetable.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⛴️ Add parking and accessibility to new timetable stop row headers](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216965272523307?focus=true)

## Implementation

- Literally just copy-pasted the parking and accessibility indicator stuff from [the existing timetable component](https://github.com/mbta/dotcom/blob/47fe6d8058ce90b43e4799237d7307fa9701665b/lib/dotcom_web/components/timetable.ex#L252-L279).

## Screenshots

Direct current-main-versus-new comparison to show how much better the world is with these icons there.
<img width="2142" height="1244" alt="Screenshot 2026-08-07 at 9 28 56 PM" src="https://github.com/user-attachments/assets/9c9de989-94e6-4329-9e28-71c55c6ea432" />

Comparison of the [old timetable component](https://github.com/mbta/dotcom/blob/47fe6d8058ce90b43e4799237d7307fa9701665b/lib/dotcom_web/components/timetable.ex) (with the feature flag disabled) with the results of this PR - to show that we're getting closer and closer to feature parity.
<img width="2140" height="1182" alt="Screenshot 2026-08-07 at 9 29 32 PM" src="https://github.com/user-attachments/assets/ae835c84-1b48-4c5b-8dea-99a84a454499" />

## How to test

Check out the [Winthrop](http://localhost:4001/schedules/Boat-F6/timetable) and [Quincy](http://localhost:4001/schedules/Boat-F7/timetable) timetables (those are good ferry choices because they're the only ones with docks that have parking). [Framingham/Worcester](http://localhost:4001/schedules/CR-Worcester/timetable) is a good commuter rail timetable to look at because it has all four permutations of accessible/inaccessible and parking/no-parking (Newtonville has neither icon, for instance).