### PR TITLE
feat(ServicePatterns): separate (no school) services

### DIFF
--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -284,6 +284,7 @@ defmodule Dotcom.ServicePatterns do
          service: %Service{typicality: :typical_service} = service
        }) do
     typical_groups = [
+      {:no_school, nil, fn s -> s.description =~ "(no school)" end},
       {:monday_thursday, ~t"Monday - Thursday schedules",
        fn s ->
          s.type == :weekday &&
@@ -300,8 +301,14 @@ defmodule Dotcom.ServicePatterns do
     ]
 
     case Enum.find(typical_groups, fn {_, _, func} -> func.(service) end) do
-      {key, label, _} -> {:typical, key, label}
-      _ -> {service.typicality, List.first(dates), service.description}
+      {:no_school, _, _} ->
+        {service.typicality, List.first(dates), service.description}
+
+      {key, label, _} ->
+        {:typical, key, label}
+
+      _ ->
+        {service.typicality, List.first(dates), service.description}
     end
   end
 

--- a/test/dotcom/service_patterns_test.exs
+++ b/test/dotcom/service_patterns_test.exs
@@ -70,21 +70,24 @@ defmodule Dotcom.ServicePatternsTest do
       assert patterns_for_route(route_id) == []
     end
 
-    test "renames (no school) typical services" do
+    test "does not rename (no school) typical services" do
       route_id = FactoryHelpers.build(:id)
 
+      no_school_service =
+        build(:service,
+          date: service_date(),
+          description: "Weekdays (no school)",
+          typicality: :typical_service,
+          type: :weekday
+        )
+
       expect(Services.Repo.Mock, :by_route_id, fn _ ->
-        [
-          build(:service,
-            date: service_date(),
-            description: "Weekdays (no school)",
-            typicality: :typical_service,
-            type: :weekday
-          )
-        ]
+        [no_school_service]
       end)
 
-      assert [%{service_label: {:typical, :weekday, "Weekday schedules"}}] =
+      description = no_school_service.description
+
+      assert [%{service_label: {:typical_service, _, ^description}}] =
                patterns_for_route(route_id)
     end
 


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🛜 🐞 Daily Schedules sometimes doesn't show school trips](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217345168848931?focus=true)

## Implementation

The current code merges together typical **services** to show a clean dropdown menu.

<img width="457" height="113" alt="image" src="https://github.com/user-attachments/assets/5991f677-4876-41ec-a049-afa57a136f93" />

The typical services can encompass service across multiple route patterns, some of those which aren't typical. One example is [37-B-1](https://api-dev.mbtace.com/route_patterns/37-B-1), which powers our very occasional school trips on the 37 (typicality of 3). This also has not concept of which stops are actually being served or not - services relate to routes, and route patterns further describe how stops along the route are (or are not) served at a given time.

Anyway, our code was combining `Monday - Thursday schedules (no school)` into `Monday - Thursday schedules` but the underlying datepicker picks the next valid service date, which across the combined services is today (well, yesterday), which isn't actually served at our school-trip-only stops (yet!). Altogether creating a confusing experience.

Because of its behavior in selecting dates which don't have a school trip, it can't show said trip.
The quickest way to resolve this is to stop letting the `"(no school)"` services get merged into the otherwise identical school version of the service, and show them both separately to avoid ambiguity. 

## Screenshots

Before | After

<img width="1567" height="268" alt="image" src="https://github.com/user-attachments/assets/86096727-674e-4c46-b98a-c8f0d9e433b1" />

| Before | After |
|--------|--------|
| <img width="675" height="149" alt="image" src="https://github.com/user-attachments/assets/e726a2a3-ee3e-41cc-b197-7fd5953ae37c" />  |  <img width="622" height="211" alt="image" src="https://github.com/user-attachments/assets/69ad61b9-5394-4041-94e3-1296591c54e9" /> |
| Can't see school Fridays! | <img width="698" height="216" alt="image" src="https://github.com/user-attachments/assets/a659cbc5-0bf9-4225-b15f-bbbef73c4109" /> | 

## How to test

Try it on your favorite routes!

Note - unfortunately, there's still bugs with respect to showing the entire school trip!  The aforementioned example doesn't show stops from Forest Hills to Avenue Louis Pasteur. This'll hopefully be resolved in a future PR.

<img width="746" height="388" alt="image" src="https://github.com/user-attachments/assets/946055dd-407b-4014-9737-ca602262c185" />

