### PR TITLE
feat: Have new timetable rows highlight on hover

### DIFF
--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -78,7 +78,10 @@ defmodule DotcomWeb.Components.NewTimetable do
         </thead>
 
         <tbody>
-          <tr :for={row <- @timetable.rows} class="even:bg-gray-bordered-background odd:bg-white">
+          <tr
+            :for={row <- @timetable.rows}
+            class="even:bg-gray-bordered-background odd:bg-white hover:bg-brand-primary-lightest"
+          >
             <th
               class="sticky left-0"
               style="background-color: inherit;"


### PR DESCRIPTION
## Scope

No ticket. I just noticed that this was missing.

## Screenshots

<img width="990" height="482" alt="Screenshot 2026-08-18 at 7 05 32 PM" src="https://github.com/user-attachments/assets/860420b8-c743-4f41-8941-db6f663b5c9f" />

## How to test

Hover on a row on a [timetable](http://localhost:4001/schedules/Boat-F10/timetable) with the [new timetables flag enabled](http://localhost:4001/_flags), and observe that it hovers the same as the old timetables!
