### PR TITLE
refactor(ContentSecurityPolicy): replace plug

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -99,13 +99,17 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
 
   @impl Plug
   def call(conn, _opts) do
-    runtime_directives =
-      Util.get_or_save_persistent_term(:csp_directives, fn -> runtime_directives() end)
+    policy =
+      Util.get_or_save_persistent_term(:csp_policy, fn ->
+        runtime_directives()
+        |> Enum.reduce(@default_policy, fn {directive, source_value}, policy ->
+          ContentSecurityPolicy.add_source_value(policy, directive, source_value)
+        end)
+      end)
 
     conn
-    |> ContentSecurityPolicy.Plug.Setup.call(default_policy: @default_policy)
+    |> ContentSecurityPolicy.Plug.Setup.call(default_policy: policy)
     |> ContentSecurityPolicy.Plug.AddNonce.call(directives: [:script_src])
-    |> ContentSecurityPolicy.Plug.AddSourceValue.call(runtime_directives)
   end
 
   defp runtime_directives do


### PR DESCRIPTION
## Scope

Just another performance tweak. 

## Implementation

I realized that the `|> ContentSecurityPolicy.Plug.AddSourceValue.call(runtime_directives)` line isn't terribly performant, and does the exact same thing on every request. This PR avoids recomputing this result by doing the same work inside a function whose result will get saved in `:persistent_term`.

> [!NOTE]
> :robot: I used AI only to crunch the before/after SVGs and generate the summary table/text!


## Before & After

| Before | After |
|--------|--------|
| <img width="1276" height="1150" alt="csp_before" src="https://github.com/user-attachments/assets/be26eabc-9884-403f-b5c5-90a404baa491" /> | <img width="1276" height="875" alt="csp_after" src="https://github.com/user-attachments/assets/1e8e0f6a-a2a0-4a2c-93a7-1fb6590a4e78" /> | 

### Summary

<h3 dir="ltr">Flamegraph comparison: <code>DotcomWeb.Plugs.ContentSecurityPolicy.call/2</code></h3>

| Metric | Before | After
| -- | -- | --
| Total time | 2,468µs | 300µs (~8.2x faster)
| Dominant cost | AddSourceValue (88%, 2,175µs) | AddNonce (85%, 255µs)
| Reduce nesting | 13 nested levels (deepening stack) | 1 flat pass
| Enum.reject_list/2 calls | 312 | 25
| Enum.uniq_list/3 calls | 197 | 25
| Max stack depth | 46 frames | 35 frames

<p dir="ltr"><strong>What changed:</strong> In the "before" trace, <code>AddSourceValue</code>'s reduce over CSP directives nested each directive's work inside the previous one's frame, so <code>uniq</code>/<code>reject</code> scans re-ran at every level — roughly quadratic cost. In "after," that reduce runs as a single flat pass, cutting redundant list scans by ~8x and dropping total middleware time by ~88%.</p>
