### PR TITLE
feat(load-testing): Add phases to the load testing script

### DIFF
--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -22,16 +22,6 @@ config:
     - name: "1k req / sec"
       duration: 120
       arrivalRate: 1000
-    - name: "Rest"
-      pause: 60
-    - name: "2k req / sec"
-      duration: 120
-      arrivalRate: 2000
-    - name: "Rest"
-      pause: 60
-    - name: "10k req / sec"
-      duration: 120
-      arrivalRate: 10000
   environments:
     dev-green:
       target: "https://dev-green.mbtace.com"

--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -22,6 +22,11 @@ config:
     - name: "1k req / sec"
       duration: 120
       arrivalRate: 1000
+    - name: "Rest"
+      pause: 60
+    - name: "2k req / sec"
+      duration: 120
+      arrivalRate: 2000
   environments:
     dev-green:
       target: "https://dev-green.mbtace.com"

--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -4,9 +4,34 @@ config:
     timeout: 300
     maxSockets: 500
   phases:
-    - name: "Sustained high-load test"
-      duration: 300
+    - name: "100 req / sec"
+      duration: 120
       arrivalRate: 100
+    - name: "Rest"
+      pause: 60
+    - name: "200 req / sec"
+      duration: 120
+      arrivalRate: 200
+    - name: "Rest"
+      pause: 60
+    - name: "500 req / sec"
+      duration: 120
+      arrivalRate: 500
+    - name: "Rest"
+      pause: 60
+    - name: "1k req / sec"
+      duration: 120
+      arrivalRate: 1000
+    - name: "Rest"
+      pause: 60
+    - name: "2k req / sec"
+      duration: 120
+      arrivalRate: 2000
+    - name: "Rest"
+      pause: 60
+    - name: "10k req / sec"
+      duration: 120
+      arrivalRate: 10000
   environments:
     dev-green:
       target: "https://dev-green.mbtace.com"
@@ -15,8 +40,5 @@ config:
 scenarios:
   - name: "Stress test single page"
     flow:
-      - loop:
-          - get:
-              url: "/"
-          - think: 1
-        count: 100
+      - get:
+          url: "/"


### PR DESCRIPTION
## Summary

This adds phases to the load testing script, so that we can measure our code's performance against 100, 200, 500, 1k, 2k, 5k, and 10k requests per second. 

## Scope

**Asana Ticket:** [📈 Set up the GHA Artillery script to increase load in stages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217421262176610?focus=true)

## Screenshots

<img width="1700" height="1204" alt="Screenshot 2026-08-18 at 4 49 07 PM" src="https://github.com/user-attachments/assets/97518ac5-fc4a-4348-bfdc-12936c30aac8" />

## How to test

Once this is merged, we can re-run the [load test Github Action](https://github.com/mbta/dotcom/actions/workflows/load-test.yml) and see how much load dev-green and dev-blue can handle. 

For extra fun, we could deploy an old release to one of those environments and see it perform worse (hopefully).