### PR TITLE
[Fix]: Add websocket connect_src lines to CSP for older IOS devices

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -108,8 +108,11 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
   defp runtime_directives do
     drupal_url = Util.config(:dotcom, :cms_api)[:base_url]
     endpoint_config = Util.config(:dotcom, DotcomWeb.Endpoint)
+    websocket_url = "#{Keyword.get(endpoint_config, :static_url, [])[:host]}"
 
     [
+      {:connect_src, "ws://#{websocket_url}"},
+      {:connect_src, "wss://#{websocket_url}"},
       {:img_src, drupal_url}
     ]
     |> static_host(Keyword.get(endpoint_config, :static_url))


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [[🐞 Line diagram + departures page are down for iOS 15 users](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217464268376067?focus=true)](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217464268376067?focus=true)

## Implementation

Restored ws:// and wss:// lines to the CSP.  The original solution used the :host of the :url config field, which is only defined for prod. This solution uses the :host of the :static_url config field which is the same value by default and defined for all environments.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

## How to test

I was able to see the new CSP entries in the response headers.  A proper Apple device test would be nice though.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
