### PR TITLE
chore(load-tests): Length "rest" phases between tests, and add lighter phases

### DIFF
--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -4,26 +4,48 @@ config:
     timeout: 300
     maxSockets: 500
   phases:
+    - name: "10 req / sec"
+      duration: 120
+      arrivalRate: 10
+
+    - name: "Rest"
+      pause: 120
+    - name: "20 req / sec"
+      duration: 120
+      arrivalRate: 20
+
+    - name: "Rest"
+      pause: 120
+    - name: "50 req / sec"
+      duration: 120
+      arrivalRate: 50
+
+    - name: "Rest"
+      pause: 120
     - name: "100 req / sec"
       duration: 120
       arrivalRate: 100
+
     - name: "Rest"
-      pause: 60
+      pause: 120
     - name: "200 req / sec"
       duration: 120
       arrivalRate: 200
+
     - name: "Rest"
-      pause: 60
+      pause: 120
     - name: "500 req / sec"
       duration: 120
       arrivalRate: 500
+
     - name: "Rest"
-      pause: 60
+      pause: 120
     - name: "1k req / sec"
       duration: 120
       arrivalRate: 1000
+
     - name: "Rest"
-      pause: 60
+      pause: 120
     - name: "2k req / sec"
       duration: 120
       arrivalRate: 2000

--- a/integration/load_tests/homepage-heavy-load.yml
+++ b/integration/load_tests/homepage-heavy-load.yml
@@ -7,45 +7,45 @@ config:
     - name: "10 req / sec"
       duration: 120
       arrivalRate: 10
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "20 req / sec"
       duration: 120
       arrivalRate: 20
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "50 req / sec"
       duration: 120
       arrivalRate: 50
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "100 req / sec"
       duration: 120
       arrivalRate: 100
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "200 req / sec"
       duration: 120
       arrivalRate: 200
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "500 req / sec"
       duration: 120
       arrivalRate: 500
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "1k req / sec"
       duration: 120
       arrivalRate: 1000
-
     - name: "Rest"
-      pause: 120
+      pause: 180
+
     - name: "2k req / sec"
       duration: 120
       arrivalRate: 2000


### PR DESCRIPTION
## Scope

No ticket. This fell out of a few discoveries when running the first batch of load tests:
- The first phase - `100 req / sec` - was enough to knock over an older build, so I wanted to add a few lighter phases that would give us useful <100% graphs.
- Having a rest phase of 1 minute wasn't enough to allow the different phases to show up as different on the graphs. This increases the rest phase to ~2 minutes (should I bump it up to 3??)~ _3 minutes_.