### PR TITLE
feat: Have Foxboro Event Service timetables default to Outbound

### DIFF
--- a/lib/dotcom_web/controllers/schedule/defaults.ex
+++ b/lib/dotcom_web/controllers/schedule/defaults.ex
@@ -39,6 +39,11 @@ defmodule DotcomWeb.Schedule.Defaults do
   def default_direction_id(%{assigns: %{route: %{direction_names: %{0 => nil}}}}), do: 1
   def default_direction_id(%{assigns: %{route: %{direction_names: %{1 => nil}}}}), do: 0
 
+  # Always default the Foxboro line to outbound, because the most
+  # common use case here is people looking for trains *to* Foxboro,
+  # which are typically outbound
+  def default_direction_id(%{assigns: %{route: %{id: "CR-Foxboro"}}}), do: 0
+
   def default_direction_id(%Conn{assigns: %{route: %Route{id: route_id}}} = conn) do
     direction_id = default_direction_id_for_hour(conn.assigns.date_time.hour)
 


### PR DESCRIPTION
## Scope

No ticket - I just got confused when I looked at the Foxboro Event Service timetable for August 17, which does have service, and it showed no service... well, we pretty much don't schedule return service, which is typically inbound, so it's more useful to show the service that we do have scheduled, which is outbound.

## Screenshots

## How to test

Look at the [Foxboro Event Service timetable for August 17](http://localhost:4001/schedules/CR-Foxboro/timetable?date=2026-08-17). It'll show the scheduled trips even if you look before the default direction changes to Outbound at 2PM.

If you're looking after 2PM, you can pretend that it's before 2PM by hacking [the definition of "now"](https://github.com/mbta/dotcom/blob/0b3213bfee4b8d816406d5764f65168275c1a99d/lib/dotcom/utils/date_time.ex#L30) to be whatever time you want.

```elixir
def now(), do: ~N[2026-08-14T12:00:00] |> Timex.to_datetime("America/New_York")
```