### PR TITLE
feat: save rendered static markup for faster retrieval

### DIFF
--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -71,6 +71,8 @@ defmodule Dotcom.Application do
 
     :ok = Logster.attach_phoenix_logger()
 
+    _ = Dotcom.Cache.PersistentTermWarmer.warm_homepage()
+
     opts = [strategy: :one_for_one, name: Dotcom.Supervisor]
 
     Supervisor.start_link(children, opts)

--- a/lib/dotcom/cache/persistent_term_warmer.ex
+++ b/lib/dotcom/cache/persistent_term_warmer.ex
@@ -1,0 +1,15 @@
+defmodule Dotcom.Cache.PersistentTermWarmer do
+  @moduledoc """
+  Functions to trigger at application startup to warm caches that are stored in
+  :persistent_term.
+
+  By starting these processes at application startup, we can ensure that the
+  caches are warmed before any user-facing requests are handled. This is
+  important for performance and to avoid cache misses on the first request.
+  """
+
+  def warm_homepage do
+    # Locale-independent — called once
+    DotcomWeb.LayoutView.hidden_icons()
+  end
+end

--- a/lib/dotcom/cache/persistent_term_warmer.ex
+++ b/lib/dotcom/cache/persistent_term_warmer.ex
@@ -11,5 +11,18 @@ defmodule Dotcom.Cache.PersistentTermWarmer do
   def warm_homepage do
     # Locale-independent — called once
     DotcomWeb.LayoutView.hidden_icons()
+
+    # Per-locale — called once per locale (8 locales)
+    # Handled inside a Task because the locale is set per-process,
+    # thus does not change locale for user-facing requests.
+    for %{code: code} <- Dotcom.Locales.locales() do
+      Task.async(fn ->
+        Dotcom.Locales.set_locale(code)
+
+        # All of these should use the locale code in its cache key.
+        DotcomWeb.LayoutView.top_tier_nav(code)
+      end)
+    end
+    |> Task.await_many()
   end
 end

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -1,5 +1,5 @@
 <%= if Laboratory.enabled?(@conn, :use_smartling_translations) do %>
-  {render("_top_tier_nav.html", assigns)}
+  {top_tier_nav(@locale)}
 <% end %>
 <aside class="c-modal__cover m-menu--cover" aria-hidden="true" data-nav="veil"></aside>
 <header class="header--new" id="header-with-search">

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html lang={Map.get(assigns, :locale, "en")}>
+<html lang={@locale}>
   <head>
+    <% is_prod = Application.get_env(:dotcom, :is_prod_env?) %>
+    <% dev_server = Application.get_env(:dotcom, :dev_server?) %>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +17,7 @@
       href={static_url(@conn, "/apple-touch-icon.png")}
       type="image/png"
     />
-    <%= if Application.get_env(:dotcom, :is_prod_env?) do %>
+    <%= if is_prod do %>
       <link
         rel="icon"
         href={static_url(@conn, "/images/mbta-logo-t-favicon.png")}
@@ -47,7 +49,7 @@
       href="/news/rss.xml"
     />
 
-    <%= if Application.get_env(:dotcom, :dev_server?) do %>
+    <%= if dev_server do %>
       <link rel="stylesheet" href={"#{webpack_path()}/css/core.css"} />
       <link rel="stylesheet" href={"#{webpack_path()}/css/app.css"} />
       <script defer src={"#{webpack_path()}/core.js"}>
@@ -63,9 +65,9 @@
       </script>
     <% end %>
   </head>
-  <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
+  <body class={Dotcom.BodyTag.class_name(@conn)}>
     <div class="body-wrapper" id="body-wrapper">
-      <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
+      <%= if !is_prod do %>
         <% language =
           Dotcom.Gettext |> Gettext.get_locale() |> Dotcom.Locales.locale() |> Map.get(:endonym) %>
         <div class={["w-full py-2 text-center leading-sm", banner_color_classes()]}>
@@ -103,18 +105,21 @@
         </div>
       <% end %>
       <div class={"page-container #{get_page_classes(Phoenix.Controller.view_module(@conn), Phoenix.Controller.view_template(@conn))}"}>
-        {content_tag(:main, @inner_content, id: "main", tabindex: -1)}
+        <main id="main" tabindex="-1">{@inner_content}</main>
       </div>
       {render(__MODULE__, "_footer.html", conn: @conn)}
     </div>
     <!-- prod only: This react script is inexplicably needed to get the app.js code to execute. -->
     <script defer {static_attributes("/js/react.js")}>
     </script>
-    <%= if google_tag_manager_id() do %>
+    <% gtm_id = google_tag_manager_id() %>
+    <%= if gtm_id do %>
+      <% gtm_auth = google_tag_manager_auth() %>
+      <% gtm_preview = google_tag_manager_preview() %>
       <!-- Google Tag Manager (noscript) -->
       <noscript>
         <iframe
-          src={"https://www.googletagmanager.com/ns.html?id=#{google_tag_manager_id()}&gtm_auth=#{google_tag_manager_auth()}&gtm_preview=#{google_tag_manager_preview()}&gtm_cookies_win=x"}
+          src={"https://www.googletagmanager.com/ns.html?id=#{gtm_id}&gtm_auth=#{gtm_auth}&gtm_preview=#{gtm_preview}&gtm_cookies_win=x"}
           height="0"
           width="0"
           style="display:none;visibility:hidden"
@@ -128,9 +133,9 @@
         data-gtm-variable={@conn.assigns[:csp_nonce]}
         id="gtm-script"
       >
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ "&gtm_auth=<%= google_tag_manager_auth() %>&gtm_preview=<%= google_tag_manager_preview() %>&gtm_cookies_win=x";var n=d.querySelector('[nonce]'); n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','<%= google_tag_manager_id() %>');
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ "&gtm_auth={gtm_auth}&gtm_preview={gtm_preview}&gtm_cookies_win=x";var n=d.querySelector('[nonce]'); n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{gtm_id}');
       </script>
       <!-- End Google Tag Manager -->
     <% end %>
-  <% end %>
+  </body>
 </html>

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -88,7 +88,7 @@
         </div>
       <% end %>
       <a href="#main" class="sr-only sr-only-focusable">{~t(Skip to main content)}</a>
-      {DotcomWeb.PartialView.render("_hidden_icons.html", conn: @conn)}
+      {hidden_icons()}
       {render("_new_header.html", conn: @conn)}
       <%= if assigns[:banner_template] do %>
         <div class={"announcement-container #{assigns[:banner_class]}"}>

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -89,7 +89,7 @@
       <% end %>
       <a href="#main" class="sr-only sr-only-focusable">{~t(Skip to main content)}</a>
       {hidden_icons()}
-      {render("_new_header.html", conn: @conn)}
+      {render("_new_header.html", assigns)}
       <%= if assigns[:banner_template] do %>
         <div class={"announcement-container #{assigns[:banner_class]}"}>
           <div class="container">

--- a/lib/dotcom_web/templates/partial/_hidden_icons.html.heex
+++ b/lib/dotcom_web/templates/partial/_hidden_icons.html.heex
@@ -1,46 +1,28 @@
 <div class="hidden-js hidden-no-js" style="display: none" aria-hidden="true">
-  {for light_rail <- ["Green", "Green-B", "Green-C", "Green-D", "Green-E", "Mattapan"] do
-    route = %Routes.Route{id: light_rail, type: 0}
-
-    content_tag(:div, [line_icon(route, :small)],
-      id: [
-        "icon-feature-",
-        route
-        |> Routes.Route.icon_atom()
-        |> Atom.to_string()
-      ]
-    )
-  end}
-  {for heavy_rail <- ["Red", "Blue", "Orange"] do
-    route = %Routes.Route{id: heavy_rail, type: 1}
-
-    content_tag(:div, [line_icon(route, :small)],
-      id: [
-        "icon-feature-",
-        route
-        |> Routes.Route.icon_atom()
-        |> Atom.to_string()
-      ]
-    )
-  end}
-  {for mode <- [:subway, :commuter_rail, :bus, :ferry, :silver_line] do
-    content_tag(:div, [mode_icon(mode, :small)], id: ["icon-feature-", Atom.to_string(mode)])
-  end}
-  {for route_type <- [0, 1, 2, 3, 4] do
-    content_tag(:div, [bw_circle_icon(route_type, :small)],
-      id: ["icon-feature-bw-", route_to_string(route_type)]
-    )
-  end}
-  {for feature <- [:stop, :station] do
-    content_tag(
-      :div,
-      [
-        svg_icon_with_circle(%SvgIconWithCircle{icon: feature, size: :small})
-      ],
-      id: ["icon-feature-", Atom.to_string(feature)]
-    )
-  end}
-
+  <%= for id <- ["Green", "Green-B", "Green-C", "Green-D", "Green-E", "Mattapan"] do %>
+    <% route = %Routes.Route{id: id, type: 0} %>
+    <div id={"icon-feature-#{Routes.Route.icon_atom(route)}"}>
+      {line_icon(route, :small)}
+    </div>
+  <% end %>
+  <%= for id <- ["Red", "Blue", "Orange"] do %>
+    <% route = %Routes.Route{id: id, type: 1} %>
+    <div id={"icon-feature-#{Routes.Route.icon_atom(route)}"}>
+      {line_icon(route, :small)}
+    </div>
+  <% end %>
+  <div
+    :for={mode <- [:subway, :commuter_rail, :bus, :ferry, :silver_line]}
+    id={"icon-feature-#{mode}"}
+  >
+    {mode_icon(mode, :small)}
+  </div>
+  <div :for={route_type <- [0, 1, 2, 3, 4]} id={"icon-feature-bw-#{route_to_string(route_type)}"}>
+    {bw_circle_icon(route_type, :small)}
+  </div>
+  <div :for={feature <- [:stop, :station]} id={"icon-feature-#{feature}"}>
+    {svg_icon_with_circle(%SvgIconWithCircle{icon: feature, size: :small})}
+  </div>
   <div id="icon-feature-alert">
     {svg_icon(%SvgIcon{icon: :alert, class: "icon-small-inline"})}
   </div>

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -244,7 +244,7 @@ defmodule DotcomWeb.LayoutView do
     [
       %{
         menu_section: ~t(Languages),
-        link: ~p"/menu#Languages-section",
+        link: "/menu#Languages-section",
         sub_menus: [
           %{
             sub_menu_section: ~t(Choose Your Language),
@@ -325,6 +325,12 @@ defmodule DotcomWeb.LayoutView do
   def hidden_icons do
     Util.get_or_save_persistent_term({__MODULE__, :hidden_icons}, fn ->
       {:safe, Phoenix.View.render_to_iodata(DotcomWeb.PartialView, "_hidden_icons.html", %{})}
+    end)
+  end
+
+  def top_tier_nav(locale_code) do
+    Util.get_or_save_persistent_term({__MODULE__, :top_tier_nav, locale_code}, fn ->
+      {:safe, Phoenix.View.render_to_iodata(__MODULE__, "_top_tier_nav.html", %{})}
     end)
   end
 end

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -318,4 +318,13 @@ defmodule DotcomWeb.LayoutView do
   def webpack_path do
     Application.get_env(:dotcom, :webpack_path)
   end
+
+  @doc """
+  Returns the cached hidden SVG icon sprite.
+  """
+  def hidden_icons do
+    Util.get_or_save_persistent_term({__MODULE__, :hidden_icons}, fn ->
+      {:safe, Phoenix.View.render_to_iodata(DotcomWeb.PartialView, "_hidden_icons.html", %{})}
+    end)
+  end
 end

--- a/test/dotcom/cache/persistent_term_warmer_test.exs
+++ b/test/dotcom/cache/persistent_term_warmer_test.exs
@@ -3,14 +3,52 @@ defmodule Dotcom.Cache.PersistentTermWarmerTest do
   use ExUnit.Case, async: false
 
   alias Dotcom.Cache.PersistentTermWarmer
+  alias Dotcom.Locales
 
   @hidden_icons_key {DotcomWeb.LayoutView, :hidden_icons}
+  @per_locale_keys Enum.map(Locales.locales(), fn %{code: code} ->
+                     {DotcomWeb.LayoutView, :top_tier_nav, code}
+                   end)
+  @all_keys [@hidden_icons_key | @per_locale_keys]
+
+  setup do
+    Enum.each(@all_keys, &:persistent_term.erase/1)
+    on_exit(fn -> Enum.each(@all_keys, &:persistent_term.erase/1) end)
+  end
 
   describe "warm_homepage/0" do
     test "populates the hidden_icons key" do
       assert :persistent_term.get(@hidden_icons_key, :missing) == :missing
       PersistentTermWarmer.warm_homepage()
       assert :persistent_term.get(@hidden_icons_key, :missing) != :missing
+    end
+
+    test "populates top_tier_nav for every locale" do
+      for key <- @per_locale_keys do
+        assert :persistent_term.get(key, :missing) == :missing
+      end
+
+      PersistentTermWarmer.warm_homepage()
+
+      for key <- @per_locale_keys do
+        assert :persistent_term.get(key, :missing) != :missing,
+               "Expected #{inspect(key)} to be populated after warm_homepage/0"
+      end
+    end
+
+    test "each locale's top_tier_nav is rendered with the correct locale" do
+      PersistentTermWarmer.warm_homepage()
+
+      results =
+        for %{code: code} <- Locales.locales() do
+          {code, :persistent_term.get({DotcomWeb.LayoutView, :top_tier_nav, code})}
+        end
+
+      # All locales must have been stored as {:safe, _} iodata
+      for {code, value} <- results do
+        assert match?({:safe, _}, value),
+               "Expected {:safe, _} for locale #{code}, got: #{inspect(value)}"
+      end
     end
   end
 end

--- a/test/dotcom/cache/persistent_term_warmer_test.exs
+++ b/test/dotcom/cache/persistent_term_warmer_test.exs
@@ -1,0 +1,16 @@
+defmodule Dotcom.Cache.PersistentTermWarmerTest do
+  # async: false because :persistent_term is global mutable state
+  use ExUnit.Case, async: false
+
+  alias Dotcom.Cache.PersistentTermWarmer
+
+  @hidden_icons_key {DotcomWeb.LayoutView, :hidden_icons}
+
+  describe "warm_homepage/0" do
+    test "populates the hidden_icons key" do
+      assert :persistent_term.get(@hidden_icons_key, :missing) == :missing
+      PersistentTermWarmer.warm_homepage()
+      assert :persistent_term.get(@hidden_icons_key, :missing) != :missing
+    end
+  end
+end


### PR DESCRIPTION
## Scope

**Asana Ticket:** a prerequisite to [📈 Optimize nav-bar rendering](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217274403544453?focus=true)

I have two goals

1. Easier, simpler rendering - I want rendering to be less work on our server. So to support that, I'm writing markup directly instead of invoking functions, where it makes sense.
2. Moving some of the rendered markup into `:persistent_term`, as described in 
- #3414 

## Implementation

I intend to follow up with similar PRs for the header navigation, footer, and parts of the homepage. But this PR only impacts the root template.

I tackled two pieces, which will never, ever* change from between individual requests:

### The hidden icons
Background: We currently render a bunch of icons and use JS to copy them and render them with search results in the navigation, here: 
<img width="324" height="288" alt="image" src="https://github.com/user-attachments/assets/967f9aa0-c3ab-4c40-b974-03a97337e304" />

### Top-tier nav
<img width="1317" height="69" alt="image" src="https://github.com/user-attachments/assets/a0512273-45b2-4dcb-b694-9abee9d43c7c" />

Now, the language menu actually does change slightly, depending which language is selected. 
<img width="383" height="268" alt="image" src="https://github.com/user-attachments/assets/33eb2fbe-171b-4d4f-82dd-d33e37eaa35c" />

So unlike the prior case, we must save a version rendered for each supported language. And the locale has to be part of the persistent term key, so we can retrieve the correct markup for the selected language.

Saving per-language can work by doing this in an isolated task:

```elixir
Task.async(fn ->
  Dotcom.Locales.set_locale("fr") # only sets the language for this fleeting process

  # trigger rendering and saving the translated markup
end)
```

Finally, this is invoked on application startup, so every actual request should retrieve the already-saved markup.

## Screenshots

No changes!

## How to test

The [before](https://github.com/user-attachments/assets/412b6a09-fdfe-455b-8bc7-8d80f8cdb8cb) and [after](https://github.com/user-attachments/assets/7e0440fd-d0f5-4c0c-ab2b-67258d85f41b) flamegraphs are kind of dramatic because the root.html rendering seems to get represented different in the "after" version - almost like it's more broken up into smaller pieces. Overall removing a bunch of HTML escaping work seems to save us ~9ms. The hidden icons template goes from 8.6ms to.. I can't even find it anymore. 
