### PR TITLE
tests: Widen potential range for `Generators.Date.random_date/0`

### DIFF
--- a/test/support/generators/date.ex
+++ b/test/support/generators/date.ex
@@ -5,14 +5,14 @@ defmodule Test.Support.Generators.Date do
 
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
-  @doc "Generate a random date this decade"
+  @doc "Generate a random date in a 20-year span"
   def random_date() do
     now = @date_time_module.now()
 
-    beginning_of_year = Date.new!(now.year, 1, 1)
-    end_of_year = Date.new!(now.year + 1, 1, 1)
+    beginning_of_range = Date.new!(now.year - 10, 1, 1)
+    end_of_range = Date.new!(now.year + 10, 1, 1)
 
-    date_generator_between({beginning_of_year, end_of_year}) |> Enum.take(1) |> List.first()
+    date_generator_between({beginning_of_range, end_of_range}) |> Enum.take(1) |> List.first()
   end
 
   def date_generator_between({start, stop}) do


### PR DESCRIPTION
## Scope

No ticket, but I noticed that `Test.Support.Generators.Date.random_date/0` doesn't exactly do what it claims to do - it picks a random date in the year in which it's run, which is both different from what its `@doc` says ("this decade"), and more limited than is ideal. This updates `random_date/0` to return a random date in a 20-year span instead.