### PR TITLE
feat: Add proper screen reader readout to new timetables

### DIFF
--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -9,6 +9,8 @@ defmodule DotcomWeb.Components.NewTimetable do
 
   attr :id, :string, required: true
   attr :timetable, Timetables.Timetable, required: true
+  attr :direction_name, :string, required: true
+  attr :route, Routes.Route, required: true
 
   def timetable(assigns) do
     assigns =
@@ -50,7 +52,7 @@ defmodule DotcomWeb.Components.NewTimetable do
           </div>
         </div>
       </div>
-      <table>
+      <table aria-label={"#{@direction_name} #{~t(timetable for)} #{@route.name}, #{@formatted_date}"}>
         <thead :if={!ferry?(@route)} class="h-10">
           <tr>
             <th class="bg-gray-bordered-background sticky left-0 relative">

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -61,9 +61,11 @@
       </.cta>
       <DotcomWeb.Components.NewTimetable.timetable
         id="new-timetable"
+        direction_name={@direction_name}
+        formatted_date={@formatted_date}
         now={@date_time}
-        timetable={@timetable}
         route={@route}
+        timetable={@timetable}
       />
     <% assigns[:linear_timetable?] -> %>
       <DotcomWeb.Components.Timetable.linear_timetable


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⛴️ Ensure that new timetable has the same screen reader readout as the old one](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216965272523308?focus=true)

## Screenshots

**Old Timetable:**
<img width="2058" height="1156" alt="Screenshot 2026-08-17 at 3 00 41 PM" src="https://github.com/user-attachments/assets/d6c9ffeb-37bc-4a67-87fc-70ca7ad40ae2" />

**New Timetable:**
<img width="2056" height="1060" alt="Screenshot 2026-08-17 at 3 00 59 PM" src="https://github.com/user-attachments/assets/b1bd134b-77d0-4404-8174-7854580a1eaa" />

(*Fun fact: This timetable does in fact have 10 columns and 5 rows, not 11 and 6. The screen reader was seeing empty columns that are there for layout purposes, and are always empty, or just have the word "Trip".*)

## How to test

Visit [a timetable page](http://localhost:4001/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1#direction-filter) with a screen reader on, and listen to the readout for the timetable.