### PR TITLE
[Fix]: FunctionClauseError: no function clause matching in DotcomWeb.ScheduleController.FinderApi.load_from_repos/2

### DIFF
--- a/lib/dotcom_web/controllers/schedule/finder_api.ex
+++ b/lib/dotcom_web/controllers/schedule/finder_api.ex
@@ -78,7 +78,7 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   end
 
   def journeys(conn, _) do
-    DotcomWeb.ControllerHelpers.return_invalid_arguments_error(conn)
+    return_invalid_arguments_error(conn)
   end
 
   # Use alternative JourneyList constructor to only return trips with predictions
@@ -184,7 +184,7 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   end
 
   def trip(conn, _) do
-    ControllerHelpers.return_invalid_arguments_error(conn)
+    return_invalid_arguments_error(conn)
   end
 
   # Use internal API to generate list of relevant schedules and predictions

--- a/lib/dotcom_web/controllers/schedule/finder_api.ex
+++ b/lib/dotcom_web/controllers/schedule/finder_api.ex
@@ -79,7 +79,6 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
 
   def journeys(conn, _) do
     DotcomWeb.ControllerHelpers.return_invalid_arguments_error(conn)
-    # Phoenix.Controller.text(conn, "Invalid parameters")
   end
 
   # Use alternative JourneyList constructor to only return trips with predictions
@@ -101,7 +100,7 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   end
 
   def departures(conn, _) do
-    ControllerHelpers.return_invalid_arguments_error(conn)
+    return_invalid_arguments_error(conn)
   end
 
   @spec get_trip_info(Plug.Conn.t(), Trip.id_t(), Route.t(), String.t(), String.t(), String.t()) ::

--- a/lib/dotcom_web/controllers/schedule/finder_api.ex
+++ b/lib/dotcom_web/controllers/schedule/finder_api.ex
@@ -40,7 +40,16 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
 
   # Leverage the JourneyList module to return a simplified set of trips
   @spec journeys(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def journeys(conn, %{"stop" => stop_id, "date" => date} = params) do
+  def journeys(
+        conn,
+        %{
+          "stop" => stop_id,
+          "date" => date,
+          "is_current" => is_current,
+          "id" => _id,
+          "direction" => _direction
+        } = params
+      ) do
     {:ok, user_selected_date} = Date.from_iso8601(date)
     {schedules, predictions} = load_from_repos(conn, params)
 
@@ -52,7 +61,7 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
     # matching the design spec architecturally better than the existing
     # Schedules-only and Predictions-only configuration for
     # ScheduleFinder.
-    today? = params["is_current"] == "true"
+    today? = is_current == "true"
     current_time = if today?, do: user_selected_date, else: nil
 
     journey_list_opts = [
@@ -66,6 +75,11 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
       |> prepare_journeys_for_json()
 
     json(conn, journeys)
+  end
+
+  def journeys(conn, _) do
+    DotcomWeb.ControllerHelpers.return_invalid_arguments_error(conn)
+    # Phoenix.Controller.text(conn, "Invalid parameters")
   end
 
   # Use alternative JourneyList constructor to only return trips with predictions


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | FunctionClauseError: no function clause matching in DotcomWeb.ScheduleController.FinderApi.load_from_repos/2](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216994482750470?focus=true)

## Implementation

Digging around the Sentry logs it appears that when/if invalid or incomplete URL params are supplied to `schedules/finder_api/journeys` the app crashes.  

Added checks to ensure code only runs when supplied with proper parameters.  Added an error message to handle invalid params instead of crashing.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

### Invalid arguments:
http://localhost:4001/schedules/finder_api/journeys?date=2026-08-13&stop=place-sstat&is_current=true&id=1

### Valid arguments (empty result)
http://localhost:4001/schedules/finder_api/journeys?date=2026-08-13&stop=place-sstat&is_current=true&id=1&direction=1

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
