### PR TITLE
[Fix]: FunctionClauseError: no function clause matching in Calendar.ISO.parse_date/1

### DIFF
--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -486,6 +486,10 @@ defmodule Util do
     end
   end
 
+  def parse_valid_daate(_) do
+    {:error, :invalid_date}
+  end
+
   @doc """
 
   Parses a string into a valid datetime, or returns an error.

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -476,7 +476,7 @@ defmodule Util do
 
   """
   @spec parse_valid_date(String.t()) :: {:ok, Date.t()} | {:error, any}
-  def parse_valid_date(str) do
+  def parse_valid_date(str) when is_binary(str) do
     with {:ok, date} <- Date.from_iso8601(str) do
       if Timex.is_valid?(date) do
         {:ok, date}

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -486,7 +486,7 @@ defmodule Util do
     end
   end
 
-  def parse_valid_daate(_) do
+  def parse_valid_date(_) do
     {:error, :invalid_date}
   end
 

--- a/test/util/util_test.exs
+++ b/test/util/util_test.exs
@@ -540,4 +540,23 @@ defmodule UtilTest do
       assert DateTime.to_naive(Util.parse(dt)) == ~N[2020-09-01 13:26:08]
     end
   end
+
+  describe "parse_valid_date" do
+    test "parses a valid date string" do
+      original_date = Faker.Date.forward(100)
+
+      {:ok, parsed_date} =
+        original_date |> Date.to_iso8601() |> Util.parse_valid_date()
+
+      assert Date.compare(original_date, parsed_date) == :eq
+    end
+
+    test "returns an error for an invalid datetime string" do
+      assert {:error, :invalid_datetime} == Util.parse_valid_date("2020-02-31")
+    end
+
+    test "returns an error for a argument of the wrong type" do
+      assert {:error, :invalid_datetime} == Util.parse_valid_date(%{foo: "bar"})
+    end
+  end
 end

--- a/test/util/util_test.exs
+++ b/test/util/util_test.exs
@@ -552,11 +552,11 @@ defmodule UtilTest do
     end
 
     test "returns an error for an invalid datetime string" do
-      assert {:error, :invalid_datetime} == Util.parse_valid_date("2020-02-31")
+      assert {:error, :invalid_date} == Util.parse_valid_date("2020-02-31")
     end
 
     test "returns an error for a argument of the wrong type" do
-      assert {:error, :invalid_datetime} == Util.parse_valid_date(%{foo: "bar"})
+      assert {:error, :invalid_date} == Util.parse_valid_date(%{foo: "bar"})
     end
   end
 end


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | FunctionClauseError: no function clause matching in Calendar.ISO.parse_date/1](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216997800645302?focus=true)

## Implementation

Logs were showing that this function was being passed a map (or other invalid arguments), which was not handled, and the app crashed.  I added some extra guards to handle bad arguments.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A?

## How to test

Unit tests

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
