### PR TITLE
hotfix: Rename CSS classes to remove duplicate `Emergency Contacts`

### DIFF
--- a/assets/css/_footer.scss
+++ b/assets/css/_footer.scss
@@ -221,7 +221,7 @@ address {
     &.emergency-contacts {
       display: block;
       white-space: normal;
-      &.mobile {
+      &.fullscreen {
         border-radius: 0;
         margin-bottom: 2px;
         margin-top: 0;

--- a/lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.heex
@@ -8,7 +8,7 @@
     {~t(711 for TTY callers;  VRS for ASL callers)}
   </div>
 </div>
-<div class="m-menu__feature emergency-contacts mobile">
+<div class="m-menu__feature emergency-contacts fullscreen">
   <h3 class="m-menu__section-heading">{~t(Emergency Contacts)}</h3>
   <small>{~t(24 hours, 7 days a week)}</small>
   <div class="m-menu__feature_phone">

--- a/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
@@ -26,7 +26,7 @@
               <div class="m-menu-dropdown__submenu-section" aria-label={"#{ section_name }"}>
                 {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
                 <%= if section_name == "Transit Police" do %>
-                  <div class="m-menu__feature emergency-contacts desktop">
+                  <div class="m-menu__feature emergency-contacts dropdown">
                     <div class="m-menu__section-heading">{~t(Emergency Contacts)}</div>
                     <small>{~t(24 hours, 7 days a week)}</small>
                     <div class="m-menu__feature_phone">


### PR DESCRIPTION
## Scope

No ticket - noticed after release. The screenshot says it all.

## Implementation

- [This change](https://github.com/mbta/dotcom/pull/3383/changes#diff-c0614b991d1e37e0942d694101aae5ca4e70fc61d54cd3bf535cd9fff4822725R332) from an earlier PR renamed the `mobile` and `desktop` CSS classes to `fullscreen` and `dropdown`.
- This PR updates the element that previously matched those CSS classes to have the `fullscreen` class instead of `mobile`, and thus be hidden at the right breakpoints.

## Screenshots

<img width="2193" height="837" alt="Screenshot 2026-08-12 at 3 13 58 PM" src="https://github.com/user-attachments/assets/9c3a9b29-af18-4fbf-b548-402f5ad3a24a" />

## How to test

With a wide enough "desktop" shaped browser, open the Contacts menu, and observe that the Emergency Contacts component is only there once.