### PR TITLE
hotfix: revert root template adjustment in GTM script

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -133,7 +133,7 @@
         data-gtm-variable={@conn.assigns[:csp_nonce]}
         id="gtm-script"
       >
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ "&gtm_auth={gtm_auth}&gtm_preview={gtm_preview}&gtm_cookies_win=x";var n=d.querySelector('[nonce]'); n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{gtm_id}');
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ "&gtm_auth=<%= gtm_auth %>&gtm_preview=<%= gtm_preview %>&gtm_cookies_win=x";var n=d.querySelector('[nonce]'); n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','<%= gtm_id %>');
       </script>
       <!-- End Google Tag Manager -->
     <% end %>


### PR DESCRIPTION
The string interpolation won't work in the inlined JavaScript. This isn't verifiable in the other environments because prod's the only one with the needed environment variables, but this is verifiable locally by hardcoding the `gtm_id`/`gtm_preview`/`gtm_auth` variables and seeing the values not get properly propagated. Honestly, how rude...