### PR TITLE
[Perf]: Optimize news entry rendering

### DIFF
--- a/lib/dotcom_web/views/page_view.ex
+++ b/lib/dotcom_web/views/page_view.ex
@@ -169,6 +169,13 @@ defmodule DotcomWeb.PageView do
     content_tag(:span, "|", aria_hidden: "true", class: "schedule-separator")
   end
 
+  @decorate cacheable(
+              cache: @cache,
+              on_error: :raise,
+              opts: [ttl: @ttl],
+              # Even though the text isn't translated, the dates are so locale is part of the key
+              key: {"homepage|news-entries", conn.assigns.locale}
+            )
   @spec render_news_entries(Plug.Conn.t()) :: Phoenix.HTML.Safe.t()
   def render_news_entries(conn) do
     content_tag(

--- a/test/dotcom_web/views/page_view_test.exs
+++ b/test/dotcom_web/views/page_view_test.exs
@@ -73,6 +73,7 @@ defmodule DotcomWeb.PageViewTest do
       document =
         conn
         |> assign(:news, entries)
+        |> assign(:locale, "en-US")
         |> PageView.render_news_entries()
         |> Phoenix.HTML.Safe.to_iodata()
         |> IO.iodata_to_binary()


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📈 Optimize news entry rendering](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217663241793917?focus=true)

## Implementation

I attempted to optimize HTML rendering without using caches but date formatting and SVG rendering were the major time sinks and aren't easily optimized or avoidable.  So this gets a function cache instead.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Main flamegraph (17000µs)
<img width="1276" height="1300" alt="flame_on (7)" src="https://github.com/user-attachments/assets/b7651852-9371-40c1-aedf-fc7ca3988d1f" />

### Local flamegraph (350µs)
<img width="1276" height="900" alt="flame_on (6)" src="https://github.com/user-attachments/assets/358b9ce1-2bdb-4b18-a6b5-b7d91b364f1a" />


## How to test

http://localhost:4001/?locale=en  - Confirm that the Press Releases section still works as expected

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
