### PR TITLE
[Fix]: Flaky test - does not include an alert if that alert is also the banner alert

### DIFF
--- a/test/dotcom/alerts_test.exs
+++ b/test/dotcom/alerts_test.exs
@@ -417,7 +417,8 @@ defmodule Dotcom.AlertsTest do
       {^route, alert_group} =
         commuter_rail_alert_groups() |> Enum.find(fn {r, _} -> r == route end)
 
-      assert MapSet.new(alert_group) == MapSet.new(non_banner_alerts)
+      assert MapSet.new(alert_group) == MapSet.new(non_banner_alerts),
+             "lists of alerts do not match, do we have an id collision?\n #{alerts |> Enum.map(& &1.id) |> List.to_string()}"
     end
 
     test "does not include currently-active service-impacting alerts" do

--- a/test/support/factories/alerts/alert.ex
+++ b/test/support/factories/alerts/alert.ex
@@ -11,7 +11,7 @@ defmodule Test.Support.Factories.Alerts.Alert do
 
   def alert_factory do
     %Alert{
-      id: :rand.uniform(999) |> Integer.to_string(),
+      id: :rand.uniform(9_999_999) |> Integer.to_string(),
       active_period: [{Faker.DateTime.forward(1), Faker.DateTime.forward(2)}],
       banner: nil,
       cause: Faker.Lorem.Shakespeare.king_richard_iii(),


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🛠️ Flaky test - does not include an alert if that alert is also the banner alert](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211996592730892?focus=true)

## Implementation

Found that there were ID collisions on the failing cases.  The factory was only using :rand(0-999) for ids, and the test was randomly selecting 5.  I upped the range to 0-9,999,999 since real alerts are in the seven digits anyway.  While this will not entirely eliminate the flakyness of this test, it will make it happen way less often (1:250 to 1:2,500,000 by my math)

Added explanation and debug info for when the assertion eventually fails

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

`mix test test/dotcom/alerts_test.exs --repeat-until-failure 500` - Confirm the test always passes.  This takes a little over a minute on my machine, you can alter the `500` to fit how patient you are.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
