### PR TITLE
fix: Alignment bug in new timetable

### DIFF
--- a/assets/ts/phoenix-hooks/timetable-scroll.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll.ts
@@ -2,6 +2,14 @@ import { ViewHook } from "phoenix_live_view";
 
 let animating = false;
 
+const min = (a: number, b: number) => {
+  if (a < b) {
+    return a;
+  } else {
+    return b;
+  }
+};
+
 const TimetableScroll: Partial<ViewHook> = {
   mounted() {
     if (this.el) {
@@ -30,8 +38,12 @@ const TimetableScroll: Partial<ViewHook> = {
           if (timetable) {
             const startingScroll = timetable.scrollLeft();
 
+            const maxScrollLeft =
+              timetable[0].scrollWidth - timetable[0].clientWidth - 1;
+            const scrollDestination = startingScroll + 100 * scrollDirection;
+
             timetable.animate(
-              { scrollLeft: startingScroll + 100 * scrollDirection },
+              { scrollLeft: min(scrollDestination, maxScrollLeft) },
               {
                 duration: 200,
                 step: () => {

--- a/assets/ts/phoenix-hooks/timetable-scroll.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll.ts
@@ -2,12 +2,12 @@ import { ViewHook } from "phoenix_live_view";
 
 let animating = false;
 
-const min = (a: number, b: number) => {
+const min = (a: number, b: number): number => {
   if (a < b) {
     return a;
-  } else {
-    return b;
   }
+
+  return b;
 };
 
 const TimetableScroll: Partial<ViewHook> = {

--- a/assets/ts/phoenix-hooks/timetable-scroll.ts
+++ b/assets/ts/phoenix-hooks/timetable-scroll.ts
@@ -2,14 +2,6 @@ import { ViewHook } from "phoenix_live_view";
 
 let animating = false;
 
-const min = (a: number, b: number): number => {
-  if (a < b) {
-    return a;
-  }
-
-  return b;
-};
-
 const TimetableScroll: Partial<ViewHook> = {
   mounted() {
     if (this.el) {
@@ -43,7 +35,7 @@ const TimetableScroll: Partial<ViewHook> = {
             const scrollDestination = startingScroll + 100 * scrollDirection;
 
             timetable.animate(
-              { scrollLeft: min(scrollDestination, maxScrollLeft) },
+              { scrollLeft: Math.min(scrollDestination, maxScrollLeft) },
               {
                 duration: 200,
                 step: () => {


### PR DESCRIPTION
## Scope

No ticket, but I just noticed that at certain browser widths (at a guess... even number of pixels? 1000px for instance), if you drag the new timetable scroll bar almost but not quite to the "Latest trips" end of the screen and then click `Later <Vehicles>`, it goes one pixel too far, and nudges the header with the `Earlier`/`Later` buttons out of alignment.

## Implementation

- Prevent the buttons from nudging the scroll bar any further than the actual max scroll. 

## Screenshots

<img width="458" height="270" alt="Screenshot 2026-08-18 at 6 52 28 PM" src="https://github.com/user-attachments/assets/959b1b27-394a-45f1-a44a-601b9939c975" />

## How to test

Navigate to [the Harbor Loop Ferry Timetable page](http://localhost:4001/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1#direction-filter) with a browser width of 1000px - on `main`, you should see the top bar get nudged a little - on this branch, you should see it stay put.

Try other routes and other browser widths!