### PR TITLE
cleanup: Remove unused `ControllerHelpers` alias

### DIFF
--- a/lib/dotcom_web/controllers/schedule/finder_api.ex
+++ b/lib/dotcom_web/controllers/schedule/finder_api.ex
@@ -13,7 +13,6 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   import DotcomWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
   alias Dotcom.TransitNearMe
-  alias DotcomWeb.ControllerHelpers
   alias DotcomWeb.ScheduleController.TripInfo, as: Trips
   alias DotcomWeb.Schedule.VehicleLocations
   alias Fares.{Format, OneWay}


### PR DESCRIPTION
This fixes 👇 warning

```elixir
    warning: unused alias ControllerHelpers
    │
 16 │   alias DotcomWeb.ControllerHelpers
    │   ~
    │
    └─ lib/dotcom_web/controllers/schedule/finder_api.ex:16:3
```

No ticket.