### PR TITLE
[Line Diagram]: Pull timetable parking+accessibility indicators into own component

### DIFF
--- a/lib/dotcom_web/components/a11y_and_parking.ex
+++ b/lib/dotcom_web/components/a11y_and_parking.ex
@@ -1,0 +1,44 @@
+defmodule DotcomWeb.Components.A11yParking do
+  @moduledoc """
+  A component for showing (or not) parking and a11y icons
+  """
+
+  use DotcomWeb, :component
+
+  attr :stop, :map, required: true
+
+  def a11y_and_parking(assigns) do
+    ~H"""
+    <div class="flex items-center gap-0.5">
+      <%= if length(@stop.parking_lots) > 0 do %>
+        <.tooltip title={~t(Parking available)} placement={:top}>
+          <.icon
+            name="square-parking"
+            class="size-4 fill-gray-light"
+            aria-hidden="true"
+          />
+        </.tooltip>
+      <% else %>
+        <span class="sr-only">{~t(No parking)}</span>
+      <% end %>
+
+      <%= if Stops.Stop.accessible?(@stop) do %>
+        <.tooltip title={~t(Accessible)} placement={:top}>
+          <.icon
+            type="icon-svg"
+            name="icon-accessible-default"
+            class="size-4 fill-brand-primary"
+            aria-hidden="true"
+          />
+        </.tooltip>
+      <% else %>
+        <%= if Stops.Stop.accessibility_known?(@stop) do %>
+          <span class="sr-only">{~t(Not accessible)}</span>
+        <% else %>
+          <span class="sr-only">{~t(May not be accessible)}</span>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/dotcom_web/components/new_timetable.ex
+++ b/lib/dotcom_web/components/new_timetable.ex
@@ -4,6 +4,7 @@ defmodule DotcomWeb.Components.NewTimetable do
   """
 
   use DotcomWeb, :component
+  import DotcomWeb.Components.A11yParking
 
   alias Dotcom.Timetables
 
@@ -88,36 +89,7 @@ defmodule DotcomWeb.Components.NewTimetable do
             >
               <div class={"#{header_column_classes()} px-2 py-1 font-medium #{font_size_classes()} border-r-xs border-gray-lighter flex gap-2"}>
                 <.link navigate={~p"/stops/#{row.stop.id}"} class="mr-auto">{row.stop.name}</.link>
-                <div class="flex items-center gap-0.5">
-                  <%= if length(row.stop.parking_lots) > 0 do %>
-                    <.tooltip title={~t(Parking available)} placement={:top}>
-                      <.icon
-                        name="square-parking"
-                        class="size-4 fill-gray-light"
-                        aria-hidden="true"
-                      />
-                    </.tooltip>
-                  <% else %>
-                    <span class="sr-only">{~t(No parking)}</span>
-                  <% end %>
-
-                  <%= if Stops.Stop.accessible?(row.stop) do %>
-                    <.tooltip title={~t(Accessible)} placement={:top}>
-                      <.icon
-                        type="icon-svg"
-                        name="icon-accessible-default"
-                        class="size-4 fill-brand-primary"
-                        aria-hidden="true"
-                      />
-                    </.tooltip>
-                  <% else %>
-                    <%= if Stops.Stop.accessibility_known?(row.stop) do %>
-                      <span class="sr-only">{~t(Not accessible)}</span>
-                    <% else %>
-                      <span class="sr-only">{~t(May not be accessible)}</span>
-                    <% end %>
-                  <% end %>
-                </div>
+                <.a11y_and_parking stop={row.stop} />
               </div>
               <.shadow />
             </th>

--- a/lib/dotcom_web/components/timetable.ex
+++ b/lib/dotcom_web/components/timetable.ex
@@ -4,6 +4,7 @@ defmodule DotcomWeb.Components.Timetable do
   """
 
   use DotcomWeb, :component
+  import DotcomWeb.Components.A11yParking
 
   import DotcomWeb.ScheduleView, only: [timetable_crowding_description: 1]
 
@@ -248,36 +249,7 @@ defmodule DotcomWeb.Components.Timetable do
         <.link navigate={~p"/stops/#{@stop.id}"} class="m-timetable__stop-link">
           {break_text_at_slash(@stop.name)}
         </.link>
-        <div class="m-timetable__stop-icons">
-          <%= if length(@stop.parking_lots) > 0 do %>
-            <.tooltip title={~t(Parking available)} placement={:top}>
-              <.icon
-                name="square-parking"
-                class="size-4 fill-gray-light"
-                aria-hidden="true"
-              />
-            </.tooltip>
-          <% else %>
-            <span class="sr-only">{~t(No parking)}</span>
-          <% end %>
-
-          <%= if Stops.Stop.accessible?(@stop) do %>
-            <.tooltip title={~t(Accessible)} placement={:top}>
-              <.icon
-                type="icon-svg"
-                name="icon-accessible-default"
-                class="size-4 fill-brand-primary"
-                aria-hidden="true"
-              />
-            </.tooltip>
-          <% else %>
-            <%= if Stops.Stop.accessibility_known?(@stop) do %>
-              <span class="sr-only">{~t(Not accessible)}</span>
-            <% else %>
-              <span class="sr-only">{~t(May not be accessible)}</span>
-            <% end %>
-          <% end %>
-        </div>
+        <.a11y_and_parking stop={@stop} />
       </div>
     </th>
     """

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -397,8 +397,7 @@ msgstr ""
 msgid "Accessibility at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2515,8 +2514,7 @@ msgstr ""
 msgid "Mattapan Trolley"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr ""
@@ -2744,8 +2742,7 @@ msgstr ""
 msgid "No events"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr ""
@@ -2793,9 +2790,8 @@ msgstr ""
 msgid "Northbound"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3041,8 +3037,7 @@ msgstr ""
 msgid "Parking at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -397,8 +397,7 @@ msgstr ""
 msgid "Accessibility at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2515,8 +2514,7 @@ msgstr ""
 msgid "Mattapan Trolley"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr ""
@@ -2744,8 +2742,7 @@ msgstr ""
 msgid "No events"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr ""
@@ -2793,9 +2790,8 @@ msgstr ""
 msgid "Northbound"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3041,8 +3037,7 @@ msgstr ""
 msgid "Parking at %{name}"
 msgstr ""
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -397,8 +397,7 @@ msgstr "Recursos de accesibilidad"
 msgid "Accessibility at %{name}"
 msgstr "accesibilidad en %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2524,8 +2523,7 @@ msgstr "Massport enlace %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Puede que no sea accesible"
@@ -2756,8 +2754,7 @@ msgstr "No se publicaron cambios durante los próximos 7 días"
 msgid "No events"
 msgstr "Sin eventos"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Prohibido parquear"
@@ -2805,9 +2802,8 @@ msgstr "servicio normal"
 msgid "Northbound"
 msgstr "Dirección norte"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3054,8 +3050,7 @@ msgstr "Tarifas de parqueadero"
 msgid "Parking at %{name}"
 msgstr "Parqueadero en %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Parqueadero disponible"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -397,8 +397,7 @@ msgstr "Ressources d’accessibilité"
 msgid "Accessibility at %{name}"
 msgstr "L’accessibilité chez %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2525,8 +2524,7 @@ msgstr "Massport navette %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Ce n’est peut-être pas accessible"
@@ -2757,8 +2755,7 @@ msgstr "Aucun changement n’a été publié pour les 7 jours suivants"
 msgid "No events"
 msgstr "Aucun événement"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Pas de stationnement"
@@ -2806,9 +2803,8 @@ msgstr "service normal"
 msgid "Northbound"
 msgstr "Direction nord"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3056,8 +3052,7 @@ msgstr "Tarifs de stationnement"
 msgid "Parking at %{name}"
 msgstr "Parking à %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Places de stationnement disponibles"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -397,8 +397,7 @@ msgstr "Resous Aksè"
 msgid "Accessibility at %{name}"
 msgstr "aksesiblite nan %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2521,8 +2520,7 @@ msgstr "Massport navèt %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Li ka pa aksesib"
@@ -2751,8 +2749,7 @@ msgstr "Pa gen okenn chanjman ki afiche pou 7 jou kap vini yo"
 msgid "No events"
 msgstr "Pa gen evènman"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Pa gen pakin"
@@ -2800,9 +2797,8 @@ msgstr "sèvis nòmal"
 msgid "Northbound"
 msgstr "Direksyon nò"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3048,8 +3044,7 @@ msgstr "Tarif Pakin"
 msgid "Parking at %{name}"
 msgstr "Pakin nan %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Pakin disponib"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -397,8 +397,7 @@ msgstr "Recursos de acessibilidade"
 msgid "Accessibility at %{name}"
 msgstr "acesso em %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2523,8 +2522,7 @@ msgstr "Circular de transporte massport %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "Pode não ser acessível"
@@ -2754,8 +2752,7 @@ msgstr "Nenhuma alteração será publicada nos próximos 7 dias."
 msgid "No events"
 msgstr "Nenhum evento"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Proibido Estacionar"
@@ -2803,9 +2800,8 @@ msgstr "serviço normal"
 msgid "Northbound"
 msgstr "Sentido norte"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3052,8 +3048,7 @@ msgstr "Tarifas de estacionamento"
 msgid "Parking at %{name}"
 msgstr "Estacionamento em %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Estacionamento disponível"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -391,8 +391,7 @@ msgstr "khả năng tiếp cận Tài nguyên"
 msgid "Accessibility at %{name}"
 msgstr "khả năng tiếp cận at %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2518,8 +2517,7 @@ msgstr "Massport xe đưa đón %{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "May not be có thể tiếp cận được"
@@ -2749,8 +2747,7 @@ msgstr "Không có thay đổi nào được đăng tải trong 7 ngày tới."
 msgid "No events"
 msgstr "Không có sự kiện nào"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "Cấm đỗ xe"
@@ -2798,9 +2795,8 @@ msgstr "dịch vụ bình thường"
 msgid "Northbound"
 msgstr "Hướng Bắc"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3048,8 +3044,7 @@ msgstr "Giá phí đậu xe"
 msgid "Parking at %{name}"
 msgstr "Đỗ xe tại %{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "Có chỗ đậu xe"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -391,8 +391,7 @@ msgstr "无障碍资源"
 msgid "Accessibility at %{name}"
 msgstr "无障碍访问%{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2509,8 +2508,7 @@ msgstr "Massport 摆渡巴士%{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "可能不太方便"
@@ -2738,8 +2736,7 @@ msgstr "未来7天内无任何变更发布"
 msgid "No events"
 msgstr "无事件"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "禁止停车"
@@ -2787,9 +2784,8 @@ msgstr "正常服务"
 msgid "Northbound"
 msgstr "北行"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3035,8 +3031,7 @@ msgstr "停车收费标准"
 msgid "Parking at %{name}"
 msgstr "停车场位于%{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "提供停车位"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -391,8 +391,7 @@ msgstr "無障礙資源"
 msgid "Accessibility at %{name}"
 msgstr "無障礙存取%{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/transit_icons.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
@@ -2509,8 +2508,7 @@ msgstr "Massport 擺渡巴士%{route_number}"
 msgid "Mattapan Trolley"
 msgstr "Mattapan Trolley"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "May not be accessible"
 msgstr "可能不太方便"
@@ -2738,8 +2736,7 @@ msgstr "未來7天內無任何變更發布"
 msgid "No events"
 msgstr "無事件"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "No parking"
 msgstr "禁止停車"
@@ -2787,9 +2784,8 @@ msgstr "正常服務"
 msgid "Northbound"
 msgstr "北行"
 
-#: lib/dotcom_web/components/new_timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #: lib/dotcom_web/components/stops/accessibility_amenity.html.heex
-#: lib/dotcom_web/components/timetable.ex
 #: lib/dotcom_web/components/trip_planner/itinerary_summary.ex
 #, elixir-autogen, elixir-format
 msgid "Not accessible"
@@ -3035,8 +3031,7 @@ msgstr "停車收費標準"
 msgid "Parking at %{name}"
 msgstr "停車場位於%{name}"
 
-#: lib/dotcom_web/components/new_timetable.ex
-#: lib/dotcom_web/components/timetable.ex
+#: lib/dotcom_web/components/a11y_and_parking.ex
 #, elixir-autogen, elixir-format
 msgid "Parking available"
 msgstr "提供停車位"


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🛠️💈 Pull timetable parking+accessibility indicators into own component](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217331426314758?focus=true)

## Implementation

Moved the duplicated A11y and parking icon logic into it's own component.  Replaced the duped code with the new component in timetable.ex and new_timetable.ex

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

<!--
> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots

### New Timetables
<img width="1351" height="717" alt="Screenshot 2026-09-01 at 2 54 45 PM" src="https://github.com/user-attachments/assets/a1657dd4-888e-49f1-9586-ccd51ecc69b6" />

### Classic Timetables
<img width="1346" height="684" alt="Screenshot 2026-09-01 at 2 55 01 PM" src="https://github.com/user-attachments/assets/82120f9d-ced2-41af-b7dc-762ef3445e27" />

## How to test

http://localhost:4001/schedules/CR-NewBedford/timetable - Confirm that the parking and accessibility icons look and work as expected.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
