### PR TITLE
[Perf]: Optimize `DotcomWeb.PageView._tabbed_nav.html`

### DIFF
--- a/lib/dotcom/cache/persistent_term_warmer.ex
+++ b/lib/dotcom/cache/persistent_term_warmer.ex
@@ -30,6 +30,7 @@ defmodule Dotcom.Cache.PersistentTermWarmer do
         DotcomWeb.PageView.shortcut_icons(code)
         DotcomWeb.PageView.important_links(code)
         DotcomWeb.PageView.top_links(code)
+        DotcomWeb.PageView.tab_list(code)
       end)
     end
     |> Task.await_many()

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -243,7 +243,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp add_url(row) do
     route_id = route_id_from_route_info(row.route_info)
     sub_page = if normal?(row.status_entry), do: "line", else: "alerts"
-    row |> put_in([:route_info, :url], ~p"/schedules/#{route_id}/#{sub_page}")
+    row |> put_in([:route_info, :url], "/schedules/#{route_id}/#{sub_page}")
   end
 
   defp normal?(%{status: :normal}), do: true

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -5,9 +5,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   use DotcomWeb, :component
 
-  use Nebulex.Caching.Decorators
-  @cache Application.compile_env!(:dotcom, :cache)
-
   import Dotcom.Alerts, only: [subheading_data: 1]
   import DotcomWeb.Components, only: [bordered_container: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
@@ -17,14 +14,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   @route_ids ["Red", "Orange", "Green", "Blue"]
 
   attr :subway_status, :any, required: true
-  attr :locale, :any, required: true
 
-  @decorate cacheable(
-              cache: @cache,
-              on_error: :raise,
-              opts: [ttl: :timer.minutes(1)],
-              key: fn assigns -> {"homepage|subway-status", assigns.locale} end
-            )
   def homepage_subway_status(assigns) do
     assigns = assigns |> assign(:rows, status_to_rows(assigns.subway_status))
 

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -5,6 +5,9 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   use DotcomWeb, :component
 
+  use Nebulex.Caching.Decorators
+  @cache Application.compile_env!(:dotcom, :cache)
+
   import Dotcom.Alerts, only: [subheading_data: 1]
   import DotcomWeb.Components, only: [bordered_container: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
@@ -14,7 +17,14 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   @route_ids ["Red", "Orange", "Green", "Blue"]
 
   attr :subway_status, :any, required: true
+  attr :locale, :any, required: true
 
+  @decorate cacheable(
+              cache: @cache,
+              on_error: :raise,
+              opts: [ttl: :timer.minutes(1)],
+              key: fn assigns -> {"homepage|subway-status", assigns.locale} end
+            )
   def homepage_subway_status(assigns) do
     assigns = assigns |> assign(:rows, status_to_rows(assigns.subway_status))
 

--- a/lib/dotcom_web/templates/page/_tab_list.html.heex
+++ b/lib/dotcom_web/templates/page/_tab_list.html.heex
@@ -1,0 +1,51 @@
+<div class="nav m-tabbed-nav__items" role="tablist">
+  <div class="m-tabbed-nav__item-container">
+    <a
+      tabindex="0"
+      class="nav-link m-tabbed-nav__item active"
+      role="tab"
+      data-toggle="tab"
+      data-tab-type="schedules"
+      aria-controls="schedules-content"
+      aria-selected="true"
+      aria-current="page"
+    >
+      <span aria-hidden="true">
+        {svg("icon-map-default.svg")}
+      </span>
+      <span href="/schedules" class="m-tabbed-nav__icon-text">{~t(Routes)}</span>
+    </a>
+  </div>
+  <div class="m-tabbed-nav__item-container">
+    <a
+      tabindex="-1"
+      class="nav-link m-tabbed-nav__item"
+      role="tab"
+      data-toggle="tab"
+      data-tab-type="trip-planner"
+      aria-controls="trip-planner-content"
+      aria-selected="false"
+    >
+      <span aria-hidden="true">
+        {svg("icon-trip-planner-default.svg")}
+      </span>
+      <span href="/trip-planner" class="m-tabbed-nav__icon-text">{~t(Trip Planner)}</span>
+    </a>
+  </div>
+  <div class="m-tabbed-nav__item-container">
+    <a
+      tabindex="-1"
+      class="nav-link m-tabbed-nav__item"
+      role="tab"
+      data-toggle="tab"
+      data-tab-type="alerts"
+      aria-controls="alerts-content"
+      aria-selected="false"
+    >
+      <span aria-hidden="true">
+        {svg("icon-alerts-default.svg")}
+      </span>
+      <span href="/alerts" class="m-tabbed-nav__icon-text">{~t(Alerts)}</span>
+    </a>
+  </div>
+</div>

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -1,55 +1,5 @@
 <nav class="m-tabbed-nav" role="navigation" aria-label="main page tabs">
-  <div class="nav m-tabbed-nav__items" role="tablist">
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="0"
-        class="nav-link m-tabbed-nav__item active"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="schedules"
-        aria-controls="schedules-content"
-        aria-selected="true"
-        aria-current="page"
-      >
-        <span aria-hidden="true">
-          {svg("icon-map-default.svg")}
-        </span>
-        <span href="/schedules" class="m-tabbed-nav__icon-text">{~t(Routes)}</span>
-      </a>
-    </div>
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="-1"
-        class="nav-link m-tabbed-nav__item"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="trip-planner"
-        aria-controls="trip-planner-content"
-        aria-selected="false"
-      >
-        <span aria-hidden="true">
-          {svg("icon-trip-planner-default.svg")}
-        </span>
-        <span href="/trip-planner" class="m-tabbed-nav__icon-text">{~t(Trip Planner)}</span>
-      </a>
-    </div>
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="-1"
-        class="nav-link m-tabbed-nav__item"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="alerts"
-        aria-controls="alerts-content"
-        aria-selected="false"
-      >
-        <span aria-hidden="true">
-          {svg("icon-alerts-default.svg")}
-        </span>
-        <span href="/alerts" class="m-tabbed-nav__icon-text">{~t(Alerts)}</span>
-      </a>
-    </div>
-  </div>
+  {tab_list(@locale)}
   <div class="m-tabbed-nav__content">
     <div
       role="tabpanel"

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -38,7 +38,7 @@
       class="m-tabbed-nav__content-item"
       data-tab-content-type="alerts"
     >
-      {alerts(@conn.assigns.alerts)}
+      {alerts(@conn.assigns)}
     </div>
   </div>
 </nav>

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -24,6 +24,7 @@ defmodule DotcomWeb.PageView do
   @spec alerts(%{alerts: [Alerts.Alert.t()], locale: String.t()}) :: Phoenix.HTML.Safe.t()
   def alerts(%{alerts: alerts, locale: locale}) do
     _ = locale
+
     [routes, stops] =
       [
         &Dotcom.Alerts.routes_with_high_priority_alerts_by_mode/1,

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -249,4 +249,10 @@ defmodule DotcomWeb.PageView do
        |> Enum.map(&Phoenix.View.render_to_iodata(DotcomWeb.PageView, &1, %{}))}
     end)
   end
+
+  def tab_list(locale) do
+    Util.get_or_save_persistent_term({__MODULE__, :tab_list, locale}, fn ->
+      {:safe, Phoenix.View.render_to_iodata(DotcomWeb.PageView, "_tab_list.html", %{})}
+    end)
+  end
 end

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -21,7 +21,7 @@ defmodule DotcomWeb.PageView do
               opts: [ttl: :timer.minutes(1)],
               key: {"homepage|alerts-tab", locale}
             )
-  @spec alerts([Alerts.Alert.t()]) :: Phoenix.HTML.Safe.t()
+  @spec alerts(%{alerts: [Alerts.Alert.t()], locale: String.t()}) :: Phoenix.HTML.Safe.t()
   def alerts(%{alerts: alerts, locale: locale}) do
     [routes, stops] =
       [

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -23,6 +23,7 @@ defmodule DotcomWeb.PageView do
             )
   @spec alerts(%{alerts: [Alerts.Alert.t()], locale: String.t()}) :: Phoenix.HTML.Safe.t()
   def alerts(%{alerts: alerts, locale: locale}) do
+    _ = locale
     [routes, stops] =
       [
         &Dotcom.Alerts.routes_with_high_priority_alerts_by_mode/1,

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -19,10 +19,10 @@ defmodule DotcomWeb.PageView do
               cache: @cache,
               on_error: :raise,
               opts: [ttl: :timer.minutes(1)],
-              key: {"homepage|alerts-tab", assigns.locale}
+              key: {"homepage|alerts-tab", locale}
             )
   @spec alerts([Alerts.Alert.t()]) :: Phoenix.HTML.Safe.t()
-  def alerts(%{alerts: alerts, locale: locale} = assigns) do
+  def alerts(%{alerts: alerts, locale: locale}) do
     [routes, stops] =
       [
         &Dotcom.Alerts.routes_with_high_priority_alerts_by_mode/1,

--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -15,8 +15,14 @@ defmodule DotcomWeb.PageView do
   alias CMS.Partial.Banner
   alias DotcomWeb.PartialView
 
+  @decorate cacheable(
+              cache: @cache,
+              on_error: :raise,
+              opts: [ttl: :timer.minutes(1)],
+              key: {"homepage|alerts-tab", assigns.locale}
+            )
   @spec alerts([Alerts.Alert.t()]) :: Phoenix.HTML.Safe.t()
-  def alerts(alerts) do
+  def alerts(%{alerts: alerts, locale: locale} = assigns) do
     [routes, stops] =
       [
         &Dotcom.Alerts.routes_with_high_priority_alerts_by_mode/1,

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -460,7 +460,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "Route %{route}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr ""
@@ -4457,7 +4457,7 @@ msgstr ""
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -460,7 +460,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "Route %{route}"
 msgstr ""
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr ""
@@ -4457,7 +4457,7 @@ msgstr ""
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -460,7 +460,7 @@ msgstr "alerta"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3459,7 +3459,7 @@ msgstr "Ruta %{name}"
 msgid "Route %{route}"
 msgstr "Ruta %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Rutas"
@@ -4475,7 +4475,7 @@ msgstr "Viaje"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -460,7 +460,7 @@ msgstr "alerte"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3461,7 +3461,7 @@ msgstr "Itinéraire %{name}"
 msgid "Route %{route}"
 msgstr "Itinéraire %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Itinéraires"
@@ -4476,7 +4476,7 @@ msgstr "Voyage"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -460,7 +460,7 @@ msgstr "avètisman"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3452,7 +3452,7 @@ msgstr "Wout %{name}"
 msgid "Route %{route}"
 msgstr "Wout %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Wout yo"
@@ -4465,7 +4465,7 @@ msgstr "Vwayaj"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -460,7 +460,7 @@ msgstr "alerta"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3457,7 +3457,7 @@ msgstr "Rota %{name}"
 msgid "Route %{route}"
 msgstr "Rota %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Rotas"
@@ -4472,7 +4472,7 @@ msgstr "Viagem"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -454,7 +454,7 @@ msgstr "cảnh báo"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3453,7 +3453,7 @@ msgstr "Tuyến đường %{name}"
 msgid "Route %{route}"
 msgstr "Tuyến đường %{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "Tuyến đường"
@@ -4467,7 +4467,7 @@ msgstr "Chuyến đi"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -454,7 +454,7 @@ msgstr "警报"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3439,7 +3439,7 @@ msgstr "路线%{name}"
 msgid "Route %{route}"
 msgstr "路线%{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "路线"
@@ -4451,7 +4451,7 @@ msgstr "旅行"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -454,7 +454,7 @@ msgstr "警報"
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
@@ -3439,7 +3439,7 @@ msgstr "路線%{name}"
 msgid "Route %{route}"
 msgstr "路線%{route}"
 
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #, elixir-autogen, elixir-format
 msgid "Routes"
 msgstr "路線"
@@ -4451,7 +4451,7 @@ msgstr "旅行"
 
 #: lib/dotcom_web/hooks/breadcrumbs.ex
 #: lib/dotcom_web/live/trip_planner_live.ex
-#: lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+#: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/views/layout_view.ex
 #: lib/feedback/message.ex
 #, elixir-autogen, elixir-format

--- a/test/dotcom_web/views/page_view_test.exs
+++ b/test/dotcom_web/views/page_view_test.exs
@@ -123,7 +123,7 @@ defmodule DotcomWeb.PageViewTest do
       ]
 
       rendered =
-        PageView.alerts(alerts)
+        PageView.alerts(%{alerts: alerts, locale: "en-us"})
         |> Phoenix.HTML.Safe.to_iodata()
         |> IO.iodata_to_binary()
 


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📈 Optimize `DotcomWeb.PageView._tabbed_nav.html`](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217663241793923?focus=true)

## Implementation

Used our new static cache to cache our static HTML for the tab list.
Replaced `~p` with a plain string in subway status `add_url` which is much faster
Used our dynamic cache to cache the alerts HTML with locale in the key and a TTL of 1 minute. 
Went ahead and added a dynamic cache to subway_status as well 

Old render time: >7000 µs
New render time <500 µs

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Main (>7000µs)
<img width="1276" height="875" alt="flame_on (4)" src="https://github.com/user-attachments/assets/a53071d7-1815-4356-8589-2bc32ab56f31" />

### This branch (<1000µs)
<img width="1276" height="900" alt="flame_on (3)" src="https://github.com/user-attachments/assets/21fe55bf-8ef6-4bef-a9d9-81f21d3366bb" />





## How to test

http://localhost:4001/ - Confirm everything looks the same and works the same across all languages.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
