### PR TITLE
[Symphony]:  Symphony logic final (final) version

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -179,13 +179,11 @@ defmodule Alerts.Alert do
   end
 
   def stale?(%__MODULE__{} = alert) do
-    now = Dotcom.Utils.DateTime.now()
-    five_weeks_ago = DateTime.shift(now, week: -5)
+    affected_stops = alert.informed_entity.stop
+    symphony? = affected_stops |> Enum.any?(fn stop -> stop == "place-symcl" end)
+    closed? = alert.effect == :station_closure or alert.effect == :stop_closure
 
-    case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
-      {:current, datetime} -> datetime |> DateTime.before?(five_weeks_ago)
-      _ -> false
-    end
+    symphony? and closed?
   end
 
   @spec build_struct(Keyword.t()) :: t()

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -44,6 +44,8 @@ defmodule Alerts.Alert do
 
   @lifecycles [:new, :ongoing, :ongoing_upcoming, :unknown, :upcoming]
 
+  @symphony_stop_id "place-symcl"
+
   defstruct id: "",
             active_period: [],
             banner: "",
@@ -179,8 +181,8 @@ defmodule Alerts.Alert do
   end
 
   def stale?(%__MODULE__{} = alert) do
-    affected_stops = alert.informed_entity.stop
-    symphony? = affected_stops |> Enum.any?(fn stop -> stop == "place-symcl" end)
+    affected_stop_ids = alert.informed_entity.stop
+    symphony? = affected_stop_ids |> Enum.member?(@symphony_stop_id)
     closed? = alert.effect == :station_closure or alert.effect == :stop_closure
 
     symphony? and closed?

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -26,58 +26,24 @@ defmodule AlertsTest do
   end
 
   describe "check_freshness/1" do
-    test "Marks alerts with no end older than 5 weeks as stale" do
-      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
-      alert = new(effect: :delay, active_period: [{stale_start_date, nil}])
-
-      assert Alerts.Alert.stale?(alert),
-             "Alert with no end was expected to be stale, but was not"
-    end
-
-    test "Marks alerts with an end older than 5 weeks as stale" do
-      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
-      stale_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
-      alert = new(effect: :delay, active_period: [{stale_start_date, stale_end_date}])
-
-      assert Alerts.Alert.stale?(alert),
-             "Alert with an end was expected to be stale, but was not #{stale_start_date}"
-    end
-
-    test "Handles alerts with multiple active periods correctly" do
-      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
-      stale_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
-      future_start_date = Timex.now() |> DateTime.add(Enum.random(1..30), :day)
-      future_end_date = future_start_date |> DateTime.add(Enum.random(1..30), :day)
+    test "Marks alerts related to the symphony work as stale" do
+      entities = [%Alerts.InformedEntity{stop: "place-symcl"}]
 
       alert =
-        new(
-          effect: :delay,
-          active_period: [
-            {stale_start_date, stale_end_date},
-            {future_start_date, future_end_date}
-          ]
-        )
+        new(effect: :station_closure, informed_entity: entities)
 
       assert Alerts.Alert.stale?(alert),
-             "Alert with an end was expected to be stale, but was not #{stale_start_date}"
+             "Alertnrelated to symphony expected to be stale, but was not"
     end
 
-    test "Marks alerts with no end younger than 5 weeks as fresh" do
-      fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
-      alert = new(effect: :delay, active_period: [{fresh_start_date, nil}])
+    test "Marks alerts unrelated to the symphony work as fresh" do
+      entities = [%Alerts.InformedEntity{stop: "place-hymnl"}]
+
+      alert =
+        new(effect: :detour, informed_entity: entities)
 
       assert !Alerts.Alert.stale?(alert),
-             "Alert with no end was expected to be fresh, but was not"
-    end
-
-    test "Marks alerts with an end younger than 5 weeks as fresh" do
-      fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
-      fresh_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
-
-      alert = new(effect: :delay, active_period: [{fresh_start_date, fresh_end_date}])
-
-      assert !Alerts.Alert.stale?(alert),
-             "Alert with an end was expected to be fresh, but was not"
+             "Alert unrelated to symphony expected to be fresh, but was not"
     end
   end
 


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐬 Symphony logic final (final) version](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217611059875181?focus=true)

## Implementation

Changed the business logic for stale? alerts, now they're only for the symphony work.  Updated alerts_test tests to suit the new logic.  

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Symphony alert hidden on Subway Status
<img width="791" height="465" alt="Screenshot 2026-08-19 at 11 44 37 AM" src="https://github.com/user-attachments/assets/ee5fabb9-a4c8-400c-83f9-d27369d3d81f" /> 
<img width="434" height="348" alt="Screenshot 2026-08-19 at 11 46 54 AM" src="https://github.com/user-attachments/assets/1caf2797-b19d-46a2-adbe-eba34643c6ac" />


### Symphony alert hidden on Green-E line
<img width="590" height="373" alt="Screenshot 2026-08-19 at 11 44 12 AM" src="https://github.com/user-attachments/assets/0539614a-75eb-49fd-8e37-e9c0f57cee7f" />

### Symphony alert shown in Green-E alerts
<img width="610" height="574" alt="Screenshot 2026-08-19 at 11 43 58 AM" src="https://github.com/user-attachments/assets/9da74bc3-3cd8-4b8a-90c2-62dd80cc7603" />

### Symphony alert hidden in Green line
<img width="599" height="320" alt="Screenshot 2026-08-19 at 11 43 27 AM" src="https://github.com/user-attachments/assets/22b05252-f7a9-47c1-851a-2dd0ba067025" />

### Symphony alert shown in Green alerts
<img width="597" height="726" alt="Screenshot 2026-08-19 at 11 43 40 AM" src="https://github.com/user-attachments/assets/43120b53-2719-4fbf-b87d-821dd1ede25d" />


## How to test

http://localhost:4001/ & http://localhost:4001/alerts/subway - Confirm the symphony alert isn't shown in Subway Status
http://localhost:4001/schedules/Green-E/line  & http://localhost:4001/schedules/Green/line - Confirm the alert doesn't show on the line diagram but does on the Alerts tab

Depending on the order in which these PRs are merged you may want to test the departures page as well.

http://localhost:4001/departures?route_id=Green&direction_id=1&stop_id=place-symcl - Confirm the alert shows
http://localhost:4001/departures?route_id=Green&direction_id=1&stop_id=place-hymnl - Confirm the alert doesn't show

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
