### PR TITLE
[Perf]: Optimize what's happening section rendering

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -110,12 +110,6 @@ defmodule CMS.Repo do
     end
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              key: "cms.repo|whats-happening",
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   def do_whats_happening do
     @cms_api.view("/cms/whats-happening", [])
   end

--- a/lib/dotcom_web/controllers/page_controller.ex
+++ b/lib/dotcom_web/controllers/page_controller.ex
@@ -81,6 +81,12 @@ defmodule DotcomWeb.PageController do
     |> Enum.map(&add_utm_url/1)
   end
 
+  @decorate cacheable(
+              cache: @cache,
+              key: "PageController.whats_happening_items",
+              on_error: :nothing,
+              opts: [ttl: @ttl]
+            )
   @spec whats_happening_items :: whats_happening_set
   defp whats_happening_items do
     Repo.whats_happening()
@@ -108,12 +114,6 @@ defmodule DotcomWeb.PageController do
     {nil, nil}
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              key: {"PageController.split_add_utm_url", promoted, rest},
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   defp split_add_utm_url({promoted, rest}) do
     {
       Enum.map(promoted, &add_utm_url(&1, true)),

--- a/lib/dotcom_web/controllers/page_controller.ex
+++ b/lib/dotcom_web/controllers/page_controller.ex
@@ -3,6 +3,7 @@ defmodule DotcomWeb.PageController do
 
   use Dotcom.Gettext.Sigils
   use DotcomWeb, :controller
+  use Nebulex.Caching.Decorators
 
   import DotcomWeb.CMSHelpers, only: [cms_route_to_class: 1]
   import CMS.Repo, only: [photo: 0]
@@ -22,6 +23,9 @@ defmodule DotcomWeb.PageController do
   @type whats_happening_set :: {nil | [WhatsHappeningItem.t()], nil | [WhatsHappeningItem.t()]}
 
   @subway_status_cache Application.compile_env!(:dotcom, :system_status_cache_modules)[:subway]
+
+  @cache Application.compile_env!(:dotcom, :cache)
+  @ttl :timer.hours(4)
 
   def index(conn, _params) do
     {promoted, remainder} = whats_happening_items()
@@ -104,6 +108,12 @@ defmodule DotcomWeb.PageController do
     {nil, nil}
   end
 
+  @decorate cacheable(
+              cache: @cache,
+              key: {"PageController.split_add_utm_url", promoted, rest},
+              on_error: :nothing,
+              opts: [ttl: @ttl]
+            )
   defp split_add_utm_url({promoted, rest}) do
     {
       Enum.map(promoted, &add_utm_url(&1, true)),

--- a/lib/url_helpers.ex
+++ b/lib/url_helpers.ex
@@ -4,6 +4,10 @@ defmodule UrlHelpers do
   alias DotcomWeb.CmsRouterHelpers
   alias Plug.Conn.Query
 
+  use Nebulex.Caching.Decorators
+  @cache Application.compile_env!(:dotcom, :cache)
+  @ttl :timer.hours(4)
+
   @spec update_url(Plug.Conn.t(), Enum.t()) :: String.t()
   def update_url(conn, query) do
     conn.query_params
@@ -75,6 +79,12 @@ defmodule UrlHelpers do
     |> URI.to_string()
   end
 
+  @decorate cacheable(
+              cache: @cache,
+              key: "url_helpers|build_utm_params",
+              on_error: :nothing,
+              opts: [ttl: @ttl]
+            )
   defp build_utm_params(item, opts) when is_list(opts) do
     URI.encode_query(%{
       utm_medium: Keyword.fetch!(opts, :type),

--- a/lib/url_helpers.ex
+++ b/lib/url_helpers.ex
@@ -4,10 +4,6 @@ defmodule UrlHelpers do
   alias DotcomWeb.CmsRouterHelpers
   alias Plug.Conn.Query
 
-  use Nebulex.Caching.Decorators
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(4)
-
   @spec update_url(Plug.Conn.t(), Enum.t()) :: String.t()
   def update_url(conn, query) do
     conn.query_params
@@ -79,12 +75,6 @@ defmodule UrlHelpers do
     |> URI.to_string()
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              key: "url_helpers|build_utm_params",
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   defp build_utm_params(item, opts) when is_list(opts) do
     URI.encode_query(%{
       utm_medium: Keyword.fetch!(opts, :type),


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📈 Optimize what's happening section rendering](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217663241793919?focus=true)

## Implementation

Added a cache to `page_controller.whats_happening_items/0` since the URL encoding inside was a bit slow.  I first tried only escaping the content parameter and just concatenating the rest, but that didn't make much difference.  So I'm back to using my favorite new hammer: function caches.  

There was a cache already in the CMS repo for the data that supplies this function, but I don't like the idea of stacked caches. I can imagine a race condition that makes us wait `2*@TTL` for an update, so I removed the Repo cache for `whats_happening()`.  This way the cache will contain the final output instead of the data to calculate it.

Summary: Execution time went from ~6000us to ~180us in exchange for about 3k of memory (probably less, since I got rid of the Repo cache).

Let me know if I'm using my shiny new cache hammers too often on all these performance nails I see.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Main Whats Happening
<img width="1276" height="1750" alt="Main_WhatsHappening" src="https://github.com/user-attachments/assets/dea51da2-3b71-4bae-acbb-95d3acc6b1f9" />

### Branch Whats Happening (aka a cache hit)
<img width="1276" height="875" alt="Branch_WH" src="https://github.com/user-attachments/assets/880ae4ef-72ac-4f48-8168-98e5869e0506" />



## How to test

http://localhost:4001/?locale=en - Confirm that the What's Happening section still shows up, no change should be visible except speed.  You (probably) have to be on VPN for the CMS to work, at least that's how my setup is configured.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
