### PR TITLE
feat: New bespoke Harbor Loop Ferry timetable layout

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -163,6 +163,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
     conn
     |> assign(:dual_direction_timetable?, true)
+    |> assign(:direction_id, nil)
     |> assign(:linear_timetable?, false)
     |> assign(:morning_timetable, morning_timetable)
     |> assign(:evening_timetable, evening_timetable)

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -132,6 +132,45 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     )
   end
 
+  # Boat-F10 dual-direction timetable
+  # This clause must come before the general new_timetables? clause
+  def assign_trip_schedules(
+        %{
+          assigns: %{
+            route: route,
+            blocking_alert: nil,
+            date_in_rating?: true,
+            date: date
+          }
+        } = conn
+      )
+      when route.id == "Boat-F10" do
+    # Fetch schedules for both directions
+    morning_schedules =
+      case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: 0) do
+        {:error, _} -> []
+        schedules -> Enum.reject(schedules, &Schedules.Schedule.no_times?/1)
+      end
+
+    evening_schedules =
+      case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: 1) do
+        {:error, _} -> []
+        schedules -> Enum.reject(schedules, &Schedules.Schedule.no_times?/1)
+      end
+
+    morning_timetable = Timetables.from_schedules(morning_schedules)
+    evening_timetable = Timetables.from_schedules(evening_schedules)
+
+    conn
+    |> assign(:dual_direction_timetable?, true)
+    |> assign(:linear_timetable?, false)
+    |> assign(:morning_timetable, morning_timetable)
+    |> assign(:evening_timetable, evening_timetable)
+    |> assign(:morning_trip_count, Enum.count(morning_timetable.trips))
+    |> assign(:evening_trip_count, Enum.count(evening_timetable.trips))
+    |> assign(:trip_count, Enum.count(morning_timetable.trips) + Enum.count(evening_timetable.trips))
+  end
+
   def assign_trip_schedules(
         %{
           assigns: %{
@@ -144,8 +183,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       )
       when route.id in [
              "Boat-F6",
-             "Boat-F7",
-             "Boat-F10"
+             "Boat-F7"
            ] or new_timetables? == true do
     timetable =
       conn

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -409,7 +409,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   # Helper function to return the timetable for the route and date
   # specified in the conn, and the direction specified in the second
   # argument.
-  @spec timetable_for_direction(Plug.Conn.t(), 0 | 1) :: [Schedules.Schedule.t()]
+  @spec timetable_for_direction(Plug.Conn.t(), 0 | 1) :: Dotcom.Timetables.Timetable.t()
   defp timetable_for_direction(conn, direction_id) do
     conn
     |> assign(:direction_id, direction_id)

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -132,8 +132,8 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     )
   end
 
-  # Boat-F10 dual-direction timetable
-  # This clause must come before the general new_timetables? clause
+  # We need a special case for Boat-F10, because that route has a
+  # special timetable layout.
   def assign_trip_schedules(
         %{
           assigns: %{
@@ -145,7 +145,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         } = conn
       )
       when route.id == "Boat-F10" do
-    # Fetch schedules for both directions
     morning_schedules =
       case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: 0) do
         {:error, _} -> []

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -169,7 +169,10 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> assign(:evening_timetable, evening_timetable)
     |> assign(:morning_trip_count, Enum.count(morning_timetable.trips))
     |> assign(:evening_trip_count, Enum.count(evening_timetable.trips))
-    |> assign(:trip_count, Enum.count(morning_timetable.trips) + Enum.count(evening_timetable.trips))
+    |> assign(
+      :trip_count,
+      Enum.count(morning_timetable.trips) + Enum.count(evening_timetable.trips)
+    )
   end
 
   def assign_trip_schedules(

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -139,26 +139,13 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           assigns: %{
             route: route,
             blocking_alert: nil,
-            date_in_rating?: true,
-            date: date
+            date_in_rating?: true
           }
         } = conn
       )
       when route.id == "Boat-F10" do
-    morning_schedules =
-      case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: 0) do
-        {:error, _} -> []
-        schedules -> Enum.reject(schedules, &Schedules.Schedule.no_times?/1)
-      end
-
-    evening_schedules =
-      case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: 1) do
-        {:error, _} -> []
-        schedules -> Enum.reject(schedules, &Schedules.Schedule.no_times?/1)
-      end
-
-    morning_timetable = Timetables.from_schedules(morning_schedules)
-    evening_timetable = Timetables.from_schedules(evening_schedules)
+    [morning_timetable, evening_timetable] =
+      [0, 1] |> Enum.map(&timetable_for_direction(conn, &1))
 
     conn
     |> assign(:dual_direction_timetable?, true)
@@ -417,6 +404,17 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     # if the scheduled stop doesn't match a canonical stop, there has been a track change
     length(canonical_stop_ids) > 0 &&
       schedule.platform_stop_id not in canonical_stop_ids
+  end
+
+  # Helper function to return the timetable for the route and date
+  # specified in the conn, and the direction specified in the second
+  # argument.
+  @spec timetable_for_direction(Plug.Conn.t(), 0 | 1) :: [Schedules.Schedule.t()]
+  defp timetable_for_direction(conn, direction_id) do
+    conn
+    |> assign(:direction_id, direction_id)
+    |> timetable_schedules()
+    |> Timetables.from_schedules()
   end
 
   # Helper function for obtaining schedule data

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -69,7 +69,12 @@
             timetable={@morning_timetable}
           />
         <% else %>
-          <p class="text-gray-500">{~t"No trips scheduled for this direction."}</p>
+          {render("_empty.html",
+            date: @date,
+            direction: Routes.Route.direction_name(@route, 0),
+            conn: @conn,
+            error: assigns[:schedule_error]
+          )}
         <% end %>
       </div>
       <div>
@@ -85,7 +90,12 @@
             timetable={@evening_timetable}
           />
         <% else %>
-          <p class="text-gray-500">{~t"No trips scheduled for this direction."}</p>
+          {render("_empty.html",
+            date: @date,
+            direction: Routes.Route.direction_name(@route, 1),
+            conn: @conn,
+            error: assigns[:schedule_error]
+          )}
         <% end %>
       </div>
     <% @new_timetables? -> %>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -58,7 +58,7 @@
     <% assigns[:dual_direction_timetable?] -> %>
       <div class="mb-5">
         <div class="container">
-          <h2 class="mb-1">{~t"Morning"}</h2>
+          <h2 class="my-1">{~t"Morning"}</h2>
           <p class="mb-3">{~t"Counterclockwise Loop"}</p>
         </div>
         <%= if @morning_trip_count > 0 do %>
@@ -81,7 +81,7 @@
       </div>
       <div>
         <div class="container">
-          <h2 class="mb-1">{~t"Evening"}</h2>
+          <h2 class="my-1">{~t"Evening"}</h2>
           <p class="mb-3">{~t"Clockwise Loop"}</p>
         </div>
         <%= if @evening_trip_count > 0 do %>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -57,8 +57,10 @@
       )}
     <% assigns[:dual_direction_timetable?] -> %>
       <div class="mb-5">
-        <h3 class="text-xl font-bold mb-1">{~t"Morning"}</h3>
-        <p class="mb-3">{~t"Counterclockwise Loop"}</p>
+        <div class="container">
+          <h3 class="text-xl font-bold mb-1">{~t"Morning"}</h3>
+          <p class="mb-3">{~t"Counterclockwise Loop"}</p>
+        </div>
         <%= if @morning_trip_count > 0 do %>
           <DotcomWeb.Components.NewTimetable.timetable
             id="morning-timetable"
@@ -78,8 +80,10 @@
         <% end %>
       </div>
       <div>
-        <h3 class="text-xl font-bold mb-1">{~t"Evening"}</h3>
-        <p class="mb-3">{~t"Clockwise Loop"}</p>
+        <div class="container">
+          <h3 class="text-xl font-bold mb-1">{~t"Evening"}</h3>
+          <p class="mb-3">{~t"Clockwise Loop"}</p>
+        </div>
         <%= if @evening_trip_count > 0 do %>
           <DotcomWeb.Components.NewTimetable.timetable
             id="evening-timetable"

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -51,7 +51,7 @@
     <% @trip_count == 0 -> %>
       {render("_empty.html",
         date: @date,
-        direction: Routes.Route.direction_name(@route, @direction_id),
+        direction: @direction_id && Routes.Route.direction_name(@route, @direction_id),
         conn: @conn,
         error: assigns[:schedule_error]
       )}

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -55,6 +55,39 @@
         conn: @conn,
         error: assigns[:schedule_error]
       )}
+    <% assigns[:dual_direction_timetable?] -> %>
+      <div class="mb-5">
+        <h3 class="text-xl font-bold mb-1">{~t"Morning"}</h3>
+        <p class="mb-3">{~t"Counterclockwise Loop"}</p>
+        <%= if @morning_trip_count > 0 do %>
+          <DotcomWeb.Components.NewTimetable.timetable
+            id="morning-timetable"
+            direction_name="Morning"
+            formatted_date={@formatted_date}
+            now={@date_time}
+            route={@route}
+            timetable={@morning_timetable}
+          />
+        <% else %>
+          <p class="text-gray-500">{~t"No trips scheduled for this direction."}</p>
+        <% end %>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold mb-1">{~t"Evening"}</h3>
+        <p class="mb-3">{~t"Clockwise Loop"}</p>
+        <%= if @evening_trip_count > 0 do %>
+          <DotcomWeb.Components.NewTimetable.timetable
+            id="evening-timetable"
+            direction_name="Evening"
+            formatted_date={@formatted_date}
+            now={@date_time}
+            route={@route}
+            timetable={@evening_timetable}
+          />
+        <% else %>
+          <p class="text-gray-500">{~t"No trips scheduled for this direction."}</p>
+        <% end %>
+      </div>
     <% @new_timetables? -> %>
       <.cta icon="flask" icon_type="solid" classes="text-sm">
         This is the new timetable, and we're still ironing out the kinks. If you'd like to go back to the original timetable, you can disable the "New timetables" flag <a href="/_flags">here</a>.

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -58,7 +58,7 @@
     <% assigns[:dual_direction_timetable?] -> %>
       <div class="mb-5">
         <div class="container">
-          <h3 class="text-xl font-bold mb-1">{~t"Morning"}</h3>
+          <h2 class="mb-1">{~t"Morning"}</h2>
           <p class="mb-3">{~t"Counterclockwise Loop"}</p>
         </div>
         <%= if @morning_trip_count > 0 do %>
@@ -81,7 +81,7 @@
       </div>
       <div>
         <div class="container">
-          <h3 class="text-xl font-bold mb-1">{~t"Evening"}</h3>
+          <h2 class="mb-1">{~t"Evening"}</h2>
           <p class="mb-3">{~t"Clockwise Loop"}</p>
         </div>
         <%= if @evening_trip_count > 0 do %>

--- a/lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
+++ b/lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
@@ -15,13 +15,15 @@
       </div>
     <% end %>
   </div>
-  {render("_direction_select.html",
-    conn: @conn,
-    direction_id: @direction_id,
-    route: @route,
-    show_date_select?: @show_date_select?,
-    column_width: 8
-  )}
+  <%= unless @route.id == "Boat-F10" do %>
+    {render("_direction_select.html",
+      conn: @conn,
+      direction_id: @direction_id,
+      route: @route,
+      show_date_select?: @show_date_select?,
+      column_width: 8
+    )}
+  <% end %>
 </div>
 <%= if @conn.assigns[:calendar] do %>
   <% date_picker = render("_date_picker.html", conn: @conn, calendar: @calendar) %>

--- a/lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
+++ b/lib/dotcom_web/templates/schedule/_trip_view_filters.html.heex
@@ -15,7 +15,7 @@
       </div>
     <% end %>
   </div>
-  <%= unless @route.id == "Boat-F10" do %>
+  <%= unless assigns[:dual_direction_timetable?] do %>
     {render("_direction_select.html",
       conn: @conn,
       direction_id: @direction_id,

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -428,52 +428,6 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
-  def timetable_note(%{route: %Route{id: "Boat-F10"}, timetable_schedules: []}), do: nil
-
-  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 0, date: date}) do
-    content_tag :div, class: "m-timetable__note" do
-      [
-        content_tag(:p, [
-          content_tag(:strong, ~t"Note:"),
-          gettext(
-            " Service continues later in the day in the opposite direction. %{link}",
-            %{
-              link:
-                link(~t"View evening timetable",
-                  to:
-                    "/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1&date=#{date}#direction-filter"
-                )
-                |> safe_to_string()
-            }
-          )
-          |> raw()
-        ])
-      ]
-    end
-  end
-
-  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 1, date: date}) do
-    content_tag :div, class: "m-timetable__note" do
-      [
-        content_tag(:p, [
-          content_tag(:strong, ~t"Note:"),
-          gettext(
-            " Service is available earlier in the day in the opposite direction. %{link}",
-            %{
-              link:
-                link(~t"View morning timetable",
-                  to:
-                    "/schedules/Boat-F10/timetable?schedule_direction[direction_id]=0&date=#{date}#direction-filter"
-                )
-                |> safe_to_string()
-            }
-          )
-          |> raw()
-        ])
-      ]
-    end
-  end
-
   def timetable_note(_), do: nil
 
   def json_safe_route(route) do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -38,16 +38,6 @@ msgstr ""
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr ""
 
@@ -4678,11 +4668,6 @@ msgstr ""
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr ""
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4692,11 +4677,6 @@ msgstr ""
 #: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
@@ -5395,4 +5375,24 @@ msgstr ""
 #: lib/dotcom_web/components/new_timetable.ex
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr ""
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr ""
 
@@ -4678,11 +4668,6 @@ msgstr ""
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr ""
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr ""
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4692,11 +4677,6 @@ msgstr ""
 #: lib/dotcom_web/components/stops/parking_amenity.html.heex
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
-msgstr ""
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
 msgstr ""
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
@@ -5395,4 +5375,24 @@ msgstr ""
 #: lib/dotcom_web/components/new_timetable.ex
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5403,19 +5403,19 @@ msgstr "%{direction_name} calendario para %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "Bucle en sentido horario"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "Bucle en sentido antihorario"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "Noche"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "Buenos días"

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " Rutas"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " El servicio continúa más tarde en dirección contraria. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " El servicio está disponible más temprano en la dirección contraria. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Los trenes salen de Foxboro 30 minutos luego de la conclusión de los eventos"
 
@@ -4697,11 +4687,6 @@ msgid "View common fare information for the MBTA bus, subway, Commuter Rail, fer
 msgstr "Consulta información de tarifas comunes para el colectivo MBTA, Subterráneo, Tren de cercanías, ferryy The RIDE. Encuentra servicios de CharlieCard online"
 " e infórmate sobre los programas de pedidos al por mayor."
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "Consulta el horario nocturno"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4712,11 +4697,6 @@ msgstr "Ver resumen de tarifas"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Ver más información sobre pagos"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "Ver horario matutino"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5419,3 +5399,23 @@ msgstr "Trenes"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendario para %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " Itinéraires"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " Le service se poursuit plus tard dans la journée dans la direction opposée. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " Le service est disponible plus tôt dans la journée dans la direction opposée. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Les trains partent de Foxboro 30 minutes après la fin des événements"
 
@@ -4698,11 +4688,6 @@ msgid "View common fare information for the MBTA bus, subway, Commuter Rail, fer
 msgstr "Consultez les informations tarifaires courantes pour le MBTA bus, le métro, le Train de banlieue, ferryet The RIDE. Trouvez en ligne les services CharlieCard"
 " et découvrez les programmes de commande en gros."
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "Voir l’horaire du soir"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4713,11 +4698,6 @@ msgstr "Voir l’aperçu des tarifs"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Voir plus d’informations sur les paiements"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "Voir l’horaire du matin"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5419,3 +5399,23 @@ msgstr "Trains"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendrier pour %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5403,19 +5403,19 @@ msgstr "%{direction_name} calendrier pour %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "Boucle dans le sens horaire"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "Boucle dans le sens antihoraire"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "Soirée"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "Bonjour"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5390,19 +5390,19 @@ msgstr "Orè %{direction_name} pou %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "Bouk nan sans zegwi mont lan"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "Boukl kontrè zegwi mont lan"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "Aswè"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "Maten"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " Wout yo"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " Sèvis la ap kontinye pita nan jounen an nan direksyon opoze a. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " Sèvis la disponib pi bonè nan jounen an nan direksyon opoze a. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Tren yo ap pati Foxboro 30 minit apre evènman yo fini."
 
@@ -4687,11 +4677,6 @@ msgid "View common fare information for the MBTA bus, subway, Commuter Rail, fer
 msgstr "Gade enfòmasyon sou pri tikè komen pou MBTA bis, subway, Tren banlye, bato, ak The RIDE. Jwenn sèvis CharlieCard sou entènèt epi aprann sou pwogram kòmand"
 " an gwo."
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "Gade orè aswè a"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4702,11 +4687,6 @@ msgstr "Gade apèsi sou pri tikè yo"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Gade plis enfòmasyon sou peman"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "Gade orè maten an"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5406,3 +5386,23 @@ msgstr "Tren yo"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Orè %{direction_name} pou %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5399,19 +5399,19 @@ msgstr "Horário %{direction_name} para %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "Laço no sentido horário"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "Laço anti-horário"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "Noite"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "Manhã"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " Rotas"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " O serviço continua mais tarde, no sentido oposto. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " O serviço está disponível mais cedo no sentido oposto. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Os trens partem de Foxboro 30 minutos após o término dos eventos."
 
@@ -4694,11 +4684,6 @@ msgid "View common fare information for the MBTA bus, subway, Commuter Rail, fer
 msgstr "Veja informações sobre tarifas comuns do ônibus MBTA, metrô, trem suburbano, balsa e The RIDE. Encontre serviços online do CharlieCard e saiba mais sobre"
 " programas de pedidos em grande quantidade."
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "Veja o horário da noite."
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4709,11 +4694,6 @@ msgstr "Veja a visão geral das tarifas"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Veja mais informações sobre pagamento"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "Veja o horário da manhã"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5415,3 +5395,23 @@ msgstr "Trens"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Horário %{direction_name} para %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5394,19 +5394,19 @@ msgstr "%{direction_name} thời khóa biểu cho %{route_name}, %{formatted_dat
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "Vòng lặp theo chiều kim đồng hồ"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "Vòng lặp ngược chiều kim đồng hồ"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "Buổi tối"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "Buổi sáng"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " Tuyến đường"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " Dịch vụ sẽ tiếp tục hoạt động vào cuối ngày theo hướng ngược lại. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " Dịch vụ có sẵn vào đầu ngày theo hướng ngược lại. %{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " Tàu khởi hành từ Foxboro 30 phút sau khi kết thúc sự kiện"
 
@@ -4689,11 +4679,6 @@ msgid "View common fare information for the MBTA bus, subway, Commuter Rail, fer
 msgstr "Xem thông tin giá vé phổ biến cho MBTA xe buýt, tàu điện ngầm, Đường sắt ngoại ô, phà và The RIDE. Tìm hiểu các dịch vụ CharlieCard trực tuyến và các chương"
 " trình đặt hàng số lượng lớn."
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "Xem lịch trình buổi tối"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4704,11 +4689,6 @@ msgstr "Xem tổng quan về giá vé"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "Xem thêm thông tin thanh toán"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "Xem lịch trình buổi sáng"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5410,3 +5390,23 @@ msgstr "Tàu hỏa"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} thời khóa biểu cho %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " 路线"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " 当天晚些时候，该服务将继续以相反的方向运行。%{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " 当天早些时候，反方向的服务也已开通。%{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " 活动结束后30分钟，列车将从Foxboro出发。"
 
@@ -4672,11 +4662,6 @@ msgstr "查看可用的自动扶梯。"
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "查看 MBTA 巴士、地铁、通勤铁路、渡轮和The RIDE的常见票价信息。 在线查找 CharlieCard 服务并了解批量订购计划。"
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "查看晚间时刻表"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4687,11 +4672,6 @@ msgstr "查看票价概览"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "查看更多付款信息"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "查看早晨时刻表"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5390,3 +5370,23 @@ msgstr "火车"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的时间表"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5374,19 +5374,19 @@ msgstr "%{direction_name} %{route_name}、%{formatted_date} 的时间表"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "顺时针循环"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "逆时针环"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "晚上"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "早晨"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5374,19 +5374,19 @@ msgstr "%{direction_name} %{route_name}、%{formatted_date} 的時間表"
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Clockwise Loop"
-msgstr ""
+msgstr "順時針循環"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Counterclockwise Loop"
-msgstr ""
+msgstr "逆時針環"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Evening"
-msgstr ""
+msgstr "晚上"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
-msgstr ""
+msgstr "早晨"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -38,16 +38,6 @@ msgstr " 路線"
 
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
-msgid " Service continues later in the day in the opposite direction. %{link}"
-msgstr " 當天晚些時候，該服務將繼續以相反的方向運行。%{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid " Service is available earlier in the day in the opposite direction. %{link}"
-msgstr " 當天早些時候，反方向的服務也已開通。%{link}"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
 msgid " Trains depart from Foxboro 30 minutes after conclusion of events"
 msgstr " 活動結束後30分鐘，列車將從Foxboro出發。"
 
@@ -4672,11 +4662,6 @@ msgstr "查看可用的自動扶梯。"
 msgid "View common fare information for the MBTA bus, subway, Commuter Rail, ferry, and The RIDE. Find online CharlieCard services and learn about bulk ordering programs."
 msgstr "查看 MBTA 巴士、地鐵、通勤鐵路、渡輪和The RIDE的常見票價資訊。 在線查找 CharlieCard 服務並了解大量訂購計劃。"
 
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View evening timetable"
-msgstr "查看晚間時刻表"
-
 #: lib/dotcom_web/templates/mode/index.html.heex
 #: lib/dotcom_web/views/fare_view.ex
 #, elixir-autogen, elixir-format
@@ -4687,11 +4672,6 @@ msgstr "查看票價概覽"
 #, elixir-autogen, elixir-format
 msgid "View more payment information"
 msgstr "查看更多付款信息"
-
-#: lib/dotcom_web/views/schedule_view.ex
-#, elixir-autogen, elixir-format
-msgid "View morning timetable"
-msgstr "查看早晨時刻表"
 
 #: lib/dotcom_web/templates/fare/_nearby_locations.html.heex
 #, elixir-autogen, elixir-format
@@ -5390,3 +5370,23 @@ msgstr "火車"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的時間表"
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Clockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Counterclockwise Loop"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Evening"
+msgstr ""
+
+#: lib/dotcom_web/templates/schedule/_timetable.html.heex
+#, elixir-autogen, elixir-format
+msgid "Morning"
+msgstr ""

--- a/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
@@ -400,4 +400,79 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
       assert conn.assigns.blocking_alert == nil
     end
   end
+
+  describe "assign_trip_schedules/1 for Boat-F10" do
+    setup do
+      boat_route = %Route{id: "Boat-F10", type: 4}
+      date = ~D[2025-01-01]
+
+      conn =
+        default_conn()
+        |> assign(:route, boat_route)
+        |> assign(:direction_id, 0)
+        |> assign(:date, date)
+        |> assign(:date_in_rating?, true)
+        |> assign(:blocking_alert, nil)
+
+      # Mock API to return empty schedules for simplicity
+      stub(MBTA.Api.Mock, :get_json, fn "/schedules/", _opts ->
+        %JsonApi{links: %{}, data: []}
+      end)
+
+      {:ok, %{conn: conn, date: date}}
+    end
+
+    test "sets dual_direction_timetable flag", %{conn: conn} do
+      conn = assign_trip_schedules(conn)
+
+      assert conn.assigns.dual_direction_timetable? == true
+      assert conn.assigns.linear_timetable? == false
+    end
+
+    test "creates both morning and evening timetables", %{conn: conn} do
+      conn = assign_trip_schedules(conn)
+
+      assert Map.has_key?(conn.assigns, :morning_timetable)
+      assert Map.has_key?(conn.assigns, :evening_timetable)
+      assert is_struct(conn.assigns.morning_timetable, Dotcom.Timetables.Timetable)
+      assert is_struct(conn.assigns.evening_timetable, Dotcom.Timetables.Timetable)
+    end
+
+    test "assigns trip counts for both directions", %{conn: conn} do
+      conn = assign_trip_schedules(conn)
+
+      assert Map.has_key?(conn.assigns, :morning_trip_count)
+      assert Map.has_key?(conn.assigns, :evening_trip_count)
+      assert Map.has_key?(conn.assigns, :trip_count)
+      assert conn.assigns.trip_count == conn.assigns.morning_trip_count + conn.assigns.evening_trip_count
+    end
+  end
+
+  describe "assign_trip_schedules/1 for other ferry routes" do
+    test "Boat-F6 and Boat-F7 still use single-direction timetable" do
+      stub(MBTA.Api.Mock, :get_json, fn "/schedules/", _opts ->
+        %JsonApi{links: %{}, data: []}
+      end)
+
+      for route_id <- ["Boat-F6", "Boat-F7"] do
+        boat_route = %Route{id: route_id, type: 4}
+
+        conn =
+          default_conn()
+          |> assign(:route, boat_route)
+          |> assign(:direction_id, 0)
+          |> assign(:date, ~D[2025-01-01])
+          |> assign(:date_in_rating?, true)
+          |> assign(:blocking_alert, nil)
+          |> assign(:new_timetables?, false)
+
+        conn = assign_trip_schedules(conn)
+
+        refute Map.has_key?(conn.assigns, :dual_direction_timetable?)
+        assert conn.assigns.linear_timetable? == false
+        assert Map.has_key?(conn.assigns, :timetable)
+        assert is_struct(conn.assigns.timetable, Dotcom.Timetables.Timetable)
+      end
+    end
+  end
 end

--- a/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
@@ -1,12 +1,16 @@
 defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
   @moduledoc false
+
   use DotcomWeb.ConnCase
+
   import DotcomWeb.ScheduleController.TimetableController
   import Mox
+
   alias Dotcom.TimetableBlocking
   alias Routes.Route
-  alias Stops.Stop
   alias Schedules.{Schedule, Trip}
+  alias Stops.Stop
+  alias Test.Support.Generators
 
   @stops [
     %Stop{id: "1"},
@@ -404,7 +408,7 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
   describe "assign_trip_schedules/1 for Boat-F10" do
     setup do
       boat_route = %Route{id: "Boat-F10", type: 4}
-      date = ~D[2025-01-01]
+      date = Generators.Date.random_date()
 
       conn =
         default_conn()
@@ -414,7 +418,6 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
         |> assign(:date_in_rating?, true)
         |> assign(:blocking_alert, nil)
 
-      # Mock API to return empty schedules for simplicity
       stub(MBTA.Api.Mock, :get_json, fn "/schedules/", _opts ->
         %JsonApi{links: %{}, data: []}
       end)
@@ -437,19 +440,12 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
       assert is_struct(conn.assigns.morning_timetable, Dotcom.Timetables.Timetable)
       assert is_struct(conn.assigns.evening_timetable, Dotcom.Timetables.Timetable)
     end
-
-    test "assigns trip counts for both directions", %{conn: conn} do
-      conn = assign_trip_schedules(conn)
-
-      assert Map.has_key?(conn.assigns, :morning_trip_count)
-      assert Map.has_key?(conn.assigns, :evening_trip_count)
-      assert Map.has_key?(conn.assigns, :trip_count)
-      assert conn.assigns.trip_count == conn.assigns.morning_trip_count + conn.assigns.evening_trip_count
-    end
   end
 
-  describe "assign_trip_schedules/1 for other ferry routes" do
+  describe "assign_trip_schedules/1 for other loop ferry routes" do
     test "Boat-F6 and Boat-F7 still use single-direction timetable" do
+      date = Generators.Date.random_date()
+
       stub(MBTA.Api.Mock, :get_json, fn "/schedules/", _opts ->
         %JsonApi{links: %{}, data: []}
       end)
@@ -461,16 +457,16 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
           default_conn()
           |> assign(:route, boat_route)
           |> assign(:direction_id, 0)
-          |> assign(:date, ~D[2025-01-01])
+          |> assign(:date, date)
           |> assign(:date_in_rating?, true)
           |> assign(:blocking_alert, nil)
           |> assign(:new_timetables?, false)
-
-        conn = assign_trip_schedules(conn)
+          |> assign_trip_schedules()
 
         refute Map.has_key?(conn.assigns, :dual_direction_timetable?)
+        refute Map.has_key?(conn.assigns, :morning_timetable)
+        refute Map.has_key?(conn.assigns, :evening_timetable)
         assert conn.assigns.linear_timetable? == false
-        assert Map.has_key?(conn.assigns, :timetable)
         assert is_struct(conn.assigns.timetable, Dotcom.Timetables.Timetable)
       end
     end


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⛴️ Render F10 schedule using the new bespoke F10 layout](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215284488469002?focus=true)

> [!IMPORTANT]
> This feature is _not_ behind a feature flag, so if this PR is merged, then on the next deploy, this will go live to riders. I think that's okay, but since most of the other timetable work I've done has been behind the `new_timetables?` feature flag, I wanted to make sure that this PR's non-flagged nature was clear.

## Implementation

> [!NOTE]
> I used 🤖 Copilot to generate the first commit of this PR. I've inspected the code and tests, and my tweaks and changes are the remaining commits.

- Defines a couple of special assigns so that the Harbor Loop special case can load both timetables onto the page.
- It uses the `NewTimetable.timetable/1` component rather than `Timetable.timetable/1` because the buttons on `Timetable.timetable/1` can only work if there's a single timetable on the page (this is the entire reason that `NewTimetable` exists).

## Screenshots

<img width="937" height="921" alt="Screenshot 2026-08-18 at 7 24 47 PM" src="https://github.com/user-attachments/assets/2d2298bf-f3d3-4571-87ad-c26c3fc0f151" />

<img width="1025" height="581" alt="Screenshot 2026-08-18 at 7 33 36 PM" src="https://github.com/user-attachments/assets/131525fa-3f49-4c52-a194-60b7085657d2" />

## How to test

Visit [the Harbor Loop Ferry timetable page](http://localhost:4001/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1#direction-filter).

Try it out for different dates and browser widths.

A thing that I tried, just to validate a corner case that I admit would surprise me, was to change `evening_schedules` or `morning_schedules` to `[]` in the `Boat-F10` `assign_trip_schedules/1` clause. This is the result (Copilot's initial implementation was much less nice):

<img width="1688" height="1406" alt="Screenshot 2026-08-27 at 8 43 43 AM" src="https://github.com/user-attachments/assets/18de9ce4-7971-4718-b5fa-466f6abe9b2d" />

(I did this before the refactor in [this commit](https://github.com/mbta/dotcom/pull/3432/commits/02ea127a3f15626d78bd87a18309faf5d9c9499f), which removes the explicit `morning/evening_schedules` variables.)

Try out whatever else you think of!