### PR TITLE
[Fix]: Flaky test - DotcomWeb.SubwayAlertsLiveTest: ...

### DIFF
--- a/test/dotcom_web/live/subway_alerts_live_test.exs
+++ b/test/dotcom_web/live/subway_alerts_live_test.exs
@@ -2,6 +2,7 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
   use DotcomWeb.ConnCase, async: true
 
   import Dotcom.Alerts, only: [service_impacting_effects: 0]
+
   import DotcomWeb.Router.Helpers, only: [live_path: 2]
   import Mox
   import Phoenix.LiveViewTest
@@ -91,6 +92,11 @@ defmodule DotcomWeb.SubwayAlertsLiveTest do
     test "does not put service-impacting alerts in the station_and_service section", %{conn: conn} do
       route_id = Faker.Util.pick(Subway.lines())
       route_type = Faker.Util.pick([0, 1])
+      stop = Factories.Stops.Stop.stop_factory()
+
+      stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _alerts, _route_ids ->
+        [%{stop: stop, direction: :all}]
+      end)
 
       stub(Alerts.Repo.Mock, :by_route_types, fn [0, 1], date ->
         Factories.Alerts.Alert.build_list(1, :alert, %{


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🛠️ Flaky test - DotcomWeb.SubwayAlertsLiveTest: subway alerts page does not put service-impacting alerts in the station_and_service section](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217319984099404?focus=true)

## Implementation

Added missing stub to flaky test

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### 50+ runs without failure
<img width="141" height="801" alt="Screenshot 2026-08-19 at 2 19 30 PM" src="https://github.com/user-attachments/assets/2612fba5-3c87-4311-a356-e5d8545dcb1b" />


## How to test

`mix test test/dotcom_web/live/subway_alerts_live_test.exs --repeat-until-failure 50`

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
