### PR TITLE
feat(Departures): show in-seat transfers

### DIFF
--- a/lib/dotcom/schedule_finder.ex
+++ b/lib/dotcom/schedule_finder.ex
@@ -61,6 +61,18 @@ defmodule Dotcom.ScheduleFinder do
           }
   end
 
+  defmodule TripHeading do
+    @moduledoc """
+    A headsign-route pairing
+    """
+    defstruct [:headsign, :route]
+
+    @type t :: %__MODULE__{
+            headsign: Trip.headsign(),
+            route: Route.t()
+          }
+  end
+
   @impl Dotcom.ScheduleFinder.Behaviour
   def current_alerts(stop, route) do
     route.id
@@ -153,9 +165,19 @@ defmodule Dotcom.ScheduleFinder do
       schedules when is_list(schedules) ->
         arrivals =
           schedules
-          |> Stream.filter(&makes_subsequent_stop?(&1, min_stop_sequence))
-          |> Stream.map(&to_arrival/1)
-          |> Enum.to_list()
+          |> Stream.filter(&makes_subsequent_stop?(&1, trip_id, min_stop_sequence))
+          |> Stream.chunk_by(& &1.trip.id)
+          |> Stream.with_index(fn
+            trip_schedules, 0 ->
+              Enum.map(trip_schedules, &to_arrival/1)
+
+            [next_schedule | more_schedules], _ ->
+              [
+                to_trip_heading(next_schedule)
+                | Enum.map(more_schedules, &to_arrival/1)
+              ]
+          end)
+          |> Enum.flat_map(& &1)
 
         {:ok, arrivals}
 
@@ -164,9 +186,21 @@ defmodule Dotcom.ScheduleFinder do
     end
   end
 
+  def to_trip_heading(%{trip: trip, route: route}) do
+    %TripHeading{
+      headsign: trip.headsign,
+      route: route
+    }
+  end
+
   # Instead of every stop in the trip, only return schedules that make later stops on the trip, as defined by the given `stop_sequence` value
+  defp makes_subsequent_stop?(%Schedule{trip: trip}, trip_id, _) when trip_id != trip.id do
+    true
+  end
+
   defp makes_subsequent_stop?(
          %Schedule{stop_sequence: stop_sequence},
+         _,
          min_stop_sequence
        ) do
     stop_sequence >= min_stop_sequence

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -110,7 +110,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
       class="container"
       id={"#{@route.id}-#{@direction_id}-#{@stop.id}-schedule-finder"}
     >
-      <div class="flex flex-col gap-y-xl max-w-xl mx-auto mt-xl">
+      <div class="flex flex-col gap-y-xl max-w-xl mx-auto mt-xl relative">
         <.alert_banner alerts={@alerts} />
         <section>
           <h2 class="mt-0 mb-md">{~t"Upcoming Departures"}</h2>
@@ -529,12 +529,12 @@ defmodule DotcomWeb.ScheduleFinderLive do
   defp departures_table(assigns) do
     ~H"""
     <div
-      class="grid grid-cols-1 divide-y-xs divide-gray-lightest border-xs border-gray-lightest"
+      class="divide-y-xs divide-gray-lightest border-xs border-gray-lightest"
       data-test="departures_table"
     >
       <.unstyled_accordion
         :for={departure <- @departures}
-        summary_class="flex items-center gap-sm hover:bg-brand-primary-lightest px-sm py-3"
+        summary_class="flex items-center gap-sm bg-white hover:bg-brand-primary-lightest px-sm py-3 sticky top-0 z-50 group-open:border-b-xs group-open:border-gray-lightest"
         phx-click="open_trip"
         phx-value-schedule_id={departure.schedule_id}
         phx-value-stop_sequence={departure.stop_sequence}

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -575,19 +575,39 @@ defmodule DotcomWeb.ScheduleFinderLive do
               </.error_container>
             </:failed>
             <.lined_list :if={arrivals}>
-              <.lined_list_item
-                :for={{arrival, index} <- Enum.with_index(arrivals)}
-                route={departure.route}
-                class={if(index == 0, do: "font-bold")}
-                stop_pin?={index == 0}
-              >
-                <DotcomWeb.Components.Departures.stop_label
-                  stop_name={arrival.stop_name}
-                  platform_name={arrival.platform_name}
-                />
+              <%= for {heading_or_arrival, index} <- Enum.with_index(arrivals) do %>
+                <%= if match?(%Dotcom.ScheduleFinder.TripHeading{}, heading_or_arrival) do %>
+                  <.lined_list_item
+                    route={heading_or_arrival.route}
+                    variant="none"
+                  >
+                    <div class="flex-col w-full">
+                      <div class="text-charcoal-30 text-sm text-nowrap">{~t"Continues as"}</div>
+                      <div class="flex items-center gap-sm">
+                        <RouteComponents.route_icon
+                          route={heading_or_arrival.route}
+                          size="small"
+                          class="shrink-0"
+                        />
+                        <span>{heading_or_arrival.headsign}</span>
+                      </div>
+                    </div>
+                  </.lined_list_item>
+                <% else %>
+                  <.lined_list_item
+                    route={departure.route}
+                    class={if(index == 0, do: "font-bold")}
+                    stop_pin?={index == 0}
+                  >
+                    <DotcomWeb.Components.Departures.stop_label
+                      stop_name={heading_or_arrival.stop_name}
+                      platform_name={heading_or_arrival.platform_name}
+                    />
 
-                <Departures.formatted_time time={arrival.time} />
-              </.lined_list_item>
+                    <Departures.formatted_time time={heading_or_arrival.time} />
+                  </.lined_list_item>
+                <% end %>
+              <% end %>
             </.lined_list>
           </.async_result>
         </:content>

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -332,7 +332,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
         phx-value-trip-id={upcoming_departure.trip_id}
         phx-value-stop-sequence={upcoming_departure.stop_sequence}
         id={"upcoming-departure-#{upcoming_departure.trip_id}-#{upcoming_departure.stop_sequence}"}
-        summary_class="flex items-center border-gray-lightest py-3 px-2 gap-2 group-open:bg-gray-lightest hover:bg-brand-primary-lightest group-open:hover:bg-brand-primary-lightest"
+        summary_class="flex items-center border-gray-lightest py-3 px-2 gap-2 bg-white group-open:bg-gray-lightest hover:bg-brand-primary-lightest group-open:hover:bg-brand-primary-lightest sticky top-0 z-50 group-open:border-b-xs group-open:border-gray-lightest"
       >
         <:heading>
           <.upcoming_departure_heading upcoming_departure={upcoming_departure} />

--- a/lib/schedules/repo.ex
+++ b/lib/schedules/repo.ex
@@ -11,7 +11,7 @@ defmodule Schedules.Repo do
 
   alias Dotcom.Cache.KeyGenerator
   alias MBTA.Api.Trips
-  alias Schedules.{Parser, Repo.Behaviour, Schedule}
+  alias Schedules.{Parser, Repo.Behaviour, Schedule, Trip}
   alias Util
 
   @behaviour Behaviour
@@ -61,6 +61,8 @@ defmodule Schedules.Repo do
   @impl Behaviour
   def schedule_for_trip(trip_id, opts \\ [])
 
+  def schedule_for_trip(nil, _), do: []
+
   def schedule_for_trip("", _) do
     # shortcut a known invalid trip ID
     []
@@ -74,6 +76,18 @@ defmodule Schedules.Repo do
     |> cache_all_from_params()
     |> filter_by_min_time(Keyword.get(opts, :min_time))
     |> load_from_other_repos
+    |> append_in_seat_transfer_trips(opts)
+  end
+
+  defp append_in_seat_transfer_trips(schedules, opts) do
+    with %Schedule{trip: trip} <- List.last(schedules),
+         %Trip{next_trip_id: next_trip_id} <- trip do
+      schedules
+      |> Enum.concat(schedule_for_trip(next_trip_id, opts))
+    else
+      _ ->
+        schedules
+    end
   end
 
   def schedules_for_stop(stop_id, opts) do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -5402,3 +5402,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr ""
+
+#: lib/dotcom_web/live/schedule_finder_live.ex
+#, elixir-autogen, elixir-format
+msgid "Continues as"
+msgstr ""

--- a/test/dotcom/schedule_finder_test.exs
+++ b/test/dotcom/schedule_finder_test.exs
@@ -4,12 +4,13 @@ defmodule Dotcom.ScheduleFinderTest do
   import Dotcom.ScheduleFinder
   import Mox
 
-  alias Dotcom.ScheduleFinder.{DailyDeparture, FutureArrival, Platforms}
+  alias Dotcom.ScheduleFinder.{DailyDeparture, FutureArrival, Platforms, TripHeading}
 
   alias Test.Support.Factories.{
     Routes.Route,
     RoutePatterns.RoutePattern,
     Schedules.Schedule,
+    Schedules.Trip,
     Stops.Stop
   }
 
@@ -120,7 +121,10 @@ defmodule Dotcom.ScheduleFinderTest do
       date = Faker.Util.format("%4d-%2d-%2d")
 
       expect(Schedules.Repo.Mock, :schedule_for_trip, fn _, _ ->
-        Schedule.build_list(4, :schedule, stop_sequence: earlier_stop_sequence)
+        Schedule.build_list(4, :schedule,
+          stop_sequence: earlier_stop_sequence,
+          trip: Trip.build(:trip, id: trip_id)
+        )
       end)
 
       assert {:ok, []} = next_arrivals(trip_id, stop_sequence, date)
@@ -147,6 +151,36 @@ defmodule Dotcom.ScheduleFinderTest do
 
       assert {:ok, arrivals} = next_arrivals(trip_id, stop_sequence_for_stop, date)
       assert %FutureArrival{} = List.first(arrivals)
+    end
+
+    test "adds a trip heading between arrivals for different trips" do
+      [trip_id1, trip_id2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
+
+      [stop_sequence_for_stop, stop_sequence_for_arrivals] =
+        Faker.Util.sample_uniq(2, fn -> Faker.random_between(1, 100) end) |> Enum.sort()
+
+      date = Faker.Util.format("%4d-%2d-%2d")
+
+      schedules =
+        Schedule.build_list(4, :schedule,
+          stop_sequence: stop_sequence_for_arrivals,
+          trip: Trip.build(:trip, id: trip_id1)
+        ) ++
+          Schedule.build_list(4, :schedule, trip: Trip.build(:trip, id: trip_id2))
+
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn _, _ ->
+        schedules
+      end)
+
+      stub(Stops.Repo.Mock, :get, fn id ->
+        assert id in Enum.map(schedules, & &1.platform_stop_id)
+
+        Stop.build(:stop, id: id)
+      end)
+
+      assert {:ok, arrivals} = next_arrivals(trip_id1, stop_sequence_for_stop, date)
+      assert %FutureArrival{} = List.first(arrivals)
+      assert [_, _, _, _, %TripHeading{} | _] = arrivals
     end
   end
 

--- a/test/schedules/repo_test.exs
+++ b/test/schedules/repo_test.exs
@@ -4,10 +4,12 @@ defmodule Schedules.RepoTest do
 
   import Mox
   import Schedules.Repo
+  import Test.Support.Factories.MBTA.Api
 
   alias Dotcom.Cache.KeyGenerator
   alias MBTA.Api.Trips
   alias Schedules.Schedule
+  alias Test.Support.FactoryHelpers
 
   setup do
     cache = Application.get_env(:dotcom, :cache)
@@ -15,6 +17,8 @@ defmodule Schedules.RepoTest do
 
     %{cache: cache}
   end
+
+  setup :verify_on_exit!
 
   describe "by_route_ids/2" do
     @describetag :external
@@ -108,37 +112,84 @@ defmodule Schedules.RepoTest do
   end
 
   describe "schedule_for_trip/2" do
-    @describetag :external
-    test "returns stops in order of their stop_sequence for a given trip" do
-      trip_id =
-        "place-WML-0442"
-        |> schedules_for_stop(direction_id: 1)
-        |> List.first()
-        |> Map.get(:trip)
-        |> Map.get(:id)
+    test "uses trip argument" do
+      trip_id = FactoryHelpers.build(:id)
 
-      # find a Worcester CR trip ID
-      response = schedule_for_trip(trip_id)
-      assert response |> Enum.all?(fn schedule -> schedule.trip.id == trip_id end)
-      refute response == []
-      assert List.first(response).stop.id == "place-WML-0442"
-      assert List.last(response).stop.id == "place-sstat"
+      MBTA.Api.Mock
+      |> expect(:get_json, fn "/schedules/", args ->
+        assert args[:trip] == trip_id
+        %JsonApi{data: []}
+      end)
+
+      _ = schedule_for_trip(trip_id)
     end
 
-    test "returns different values for different dates" do
-      trip_id =
-        "place-WML-0442"
-        |> schedules_for_stop(direction_id: 1)
-        |> List.first()
-        |> Map.get(:trip)
-        |> Map.get(:id)
-
+    test "uses date argument" do
+      trip_id = FactoryHelpers.build(:id)
       today = Util.service_date()
-      tomorrow = Timex.shift(today, days: 1)
-      assert schedule_for_trip(trip_id) == schedule_for_trip(trip_id, date: today)
+      tomorrow = Date.shift(today, day: 1)
 
-      refute schedule_for_trip(trip_id, date: today) ==
-               schedule_for_trip(trip_id, date: tomorrow)
+      MBTA.Api.Mock
+      |> expect(:get_json, fn "/schedules/", args ->
+        assert args[:date] == today
+        %JsonApi{data: []}
+      end)
+      |> expect(:get_json, fn "/schedules/", args ->
+        assert args[:date] == tomorrow
+        %JsonApi{data: []}
+      end)
+
+      _ = schedule_for_trip(trip_id, date: today)
+      _ = schedule_for_trip(trip_id, date: tomorrow)
+    end
+
+    test "gets schedules from additional trips if needed" do
+      [trip_id1, trip_id2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
+      trip2 = build(:trip_item, id: trip_id2)
+
+      trip1 =
+        build(:trip_item,
+          id: trip_id1,
+          relationships: %{
+            "from_trip_transfers" => [
+              build(:item, %{
+                attributes: %{"transfer_type" => 4},
+                relationships: %{"to_trip" => [trip2]},
+                type: "transfer"
+              })
+            ]
+          }
+        )
+
+      MBTA.Api.Mock
+      |> expect(:get_json, fn "/schedules/", args ->
+        assert args[:trip] == trip_id1
+
+        %JsonApi{
+          links: %{},
+          data: build_list(5, :schedule_item, relationships: %{"trip" => [trip1]})
+        }
+      end)
+      |> expect(:get_json, fn "/schedules/", args ->
+        assert args[:trip] == trip_id2
+
+        %JsonApi{
+          links: %{},
+          data: build_list(5, :schedule_item, relationships: %{"trip" => [trip2]})
+        }
+      end)
+
+      stub(Routes.Repo.Mock, :get, fn _ ->
+        Test.Support.Factories.Routes.Route.build(:route)
+      end)
+
+      stub(Stops.Repo.Mock, :get_parent, fn _ ->
+        Test.Support.Factories.Stops.Stop.build(:stop)
+      end)
+
+      schedules = schedule_for_trip(trip_id1)
+      assert Enum.any?(schedules, &(&1.trip.id == trip_id1))
+      assert Enum.any?(schedules, &(&1.trip.id == trip_id2))
     end
   end
 

--- a/test/support/factories/mbta/api.ex
+++ b/test/support/factories/mbta/api.ex
@@ -357,12 +357,22 @@ defmodule Test.Support.Factories.MBTA.Api do
             "arrival_time" => formatted_datetime(),
             "departure_time" => formatted_datetime(),
             "pickup_type" => "",
+            "drop_off_type" => "",
+            "timepoint" => "",
             "stop_headsign" => "",
             "stop_sequence" => stop_sequence || 90
           },
+          relationships: %{
+            "route" => [build(:route_item)],
+            "stop" => [build(:stop_item)],
+            "trip" => [build(:trip_item)]
+          },
           type: "schedule"
         },
-        attrs
+        attrs,
+        fn _k, v1, v2 ->
+          Map.merge(v1, v2)
+        end
       )
     )
   end


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Follow up on "🛜 🐞 Daily Schedules sometimes doesn't show school trips "](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217929539836227?focus=true)

This leverages the addition to transfers to the V3 API from this PR: 
- https://github.com/mbta/api/pull/1074

## Implementation

- When fetching and parsing **schedules**, we include the included trip's **from_trip_transfers**. When parsing trips, we use that included transfer to populate a new property: `next_trip_id`. This indicates a trip you can transfer to.

- I edited `Schedules.Repo.schedule_for_trip/1` to detect the presence of a populated `next_trip_id` and fetch and append even more schedules from that

> [!NOTE]
>  This output results in longer lists of schedules/predictions which might now cover more than one trip. This complicates filtering based on `stop_sequence`, because new trips will have a new sequence of `stop_sequence` values.

- Finagled the code for daily schedules "next arrivals" to find where in the list of schedules we transition from one trip to the next, and insert a new value: a `%Dotcom.ScheduleFinder.TripHeading{}` to hold the route/headsign for later rendering.

## Screenshots

Dev on left, this PR on right

https://github.com/user-attachments/assets/4cae11c9-fd59-46f5-a8d6-b6647be0cef0

## How to test

In transfers.txt we can see the trips which come into play, so we can look up those trips and find departures pages to test. I've been enjoying these:

http://localhost:4001/departures?route_id=57&direction_id=1&stop_id=917
http://localhost:4001/departures?route_id=741&direction_id=0&stop_id=place-crtst
http://localhost:4001/departures?route_id=Boat-F10&direction_id=0&stop_id=Boat-Aquarium
http://localhost:4001/departures?route_id=37&direction_id=1&stop_id=11839
