### PR TITLE
[Perf]: Optimize `DotcomWeb.EventView.-_event_teaser.html/1-fun-1-/2`

### DIFF
--- a/lib/dotcom_web/templates/page/_homepage-events.html.heex
+++ b/lib/dotcom_web/templates/page/_homepage-events.html.heex
@@ -11,15 +11,7 @@
         </a>
       </div>
       <ul class="m-homepage__events-container">
-        <%= for event_teaser <- @event_teasers do %>
-          {render(DotcomWeb.EventView, "_event_teaser.html",
-            event_teaser: event_teaser,
-            check_event_ended: true,
-            conn: @conn,
-            month_number: event_teaser.date.month,
-            year: event_teaser.date.year
-          )}
-        <% end %>
+        {render_upcoming_events(@conn, @event_teasers)}
       </ul>
     </div>
   </div>

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -220,7 +220,7 @@ defmodule DotcomWeb.PageView do
               cache: @cache,
               on_error: :raise,
               opts: [ttl: @ttl],
-              key: "homepage|upcoming-events"
+              key: {"homepage|upcoming-events", conn.assigns.locale}
             )
   def render_upcoming_events(conn, event_teasers) do
     event_teasers

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -7,6 +7,10 @@ defmodule DotcomWeb.PageView do
   import DotcomWeb.CMSHelpers
   import DotcomWeb.Components.SystemStatus.SubwayStatus, only: [homepage_subway_status: 1]
 
+  use Nebulex.Caching.Decorators
+  @cache Application.compile_env!(:dotcom, :cache)
+  @ttl :timer.hours(1)
+
   alias CMS.Page.NewsEntry
   alias CMS.Partial.Banner
   alias DotcomWeb.PartialView
@@ -210,5 +214,25 @@ defmodule DotcomWeb.PageView do
 
   defp banner_cta(%Banner{}) do
     ""
+  end
+
+  @decorate cacheable(
+              cache: @cache,
+              on_error: :raise,
+              opts: [ttl: @ttl],
+              key: "homepage|upcoming-events"
+            )
+  def render_upcoming_events(conn, event_teasers) do
+    event_teasers
+    |> Enum.map(fn event_teaser ->
+      render_to_string(DotcomWeb.EventView, "_event_teaser.html",
+        event_teaser: event_teaser,
+        check_event_ended: true,
+        conn: conn,
+        month_number: event_teaser.date.month,
+        year: event_teaser.date.year
+      )
+    end)
+    |> Phoenix.HTML.raw()
   end
 end


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📈 Optimize `DotcomWeb.EventView.-_event_teaser.html/1-fun-1-/2`](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217274403544447?focus=true)

## Implementation

In my investigation there really wasn't anywhere to tighten up the code, most of the processing time was spent formatting dates.  Instead I added an HTML cache for the rendered output with a 1hr TTL.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Main Branch
<img width="1276" height="1650" alt="flame_on (1)" src="https://github.com/user-attachments/assets/b73ca987-bf68-403a-9641-adc80f550e09" />

### This branch
<img width="1276" height="1900" alt="flame_on (2)" src="https://github.com/user-attachments/assets/32458763-c48a-4f52-a7ba-999ef3fccfd0" />

Summary:  Rendering this section went from >28ms to <2ms

No visual changes

## How to test

http://localhost:4001/ - Confirm the upcoming events render correctly

http://localhost:4001/cache/homepage%7Cupcoming-events - Confirm cache entries are made 

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
