### PR TITLE
[Fix] Flaky test - trip planner time rendering for <1m trips

### DIFF
--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -385,7 +385,10 @@ defmodule Dotcom.Utils.Time do
     case Cldr.Time.Interval.greatest_difference(time1, time2) do
       {:error, :no_practical_difference} ->
         start_string = format!(time1, :hour_12_minutes_no_ampm)
-        end_string = format!(time2, :hour_12_minutes) |> String.downcase()
+
+        end_string =
+          format!(time2, :hour_12_minutes) |> String.downcase() |> String.replace(" ", " ")
+
         "#{start_string}\u2009–\u2009#{end_string}"
 
       _ ->

--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -263,6 +263,13 @@ defmodule Dotcom.Utils.Time do
     string
   end
 
+  # 11:59 PM
+  def format!(datetime, :hour_12_minutes_no_ampm) do
+    {:ok, string} = Cldr.DateTime.to_string(datetime, Dotcom.Cldr, format: "h:mm")
+
+    string
+  end
+
   # 11 PM
   def format!(datetime, :hour_12) do
     {:ok, string} = Cldr.DateTime.to_string(datetime, Dotcom.Cldr, format: "h a")
@@ -375,12 +382,20 @@ defmodule Dotcom.Utils.Time do
       "9:41\u2009–\u20099:38 am"
   """
   def formatted_time_range(time1, time2) do
-    Dotcom.Cldr.Time.Interval.to_string!(
-      time1 |> to_time(),
-      time2 |> to_time(),
-      format: :medium,
-      period: :variant
-    )
+    case Cldr.Time.Interval.greatest_difference(time1, time2) do
+      {:error, :no_practical_difference} ->
+        start_string = format!(time1, :hour_12_minutes_no_ampm)
+        end_string = format!(time2, :hour_12_minutes)
+        "#{start_string}\u2009–\u2009#{end_string}"
+
+      _ ->
+        Dotcom.Cldr.Time.Interval.to_string!(
+          time1 |> to_time(),
+          time2 |> to_time(),
+          format: :medium,
+          period: :variant
+        )
+    end
   end
 
   defp to_time(%DateTime{} = date_time) do

--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -385,7 +385,7 @@ defmodule Dotcom.Utils.Time do
     case Cldr.Time.Interval.greatest_difference(time1, time2) do
       {:error, :no_practical_difference} ->
         start_string = format!(time1, :hour_12_minutes_no_ampm)
-        end_string = format!(time2, :hour_12_minutes)
+        end_string = format!(time2, :hour_12_minutes) |> String.downcase()
         "#{start_string}\u2009–\u2009#{end_string}"
 
       _ ->

--- a/test/dotcom_web/live/trip_planner_live_test.exs
+++ b/test/dotcom_web/live/trip_planner_live_test.exs
@@ -586,7 +586,7 @@ defmodule DotcomWeb.TripPlannerLiveTest do
         Generators.DateTime.random_date_time()
         |> Map.update!(:second, fn _ -> 0 end)
         |> Map.update!(:hour, fn hour ->
-          if hour > 12 do
+          if hour >= 12 do
             hour - 12
           else
             hour

--- a/test/dotcom_web/live/trip_planner_live_test.exs
+++ b/test/dotcom_web/live/trip_planner_live_test.exs
@@ -578,6 +578,35 @@ defmodule DotcomWeb.TripPlannerLiveTest do
       assert rendered_time_range(view) ==
                "#{pretty_time(start_time)} pm\u2009–\u2009#{pretty_time(end_time)} am +1"
     end
+
+    test "renders time range as 'h:mm - h:mm am/pm' if both times are within the minute", %{
+      view: view
+    } do
+      start_time =
+        Generators.DateTime.random_date_time()
+        |> Map.update!(:second, fn _ -> 0 end)
+        |> Map.update!(:hour, fn hour ->
+          if hour > 12 do
+            hour - 12
+          else
+            hour
+          end
+        end)
+
+      end_time = start_time |> DateTime.add(Enum.random(1..58))
+
+      # Setup
+      expect(OpenTripPlannerClient.Mock, :plan, fn _ ->
+        {:ok, [itinerary_group_with_time_range(start_time, end_time)]}
+      end)
+
+      # Exercise
+      view |> element("form") |> render_change(%{"input_form" => @valid_params})
+
+      # Verify
+      assert rendered_time_range(view) ==
+               "#{pretty_time(start_time)}\u2009–\u2009#{pretty_time(end_time)} am"
+    end
   end
 
   defp itinerary_group_with_time_range(start_time, end_time) do


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🛠️ Flaky test - trip planner time rendering for <1m trips](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215244931974646?focus=true)

## Implementation

I agree with the test and Josh that the way Trip Planner currently shows sub-minute trips is a little odd.  So I added logic to the function that does that formatting to handle the edge case where the start and end time of a journey takes less than a minute. 

Fun fact: Thin spaces are a thing and they are  tricky to notice!

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Weird time on main
<img width="420" height="179" alt="Screenshot 2026-08-20 at 2 04 59 PM" src="https://github.com/user-attachments/assets/19a6e414-de32-4ad3-91d6-e16df3d335c7" />

### Looks like every other trip on local

<img width="423" height="185" alt="Screenshot 2026-08-20 at 2 04 44 PM" src="https://github.com/user-attachments/assets/ddc86e2e-e642-4343-8e6f-48edae6229d7" />

(Ignore the difference in time)

## How to test

[This is the example Josh used](http://localhost:4001/trip-planner?plan=jMQVX3VudXNlZF9kYXRldGltZV90eXBlxADEF191bnVzZWRfdGltZXBpY2tlcl9hbXBtxADEF191bnVzZWRfdGltZXBpY2tlcl9ob3VyxADEGV91bnVzZWRfdGltZXBpY2tlcl9taW51dGXEAMQSX3VudXNlZF93aGVlbGNoYWlyxADECGRhdGV0aW1lxBkyMDI2LTA4LTIwVDE3OjMwOjAwLTA0OjAwxARmcm9thMQIbGF0aXR1ZGXEDzQyLjMxMTQwMDAxMzE4OcQJbG9uZ2l0dWRlxA8tNzEuMTE0NjY5OTU5NTjEBG5hbWXELDcwOSBDZW50cmUgU3QsIEphbWFpY2EgUGxhaW4sIE1BLCAwMjEzMCwgVVNBxAdzdG9wX2lkxADEBW1vZGVzicQDQlVTxAR0cnVlxAVGRVJSWcQEdHJ1ZcQEUkFJTMQEdHJ1ZcQGU1VCV0FZxAR0cnVlxA5fcGVyc2lzdGVudF9pZMQBMMQLX3VudXNlZF9CVVPEAMQNX3VudXNlZF9GRVJSWcQAxAxfdW51c2VkX1JBSUzEAMQOX3VudXNlZF9TVUJXQVnEAMQPdGltZXBpY2tlcl9hbXBtxAJQTcQPdGltZXBpY2tlcl9ob3VyxAE1xBF0aW1lcGlja2VyX21pbnV0ZcQCMzDEAnRvhMQIbGF0aXR1ZGXLQEUn20SCT7LECWxvbmdpdHVkZcvAUcdWvo-OwcQEbmFtZcQsNzExIENlbnRyZSBTdCwgSmFtYWljYSBQbGFpbiwgTUEsIDAyMTMwLCBVU0HEB3N0b3BfaWTEAA==) but any trip between two very close locations should do the trick.

It also solves the flaky test issue this ticket was originally for.
`mix test test/dotcom_web/live/trip_planner_live_test.exs --repeat-until-failure 50`

<img width="80" height="829" alt="Screenshot 2026-08-20 at 2 09 15 PM" src="https://github.com/user-attachments/assets/76640f93-df5d-4f23-9d55-a6c94385ec5d" />


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
