### PR TITLE
feat(Util): get or save `:persistent_term`

### DIFF
--- a/lib/dotcom/cache/key_generator.ex
+++ b/lib/dotcom/cache/key_generator.ex
@@ -11,7 +11,10 @@ defmodule Dotcom.Cache.KeyGenerator do
   def generate(mod, fun, args) do
     unique_id = args |> inspect() |> Base.encode64()
 
-    "#{clean_mod(mod)}|#{fun}|#{unique_id}"
+    module_name =
+      Util.get_or_save_persistent_term({:key_generator, mod}, fn -> clean_mod(mod) end)
+
+    "#{module_name}|#{fun}|#{unique_id}"
   end
 
   defp clean_mod(mod) do
@@ -20,6 +23,5 @@ defmodule Dotcom.Cache.KeyGenerator do
     |> String.split(".")
     |> Kernel.tl()
     |> Enum.map_join(".", &Recase.to_snake/1)
-    |> String.downcase()
   end
 end

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -99,10 +99,13 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
 
   @impl Plug
   def call(conn, _opts) do
+    runtime_directives =
+      Util.get_or_save_persistent_term(:csp_directives, fn -> runtime_directives() end)
+
     conn
     |> ContentSecurityPolicy.Plug.Setup.call(default_policy: @default_policy)
     |> ContentSecurityPolicy.Plug.AddNonce.call(directives: [:script_src])
-    |> ContentSecurityPolicy.Plug.AddSourceValue.call(runtime_directives())
+    |> ContentSecurityPolicy.Plug.AddSourceValue.call(runtime_directives)
   end
 
   defp runtime_directives do

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -555,4 +555,31 @@ defmodule Util do
         error
     end
   end
+
+  @doc """
+  Uses Erlang's :persistent_term as a store, which is suitable for storing terms
+  that are frequently accessed but never or infrequently updated. This will
+  store the result of the function call if it doesn't already exist, and return
+  the stored value on subsequent calls.
+
+  Only use this for values which you don't expect will change.
+
+  ## Examples
+      iex> Util.get_or_save_persistent_term(:my_key, fn -> "my_value" end)
+      "my_value"
+      iex> Util.get_or_save_persistent_term(:my_key, fn -> "new_value" end)
+      "my_value"
+  """
+  @spec get_or_save_persistent_term(term(), function()) :: term()
+  def get_or_save_persistent_term(key, func) when is_function(func, 0) do
+    case :persistent_term.get(key, :cache_miss) do
+      :cache_miss ->
+        result = func.()
+        :persistent_term.put(key, result)
+        result
+
+      result ->
+        result
+    end
+  end
 end

--- a/test/util/util_test.exs
+++ b/test/util/util_test.exs
@@ -541,6 +541,50 @@ defmodule UtilTest do
     end
   end
 
+  describe "get_or_save_persistent_term/2" do
+    test "calls the function and returns its result on a cache miss" do
+      key = {__MODULE__, :cache_miss_test}
+
+      assert Util.get_or_save_persistent_term(key, fn -> "initial_value" end) == "initial_value"
+
+      on_exit(fn ->
+        :persistent_term.erase(key)
+      end)
+    end
+
+    test "returns the cached value and does not call the function again on a cache hit" do
+      key = {__MODULE__, :cache_hit_test}
+
+      Util.get_or_save_persistent_term(key, fn -> "first" end)
+      result = Util.get_or_save_persistent_term(key, fn -> "second" end)
+
+      assert result == "first"
+
+      on_exit(fn ->
+        :persistent_term.erase(key)
+      end)
+    end
+
+    test "caches and returns nil without re-executing the function" do
+      key = {__MODULE__, :nil_value_test}
+
+      call_count = :counters.new(1, [])
+
+      func = fn ->
+        :counters.add(call_count, 1, 1)
+        nil
+      end
+
+      assert Util.get_or_save_persistent_term(key, func) == nil
+      assert Util.get_or_save_persistent_term(key, func) == nil
+      assert :counters.get(call_count, 1) == 1
+
+      on_exit(fn ->
+        :persistent_term.erase(key)
+      end)
+    end
+  end
+
   describe "parse_valid_date" do
     test "parses a valid date string" do
       original_date = Faker.Date.forward(100)


### PR DESCRIPTION
## Scope

[Slack thread](https://mbta.slack.com/archives/C06TP48CJ9W/p1786547373071049)

From a linked page from the linked thread:

> Erlang's [persistent_term](https://www.erlang.org/doc/apps/erts/persistent_term.html) is a great option if you want to keep a large state in memory and you modify it rarely or ideally, never. It solves a problem that you'll run into if you use :ets or a [GenServer](https://hexdocs.pm/elixir/GenServer.html) to store a large state in memory: whenever a process fetches your large state, the BEAM will copy the entire state and return it to the calling process. Additionally, the state is copied again and again whenever the process uses it. If your state is large, this will seriously impact your processing speed and memory usage.

> That's where persistent_term comes in. Instead of returning a copy of your state, it returns a reference to it. That way, only one version of the state stays in memory, but processes can still look up data and pass it around without problems.

I think we have an opportunity to use this tool, so long as we're careful to avoid updates or deletes to the things we store in `:persistent_term`.

Everything gets reset on redeploy, so we don't have to worry about unexpected stale states.

## Implementation

- Added a function which either retrieves an item from `:persistent_term`, or computes and returns the result (while storing it for future use).
- Uses it in two places which I noticed while profiling the homepage:
  - Generating our Content Security Policy, which is identical for every response
  - Formatting module names for use in cache keys, which will be consistent for each module name

## Screenshots

No change!

## How to test

Not much to test here.