### PR TITLE
feat(header): save rendered static markup for faster retrieval

### DIFF
--- a/lib/dotcom/cache/persistent_term_warmer.ex
+++ b/lib/dotcom/cache/persistent_term_warmer.ex
@@ -23,6 +23,7 @@ defmodule Dotcom.Cache.PersistentTermWarmer do
         # All of these should use the locale code in its cache key.
         DotcomWeb.LayoutView.top_tier_nav(code)
         DotcomWeb.LayoutView.desktop_menu(code)
+        DotcomWeb.LayoutView.mobile_menu(code)
         DotcomWeb.LayoutView.contact_numbers(code)
         DotcomWeb.LayoutView.footer_links(code)
         DotcomWeb.LayoutView.footer_social_links(code)

--- a/lib/dotcom/cache/persistent_term_warmer.ex
+++ b/lib/dotcom/cache/persistent_term_warmer.ex
@@ -22,6 +22,7 @@ defmodule Dotcom.Cache.PersistentTermWarmer do
 
         # All of these should use the locale code in its cache key.
         DotcomWeb.LayoutView.top_tier_nav(code)
+        DotcomWeb.LayoutView.desktop_menu(code)
         DotcomWeb.LayoutView.contact_numbers(code)
         DotcomWeb.LayoutView.footer_links(code)
         DotcomWeb.LayoutView.footer_social_links(code)

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -74,5 +74,17 @@
       <% end %>
     </div>
   </div>
-  {render("_new_nav_mobile.html", assigns)}
+  <nav class="m-menu--mobile" id="navmenu" aria-label={~t(Navigation Menu)}>
+    <div class="m-menu__content" data-nav="fullscreen-menu-content">
+      {mobile_menu(@locale)}
+      <div
+        :if={!Laboratory.enabled?(@conn, :use_smartling_translations)}
+        class="m-menu__language m-menu__section"
+      >
+      </div>
+    </div>
+    <div class="m-menu__search" data-nav="search">
+      <.algolia_autocomplete id="header-mobile" config_type="basic-config" />
+    </div>
+  </nav>
 </header>

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -31,7 +31,14 @@
         </a>
       <% end %>
 
-      {render("_new_nav_desktop.html", assigns)}
+      <nav id="navmenu-dropdown" class="m-menu--dropdown" aria-label="Main">
+        {desktop_menu(@locale)}
+        <div
+          :if={!Laboratory.enabled?(@conn, :use_smartling_translations)}
+          class="m-menu__language"
+        >
+        </div>
+      </nav>
       <div class="search-wrapper">
         <div class="search">
           <.algolia_autocomplete id="header-desktop" config_type="basic-config" />

--- a/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
@@ -25,7 +25,7 @@
             <div class="m-menu-dropdown__submenu-section" aria-label={section_name}>
               {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
               <div
-                :if={section_name == "Transit Police"}
+                :if={section_name == ~t"Transit Police"}
                 class="m-menu__feature emergency-contacts dropdown"
               >
                 <div class="m-menu__section-heading">{~t(Emergency Contacts)}</div>
@@ -41,13 +41,13 @@
           <% end %>
           <%= for %{sub_menu_section: special_section} <- sub_menus do %>
             <div
-              :if={special_section == "Most popular fares"}
+              :if={special_section == ~t"Most popular fares"}
               class="m-menu-dropdown__section-feature"
             >
               {render("_new_nav_popular_fares.html")}
             </div>
             <div
-              :if={special_section == "Contact numbers"}
+              :if={special_section == ~t"Contact numbers"}
               class="m-menu-dropdown__section-feature"
             >
               {contact_numbers(@locale)}

--- a/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
@@ -1,63 +1,60 @@
-<nav id="navmenu-dropdown" class="m-menu--dropdown" aria-label="Main">
-  <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- DotcomWeb.LayoutView.nav_link_content do %>
-    <a
-      class="m-menu--dropdown__toggle"
-      href={"#{ href }"}
-      data-nav="toggle-dropdown-nav"
-      role="button"
-      aria-expanded="false"
-      aria-controls={"#{ to_camelcase(name) }"}
-    >
-      {name}
-      <span class="c-indicator--angle"></span>
-    </a>
+<%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- DotcomWeb.LayoutView.nav_link_content() do %>
+  <a
+    class="m-menu--dropdown__toggle"
+    href={href}
+    data-nav="toggle-dropdown-nav"
+    role="button"
+    aria-expanded="false"
+    aria-controls={to_camelcase(name)}
+  >
+    {name}
+    <span class="c-indicator--angle"></span>
+  </a>
 
-    <div class="m-menu--dropdown__menu">
-      <div class="container">
-        <div id={"#{ to_camelcase(name) }"}>
-          <div
-            class={"m-menu-dropdown__section #{ to_camelcase(name) }"}
-            data-nav="dropdown-section"
-          >
-            <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
-              <div class="m-menu__section-heading">
-                {section_name}
-              </div>
-              <div class="m-menu-dropdown__submenu-section" aria-label={"#{ section_name }"}>
-                {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
-                <%= if section_name == "Transit Police" do %>
-                  <div class="m-menu__feature emergency-contacts dropdown">
-                    <div class="m-menu__section-heading">{~t(Emergency Contacts)}</div>
-                    <small>{~t(24 hours, 7 days a week)}</small>
-                    <div class="m-menu__feature_phone">
-                      <strong>{~t(Transit Police)}:</strong> {tel_link("617-222-1212")}
-                    </div>
-                    <div class="m-menu__feature_phone">
-                      <strong>TTY:</strong> {tel_link("711")}
-                    </div>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-            <%= for %{sub_menu_section: special_section} <- sub_menus do %>
-              <%= if special_section == "Most popular fares" do %>
-                <div class="m-menu-dropdown__section-feature">
-                  {render("_new_nav_popular_fares.html")}
+  <div class="m-menu--dropdown__menu">
+    <div class="container">
+      <div id={to_camelcase(name)}>
+        <div
+          class={"m-menu-dropdown__section #{to_camelcase(name)}"}
+          data-nav="dropdown-section"
+        >
+          <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
+            <div class="m-menu__section-heading">
+              {section_name}
+            </div>
+            <div class="m-menu-dropdown__submenu-section" aria-label={section_name}>
+              {Enum.map(links, &DotcomWeb.LayoutView.render_nav_link/1)}
+              <div
+                :if={section_name == "Transit Police"}
+                class="m-menu__feature emergency-contacts dropdown"
+              >
+                <div class="m-menu__section-heading">{~t(Emergency Contacts)}</div>
+                <small>{~t(24 hours, 7 days a week)}</small>
+                <div class="m-menu__feature_phone">
+                  <strong>{~t(Transit Police)}:</strong> {tel_link("617-222-1212")}
                 </div>
-              <% end %>
-
-              <%= if special_section == "Contact numbers" do %>
-                <div class="m-menu-dropdown__section-feature">
-                  {contact_numbers(@locale)}
+                <div class="m-menu__feature_phone">
+                  <strong>TTY:</strong> {tel_link("711")}
                 </div>
-              <% end %>
-            <% end %>
-          </div>
+              </div>
+            </div>
+          <% end %>
+          <%= for %{sub_menu_section: special_section} <- sub_menus do %>
+            <div
+              :if={special_section == "Most popular fares"}
+              class="m-menu-dropdown__section-feature"
+            >
+              {render("_new_nav_popular_fares.html")}
+            </div>
+            <div
+              :if={special_section == "Contact numbers"}
+              class="m-menu-dropdown__section-feature"
+            >
+              {contact_numbers(@locale)}
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
-  <% end %>
-  <%= if !Laboratory.enabled?(@conn, :use_smartling_translations) do %>
-    <div class="m-menu__language"></div>
-  <% end %>
-</nav>
+  </div>
+<% end %>

--- a/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
@@ -1,43 +1,33 @@
-<nav class="m-menu--mobile" id="navmenu" aria-label={~t(Navigation Menu)}>
-  <div class="m-menu__content" data-nav="fullscreen-menu-content">
-    <h1 class="m-menu__title h2">{~t(Main Menu)}</h1>
-    <%= for {%{menu_section: menu_section, sub_menus: sub_menus}, index} <- Enum.with_index(nav_link_content()) do %>
-      <nav aria-labelledby={"section-heading-#{menu_section}"} class="m-menu__section">
-        <h2 id={"section-heading-#{menu_section}"} class="m-menu__section-heading">
-          {menu_section}
-        </h2>
-        {DotcomWeb.PartialView.render(
-          "_accordion_ui_no_bootstrap.html",
-          Map.merge(assigns, %{
-            id: menu_section,
-            multiselectable: false,
-            sections:
-              for {%{links: links} = sub_menu, sub_index} <- Enum.with_index(sub_menus) do
-                %{
-                  content: Enum.map(links, &render_nav_link/1),
-                  title: sub_menu.sub_menu_section,
-                  prefix: String.replace(sub_menu.sub_menu_section, " ", "-"),
-                  expanded?: index === 0 && sub_index === 0
-                }
-              end
-          })
-        )}
+<h1 class="m-menu__title h2">{~t(Main Menu)}</h1>
+<%= for {%{menu_section: menu_section, sub_menus: sub_menus}, index} <- Enum.with_index(nav_link_content()) do %>
+  <nav aria-labelledby={"section-heading-#{menu_section}"} class="m-menu__section">
+    <h2 id={"section-heading-#{menu_section}"} class="m-menu__section-heading">
+      {menu_section}
+    </h2>
+    {DotcomWeb.PartialView.render(
+      "_accordion_ui_no_bootstrap.html",
+      Map.merge(assigns, %{
+        id: menu_section,
+        multiselectable: false,
+        sections:
+          for {%{links: links} = sub_menu, sub_index} <- Enum.with_index(sub_menus) do
+            %{
+              content: Enum.map(links, &render_nav_link/1),
+              title: sub_menu.sub_menu_section,
+              prefix: String.replace(sub_menu.sub_menu_section, " ", "-"),
+              expanded?: index === 0 && sub_index === 0
+            }
+          end
+      })
+    )}
 
-        <%= for %{sub_menu_section: sub_menu_section} <- sub_menus do %>
-          <%= if sub_menu_section == "Most popular fares" do %>
-            {render("_new_nav_popular_fares.html")}
-          <% end %>
-          <%= if sub_menu_section == "Contact numbers" do %>
-            {contact_numbers(@locale)}
-          <% end %>
-        <% end %>
-      </nav>
+    <%= for %{sub_menu_section: sub_menu_section} <- sub_menus do %>
+      <%= if sub_menu_section == "Most popular fares" do %>
+        {render("_new_nav_popular_fares.html")}
+      <% end %>
+      <%= if sub_menu_section == "Contact numbers" do %>
+        {contact_numbers(@locale)}
+      <% end %>
     <% end %>
-    <%= if !Laboratory.enabled?(@conn, :use_smartling_translations) do %>
-      <div class="m-menu__language m-menu__section"></div>
-    <% end %>
-  </div>
-  <div class="m-menu__search" data-nav="search">
-    <.algolia_autocomplete id="header-mobile" config_type="basic-config" />
-  </div>
-</nav>
+  </nav>
+<% end %>

--- a/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
@@ -22,10 +22,10 @@
     )}
 
     <%= for %{sub_menu_section: sub_menu_section} <- sub_menus do %>
-      <%= if sub_menu_section == "Most popular fares" do %>
+      <%= if sub_menu_section == ~t"Most popular fares" do %>
         {render("_new_nav_popular_fares.html")}
       <% end %>
-      <%= if sub_menu_section == "Contact numbers" do %>
+      <%= if sub_menu_section == ~t"Contact numbers" do %>
         {contact_numbers(@locale)}
       <% end %>
     <% end %>

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -365,6 +365,16 @@ defmodule DotcomWeb.LayoutView do
     end)
   end
 
+  def mobile_menu(locale) do
+    Util.get_or_save_persistent_term({__MODULE__, :mobile_menu, locale}, fn ->
+      {:safe,
+       Phoenix.View.render_to_iodata(DotcomWeb.LayoutView, "_new_nav_mobile.html", %{
+         conn: %Plug.Conn{},
+         locale: locale
+       })}
+    end)
+  end
+
   def desktop_menu(locale) do
     Util.get_or_save_persistent_term({__MODULE__, :desktop_menu, locale}, fn ->
       {:safe,

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -364,4 +364,13 @@ defmodule DotcomWeb.LayoutView do
       {:safe, Phoenix.View.render_to_iodata(__MODULE__, "_footer_social_links.html", %{})}
     end)
   end
+
+  def desktop_menu(locale) do
+    Util.get_or_save_persistent_term({__MODULE__, :desktop_menu, locale}, fn ->
+      {:safe,
+       Phoenix.View.render_to_iodata(DotcomWeb.LayoutView, "_new_nav_desktop.html", %{
+         locale: locale
+       })}
+    end)
+  end
 end

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -81,7 +81,7 @@ defmodule DotcomWeb.LayoutView do
     [
       %{
         menu_section: ~t(Transit),
-        link: ~p"/menu#Transit-section",
+        link: "/menu#Transit-section",
         sub_menus: [
           %{
             sub_menu_section: ~t(Modes of Transit),
@@ -119,7 +119,7 @@ defmodule DotcomWeb.LayoutView do
       },
       %{
         menu_section: ~t(Fares),
-        link: ~p"/menu#Fares-section",
+        link: "/menu#Fares-section",
         sub_menus: [
           %{
             sub_menu_section: ~t(Fares Info),
@@ -155,7 +155,7 @@ defmodule DotcomWeb.LayoutView do
       },
       %{
         menu_section: ~t(Contact),
-        link: ~p"/menu#Contact-section",
+        link: "/menu#Contact-section",
         sub_menus: [
           %{
             sub_menu_section: ~t(Customer Support),
@@ -185,7 +185,7 @@ defmodule DotcomWeb.LayoutView do
       },
       %{
         menu_section: ~t(About),
-        link: ~p"/menu#About-section",
+        link: "/menu#About-section",
         sub_menus: [
           %{
             sub_menu_section: ~t(Get to Know Us),

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -2684,7 +2684,7 @@ msgstr ""
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr ""

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -1028,6 +1028,8 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2673,6 +2675,8 @@ msgstr ""
 msgid "Most Direct"
 msgstr ""
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -2684,7 +2684,7 @@ msgstr ""
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -1028,6 +1028,8 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2673,6 +2675,8 @@ msgstr ""
 msgid "Most Direct"
 msgstr ""
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -2696,7 +2696,7 @@ msgstr "La mayoría, pero no todas, las muelles de la MBTA son accesibles para p
 " para viajar, puedes encontrar pendientes significativas y corredores estrechos, incluso en muellers accesibles. En absoluto, mulas, espera a que un afiliado"
 " a la tripulación te diga que es seguro continuar."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menú de navegación"

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -1031,6 +1031,8 @@ msgstr "Contacto"
 msgid "Contact Us"
 msgstr "Contáctanos"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2683,6 +2685,8 @@ msgstr "Más de "
 msgid "Most Direct"
 msgstr "Más directo"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -1031,6 +1031,8 @@ msgstr "Contact"
 msgid "Contact Us"
 msgstr "Contactez-nous"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2684,6 +2686,8 @@ msgstr "Plus de "
 msgid "Most Direct"
 msgstr "Les plus directs"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -2697,7 +2697,7 @@ msgstr "La plupart, mais pas tous, des quai MBTA sont accessible à un passager 
 " navigation, vous pouvez rencontrer des pentes importantes et des passerelles étroites, même à accessible quai. Au quai, attendez qu’un membre d’équipage"
 " vous dise qu’il est sûr de continuer."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Navigation Menu"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -2691,7 +2691,7 @@ msgid "Most, but not all, MBTA docks are accessible to riders with disabilities.
 msgstr "Pifò, men pa tout, waf MBTA yo aksesib pou pase ak andikap. Selon nivo mare a ak kalite veso ou itilize pou vwayaj la, ou ka rankontre pant enpòtan ak"
 " pasaj pyeton etwat, menm nan waf aksesib. Nan tout waf yo, tann jiskaske yon manm ekipaj di ou ke li an sekirite pou ou kontinye."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Meni Navigasyon"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -1031,6 +1031,8 @@ msgstr "Kontakte"
 msgid "Contact Us"
 msgstr "Kontakte nou"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2679,6 +2681,8 @@ msgstr "Plis nan men "
 msgid "Most Direct"
 msgstr "Pi Dirèk"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -1031,6 +1031,8 @@ msgstr "Contato"
 msgid "Contact Us"
 msgstr "Contate-nos"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2681,6 +2683,8 @@ msgstr "Mais de "
 msgid "Most Direct"
 msgstr "Mais direto"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -2694,7 +2694,7 @@ msgstr "A maioria, mas não todos, dos píer MBTA são acessíveis a passageiros
 " a viagem, você poderá encontrar declives acentuados e passarelas estreitas, mesmo em locais acessíveis. Em todas as situações, espere até que um membro"
 " da tripulação diga que é seguro prosseguir."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menu de navegação"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -2689,7 +2689,7 @@ msgstr "Hầu hết, nhưng không phải tất cả, MBTA bến tàu đều có
 " dụng để đi lại, bạn có thể gặp phải những con dốc đáng kể và lối đi hẹp, ngay cả tại có thể tiếp cận được bến tàu. Tại tất cả các bến tàu, hãy đợi cho"
 " đến khi một thành viên thủy thủ đoàn nói với bạn rằng có thể tiếp tục an toàn."
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "Menu điều hướng"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -1025,6 +1025,8 @@ msgstr "Liên hệ"
 msgid "Contact Us"
 msgstr "Liên hệ với chúng tôi"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2676,6 +2678,8 @@ msgstr "Xem thêm từ "
 msgid "Most Direct"
 msgstr "Trực tiếp nhất"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -1022,6 +1022,8 @@ msgstr "联系"
 msgid "Contact Us"
 msgstr "联系我们"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2667,6 +2669,8 @@ msgstr "更多内容 "
 msgid "Most Direct"
 msgstr "最直接"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -2678,7 +2678,7 @@ msgstr "最受欢迎的票价"
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "大多数（但不是全部）MBTA 码头都易于通过残障进行上升。 根据潮汐水位和航行所用船只的类型，即使在无障碍码头，您也可能会遇到较大的坡度和狭窄的通道。在所有码头，请等待船员告知您可以安全通行后再继续前进。"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "导航菜单"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -2678,7 +2678,7 @@ msgstr "最受歡迎的票價"
 msgid "Most, but not all, MBTA docks are accessible to riders with disabilities. Based on the tide level and the type of vessel used for travel, you may encounter significant slopes and narrow walkways, even at accessible docks. At all docks, wait until a crew member tells you it is safe to proceed."
 msgstr "大多數（但不是全部）MBTA 碼頭都易於透過殘障進行上升。 根據潮汐水位和航行所用船隻的類型，即使在無障礙碼頭，您也可能會遇到較大的坡度和狹窄的通道。在所有碼頭，請等待船員告知您可以安全通行後再繼續前進。"
 
-#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+#: lib/dotcom_web/templates/layout/_new_header.html.heex
 #, elixir-autogen, elixir-format
 msgid "Navigation Menu"
 msgstr "導航選單"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -1022,6 +1022,8 @@ msgstr "聯繫"
 msgid "Contact Us"
 msgstr "聯絡我們"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format
 msgid "Contact numbers"
@@ -2667,6 +2669,8 @@ msgstr "更多內容 "
 msgid "Most Direct"
 msgstr "最直接"
 
+#: lib/dotcom_web/templates/layout/_new_nav_desktop.html.heex
+#: lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
 #: lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
Same scope/implementation as this PR, just focused on the header!

- https://github.com/mbta/dotcom/pull/3426

This required some light refactoring, because I can't save the `Laboratory.enabled?(@conn, :use_smartling_translations)` calls in `:persistent_term`.

This one was a lot harder to isolate in the flamegraphs, sorry. Best I can offer is an attempt from rendering the pages (which obviously includes many other things beyond the navigation).

| Before | After |
|--------|--------|
| 142,486µs | 116,482µs | 
|  <img width="500" height="287" alt="image" src="https://github.com/user-attachments/assets/7b9b437d-f89d-4d77-aaf1-356463d9e6a9" /> | <img width="468" height="291" alt="image" src="https://github.com/user-attachments/assets/f19413f3-ebe9-46df-9320-2ae3d5e8bd1a" /> | 