### PR TITLE
QF | BadMapError: expected a map, got: nil

### DIFF
--- a/lib/dotcom_web/controllers/schedule_controller.ex
+++ b/lib/dotcom_web/controllers/schedule_controller.ex
@@ -176,8 +176,14 @@ defmodule DotcomWeb.ScheduleController do
   defp trim_response(schedules) do
     schedules
     |> Enum.map(&Map.drop(&1, [:stop]))
-    |> Enum.map(fn %Schedule{route: route} = schedule ->
-      %Schedule{schedule | route: Map.take(route, [:id])}
-    end)
+    |> Enum.map(fn schedule -> route_to_id(schedule) end)
+  end
+
+  defp route_to_id(%Schedule{route: nil} = schedule) do
+    schedule
+  end
+
+  defp route_to_id(%Schedule{route: route} = schedule) do
+    %Schedule{schedule | route: Map.take(route, [:id])}
   end
 end

--- a/test/dotcom_web/controllers/schedule_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule_controller_test.exs
@@ -452,6 +452,26 @@ defmodule DotcomWeb.ScheduleControllerTest do
         assert log =~ "no_schedules_returned"
       end
     end
+
+    test "doesn't crash when a nil route is encountered", %{conn: conn} do
+      with_mock(Schedules.Repo, [:passthrough],
+        schedules_for_stop: fn
+          "TEST 1234", _ ->
+            [
+              %Schedules.Schedule{
+                route: nil,
+                stop: %Stops.Stop{id: "TEST 1234"},
+                departure_time: ~U[2219-05-18 22:25:06.098765Z]
+              }
+            ]
+        end
+      ) do
+        conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+        body = json_response(conn, 200)
+        assert Kernel.length(body) == 1
+        assert %{"departure_time" => "2219-05-18T22:25:06.098765Z"} = Enum.at(body, 0)
+      end
+    end
   end
 
   describe "route redirects" do


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | BadMapError: expected a map, got:](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216804181069935?focus=true)

## Implementation

The schedule controller was encountering data where the route was unexpectedly nil.  The particular code in question was updating `route = route.id` but `route` was `nil`.  I figured that means the id is nil too.   Added a unit test for this edge case.


Turns out this function is there to reformat data before it is returned via the API as JSON. One one hand, this PR solves this particular error, this request should not crash when encountering this type of data.  On the other hand, if the consumer of this API data isn't expecting route to be `nil/null` then this just kicks the can down the road.  

I'll try to find a consumer for this call and see what's what.

Update: From what I can tell this API call is only used by the stop page.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

Unit test

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
