### PR TITLE
fix(PageView): add :kill_task on timeout

### DIFF
--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -22,8 +22,11 @@ defmodule DotcomWeb.PageView do
         &Dotcom.Alerts.routes_with_high_priority_alerts_by_mode/1,
         &Dotcom.Alerts.stops_with_access_alerts_by_effect/1
       ]
-      |> Task.async_stream(& &1.(alerts), timeout: 10_000)
-      |> Enum.map(fn {:ok, result} -> result end)
+      |> Task.async_stream(& &1.(alerts), timeout: 10_000, on_timeout: :kill_task)
+      |> Enum.map(fn
+        {:ok, result} -> result
+        _ -> []
+      end)
 
     render("_alerts.html",
       routes_with_high_priority_alerts_by_mode: routes,


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Uncaught exit - {:timeout, {Task.Supervised, :stream, [10000]}}](https://app.asana.com/1/15492006741476/project/385363666817452/task/1217493355202399?focus=true)

## Implementation

This is one of the few errors generated under high load. The task times out, and the result isn't properly handled. This PR

- adds `on_timeout: :kill_task` so it gets killed, and outputs a `{:exit, :timeout}` tuple
- catches that tuple and returns an empty list instead 

I don't love it, but the async task which fetches alerts on the homepage currently has similar behavior (when _that_ task times out, it resolves to `[]`).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216391479851803