### PR TITLE
Line Page | Set up a feature flagged "Schedules & Maps (new)" tab and page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -134,7 +134,9 @@ config :laboratory,
      "Uses the new timetable component and logic for all timetables"},
     {:use_smartling_translations, "Smartling translations",
      "Uses Smartling's translation workflows"},
-    {:fares_v2, "Fares v2", "Exposes information from GTFS Fares V2 in trip plans"}
+    {:fares_v2, "Fares v2", "Exposes information from GTFS Fares V2 in trip plans"},
+    {:line_diagram, "New Line Diagram",
+     "Adds a tab to the schedules page for the new line diagram"}
   ],
   cookie: [
     # one month,

--- a/config/test.exs
+++ b/config/test.exs
@@ -72,7 +72,9 @@ config :laboratory,
     {:test_flag, "Cool Bean", "cool bean for test"},
     {:use_smartling_translations, "Smartling translations",
      "Uses Smartling's translation workflows"},
-    {:fares_v2, "Fares v2", "Exposes information from GTFS Fares V2 in trip plans"}
+    {:fares_v2, "Fares v2", "Exposes information from GTFS Fares V2 in trip plans"},
+    {:line_diagram, "New Line Diagram",
+     "Adds a tab to the schedules page for the new line diagram"}
   ],
   cookie: [
     # one month,

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -23,7 +23,7 @@ defmodule DotcomWeb.LineDiagramLive do
 
     ~H"""
     <marquee style="font-size:2cm" scrollamount="16" scrolldelay="60">
-      Hello World
+      🚧 Under Construction 🚧
     </marquee>
     """
   end

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -7,7 +7,7 @@ defmodule DotcomWeb.LineDiagramLive do
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
 
   def mount(params, _session, socket) do
-    route_id = params |> Map.get("route_id", "Red")
+    route_id = params |> Map.get("route_id")
     direction_id = params |> Map.get("direction_id", "1")
     route_patterns = @route_patterns_repo.by_route_id(route_id)
 

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -1,0 +1,28 @@
+defmodule DotcomWeb.LineDiagramLive do
+  @moduledoc """
+  The primary view for looking up stops, maps, and schedules for a particular line
+  """
+
+  use DotcomWeb, :live_view
+  @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
+
+  def mount(params, _session, socket) do
+    route_id = params |> Map.get("route_id", "Red")
+    direction_id = params |> Map.get("direction_id", "1")
+    route_patterns = @route_patterns_repo.by_route_id(route_id)
+
+    {:ok,
+     socket
+     |> assign(:direction_id, direction_id)
+     |> assign(:route_patterns, route_patterns)
+     |> assign(:route_id, route_id)}
+  end
+
+  def render(assigns) do
+    dbg(assigns)
+
+    ~H"""
+    <marquee>Hello World</marquee>
+    """
+  end
+end

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -19,8 +19,6 @@ defmodule DotcomWeb.LineDiagramLive do
   end
 
   def render(assigns) do
-    dbg(assigns)
-
     ~H"""
     <marquee style="font-size:2cm" scrollamount="16" scrolldelay="60">
       🚧 Under Construction 🚧

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -22,7 +22,9 @@ defmodule DotcomWeb.LineDiagramLive do
     dbg(assigns)
 
     ~H"""
-    <marquee>Hello World</marquee>
+    <marquee style="font-size:2cm" scrollamount="16" scrolldelay="60">
+      Hello World
+    </marquee>
     """
   end
 end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -122,6 +122,17 @@ defmodule DotcomWeb.Router do
     end
   end
 
+  scope "/schedules", DotcomWeb do
+    import Phoenix.LiveView.Router
+    pipe_through([:browser, :browser_live])
+
+    live_session :schedules,
+      layout: {DotcomWeb.LayoutView, :live},
+      on_mount: DotcomWeb.Plugs.PutFlagsInAssignsHook do
+      live("/:route_id/line_new", LineDiagramLive)
+    end
+  end
+
   scope "/", DotcomWeb do
     pipe_through([:secure, :browser])
 

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -309,7 +309,7 @@ defmodule DotcomWeb.ScheduleView do
         [
           %HeaderTab{
             id: "new_line_diagram",
-            name: ~t"Line Diagram",
+            name: ~t"Schedules & Maps (new)",
             href: line_path
           }
           | tabs

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -305,7 +305,7 @@ defmodule DotcomWeb.ScheduleView do
     ]
 
     tabs =
-      if conn.assigns.line_diagram do
+      if conn.assigns |> Map.get(:line_diagram, false) do
         [
           %HeaderTab{
             id: "new_line_diagram",

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -291,6 +291,7 @@ defmodule DotcomWeb.ScheduleView do
     route = conn.assigns.route
     tab_params = conn.assigns.tab_params
     info_link = line_path(conn, :show, route.id, tab_params)
+    line_path = info_link |> String.replace("/line", "/line_new")
     timetable_link = timetable_path(conn, :show, route.id, tab_params)
     alerts_link = alerts_path(conn, :show, route.id, tab_params)
 
@@ -302,6 +303,20 @@ defmodule DotcomWeb.ScheduleView do
         badge: conn |> alert_count() |> alert_badge()
       }
     ]
+
+    tabs =
+      if conn.assigns.line_diagram do
+        [
+          %HeaderTab{
+            id: "new_line_diagram",
+            name: ~t"Line Diagram",
+            href: line_path
+          }
+          | tabs
+        ]
+      else
+        tabs
+      end
 
     tabs =
       case route.type do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5380,6 +5380,7 @@ msgstr ""
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
+msgstr ""
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5396,3 +5396,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr ""
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -5380,6 +5380,7 @@ msgstr ""
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
+msgstr ""
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -5396,3 +5396,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr ""
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5403,7 +5403,7 @@ msgstr "%{direction_name} calendario para %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "horario & Mapas (nuevo)"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -5419,3 +5419,8 @@ msgstr "Trenes"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendario para %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5403,7 +5403,7 @@ msgstr "%{direction_name} calendrier pour %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "Horaire & Cartes (nouveau)"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -5419,3 +5419,8 @@ msgstr "Trains"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendrier pour %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5406,3 +5406,8 @@ msgstr "Tren yo"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Orè %{direction_name} pou %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -5390,7 +5390,7 @@ msgstr "Orè %{direction_name} pou %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "orè ak Kat (nouvo)"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5415,3 +5415,8 @@ msgstr "Trens"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Horário %{direction_name} para %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -5399,7 +5399,7 @@ msgstr "Horário %{direction_name} para %{route_name}, %{formatted_date}"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "Horário e mapas (novo)"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5394,7 +5394,7 @@ msgstr "%{direction_name} thời khóa biểu cho %{route_name}, %{formatted_dat
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "lịch trình & Bản đồ (mới)"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -5410,3 +5410,8 @@ msgstr "Tàu hỏa"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} thời khóa biểu cho %{route_name}, %{formatted_date}"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5390,3 +5390,8 @@ msgstr "火车"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的时间表"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -5374,7 +5374,7 @@ msgstr "%{direction_name} %{route_name}、%{formatted_date} 的时间表"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "时刻表和地图（新增）"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5390,3 +5390,8 @@ msgstr "火車"
 #, elixir-autogen, elixir-format
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的時間表"
+
+#: lib/dotcom_web/views/schedule_view.ex
+#, elixir-autogen, elixir-format
+msgid "Schedules & Maps (new)"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -5374,7 +5374,7 @@ msgstr "%{direction_name} %{route_name}、%{formatted_date} 的時間表"
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"
-msgstr ""
+msgstr "時刻表和地圖（新增）"
 
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🚩💈Line Page | Set up a feature flagged "Schedules & Maps (new)" tab and page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217398531030279?focus=true)

## Implementation

Added a new feature flag
Added a new tab to the /schedules page when that flag is enabled
Created a new live view with a few prepared assigns
Added that live view to the router


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Feature Flag
<img width="791" height="437" alt="Screenshot 2026-08-31 at 1 46 44 PM" src="https://github.com/user-attachments/assets/6ce79cae-2155-4c5a-9760-7af03c35f383" />

### New Tab
<img width="895" height="234" alt="Screenshot 2026-08-31 at 1 46 13 PM" src="https://github.com/user-attachments/assets/e38f506d-8de1-4ab6-9683-16031cd4f7ae" />

### New tab is gone when flag is off
<img width="902" height="234" alt="Screenshot 2026-08-31 at 1 46 54 PM" src="https://github.com/user-attachments/assets/c4718048-9e37-40e1-93a0-5e4a67a31565" />

### New (blank) live view
<img width="1507" height="366" alt="Screenshot 2026-08-31 at 1 54 46 PM" src="https://github.com/user-attachments/assets/ebd64108-b3a4-4bc4-a5e2-1e320f666374" />


## How to test

http://localhost:4001/_flags - Confirm the new flag is there 
http://localhost:4001/schedules/Red/line - Confirm the new tab is visible and links to the new (mostly empty) live view


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
