### PR TITLE
fix(alerts): Provide all applicable service ranges when only given start time

### DIFF
--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -244,12 +244,17 @@ defmodule Dotcom.Utils.ServiceDateTime do
 
   @doc """
   Returns service ranges between two datetimes, inclusive.
-  One datetime can be given, which will return only the service range for the given datetime.
+  If only the stop datetime is provided, returns the service range for that datetime.
+  If only the start datetime is provided, returns all service ranges from that datetime onward.
   """
   @spec service_range_range(DateTime.t() | nil, DateTime.t() | nil) :: [named_service_range()]
   def service_range_range(nil, nil), do: []
-  def service_range_range(start, nil) when not is_nil(start), do: [service_range(start)]
-  def service_range_range(nil, stop) when not is_nil(stop), do: [service_range(stop)]
+  def service_range_range(nil, stop), do: [service_range(stop)]
+
+  def service_range_range(start, nil) do
+    all_service_ranges()
+    |> Enum.drop_while(&(&1 != service_range(start)))
+  end
 
   def service_range_range(start, stop) do
     start_index = service_range_index(start)

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -241,20 +241,20 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
       assert service_range_range(today, next_week) == [:today, :this_week, :next_week]
     end
 
-    test "returns one service range when given only one start datetime" do
-      # Setup
-      next_week = service_range_next_week() |> random_time_range_date_time()
-
-      # Exercise / Verify
-      assert service_range_range(next_week, nil) == [:next_week]
-    end
-
     test "returns one service range when given only one stop datetime" do
       # Setup
       next_week = service_range_next_week() |> random_time_range_date_time()
 
       # Exercise / Verify
       assert service_range_range(nil, next_week) == [:next_week]
+    end
+
+    test "returns all service ranges from the start datetime onward when given only one start datetime" do
+      # Setup
+      next_week = service_range_next_week() |> random_time_range_date_time()
+
+      # Exercise / Verify
+      assert service_range_range(next_week, nil) == [:next_week, :after_next_week]
     end
   end
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐬 Investigate why Symphony isn't showing up in Planned Work](https://app.asana.com/1/15492006741476/project/1213039586590742/task/1216640941991694)

## Implementation
Changes `service_range_range` to give all ranges from the start time onward. 

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before: 
<img width="817" height="717" alt="image" src="https://github.com/user-attachments/assets/d253879f-c91e-482f-bde4-04b134548fb3" />


After (notice Symphony alert appears):
<img width="815" height="832" alt="image" src="https://github.com/user-attachments/assets/7095b2b6-c24d-4b4e-ae68-0c76596fd464" />


## How to test
Verify that alerts on the [alerts page](http://localhost:4001/alerts/subway) with an indefinite end time appear in all applicable parts of Planned Work (e.g. if start time is next week, it should not appear under "this week").


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->

## TODOs
- [x] inform OIOs about this behavior