### PR TITLE
fix: Remove `with_mock` call in `ScheduleControllerTest`

### DIFF
--- a/test/dotcom_web/controllers/schedule_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule_controller_test.exs
@@ -451,23 +451,22 @@ defmodule DotcomWeb.ScheduleControllerTest do
     end
 
     test "doesn't crash when a nil route is encountered", %{conn: conn} do
-      with_mock(Schedules.Repo, [:passthrough],
-        schedules_for_stop: fn
-          "TEST 1234", _ ->
-            [
-              %Schedules.Schedule{
-                route: nil,
-                stop: %Stops.Stop{id: "TEST 1234"},
-                departure_time: ~U[2219-05-18 22:25:06.098765Z]
-              }
-            ]
-        end
-      ) do
-        conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
-        body = json_response(conn, 200)
-        assert Kernel.length(body) == 1
-        assert %{"departure_time" => "2219-05-18T22:25:06.098765Z"} = Enum.at(body, 0)
-      end
+      Schedules.Repo.Mock
+      |> stub(:schedules_for_stop, fn
+        "TEST 1234", _ ->
+          [
+            %Schedules.Schedule{
+              route: nil,
+              stop: %Stops.Stop{id: "TEST 1234"},
+              departure_time: ~U[2219-05-18 22:25:06.098765Z]
+            }
+          ]
+      end)
+
+      conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+      body = json_response(conn, 200)
+      assert Kernel.length(body) == 1
+      assert %{"departure_time" => "2219-05-18T22:25:06.098765Z"} = Enum.at(body, 0)
     end
   end
 


### PR DESCRIPTION
## Scope

No ticket, but CI is currently failing on `main`:

```elixir
error: undefined function with_mock/4 (expected DotcomWeb.ScheduleControllerTest to define such a function or for it to be imported, but none are available)
 14      │
 15  454 │       with_mock(Schedules.Repo, [:passthrough],
 16      │       ^^^^^^^^^
 17      │
 18      └─ test/dotcom_web/controllers/schedule_controller_test.exs:454:7: DotcomWeb.ScheduleControllerTest."test schedules_for_stop/2 doesn't crash when a nil route is encountered"/1
 19
 20
 21 == Compilation error in file test/dotcom_web/controllers/schedule_controller_test.exs ==
 22 ** (CompileError) test/dotcom_web/controllers/schedule_controller_test.exs: cannot compile module DotcomWeb.ScheduleControllerTest (errors have been logged)
```

Turns out [this PR](https://github.com/mbta/dotcom/pull/3453) added a new call to `with_mock` at the same time that [this PR](https://github.com/mbta/dotcom/pull/3454) wiped `:mock` (and with it `with_mock`) out of our dependency list.

## Implementation

> [!NOTE]
> :robot: I used AI to convert the `with_mock` call to `Mox` syntax. The prompt I used was:
> > Look at test/dotcom_web/controllers/schedule_controller_test.exs. There's one test in there that uses `with_mock`. Please update it to use Mox instead

AI note notwithstanding, this test does not run. The whole test is excluded from running because of [its `external` moduletag](https://github.com/mbta/dotcom/blob/218f14cf6cc8746b4055f661f9d4f8f1bdc19c51/test/dotcom_web/controllers/schedule_controller_test.exs#L13), which means that its only impact on the test suite is its current failure to compile causing the whole build to crash.

## How to test

`mix test`