### PR TITLE
fix(Util): parse event date param

### DIFF
--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -462,7 +462,8 @@ defmodule Util do
 
   @doc """
 
-  Parses a string into a valid date, or returns an error.
+  Parses an ISO date string or a year/month parameter map into a valid date, or
+  returns an error.
 
   ## Examples
       iex> Util.parse_valid_date("2025-12-25")
@@ -474,8 +475,11 @@ defmodule Util do
       iex> Util.parse_valid_date("2025-13-35")
       {:error, :invalid_date}
 
+      iex> Util.parse_valid_date(%{"year" => "2025", "month" => "7"})
+      {:ok, ~D[2025-07-01]}
+
   """
-  @spec parse_valid_date(String.t()) :: {:ok, Date.t()} | {:error, any}
+  @spec parse_valid_date(String.t() | map) :: {:ok, Date.t()} | {:error, any}
   def parse_valid_date(str) when is_binary(str) do
     with {:ok, date} <- Date.from_iso8601(str) do
       if Timex.is_valid?(date) do
@@ -483,6 +487,17 @@ defmodule Util do
       else
         {:error, :invalid_date}
       end
+    end
+  end
+
+  def parse_valid_date(%{"year" => year, "month" => month})
+      when is_binary(year) and is_binary(month) do
+    with {year, ""} <- Integer.parse(year),
+         {month, ""} <- Integer.parse(month),
+         {:ok, date} <- Date.new(year, month, 1) do
+      {:ok, date}
+    else
+      _ -> {:error, :invalid_date}
     end
   end
 

--- a/test/dotcom_web/controllers/event_controller_test.exs
+++ b/test/dotcom_web/controllers/event_controller_test.exs
@@ -22,6 +22,13 @@ defmodule DotcomWeb.EventControllerTest do
       assert %{year: 2020, month: 5} = conn.assigns
     end
 
+    test "assigns month and year based on nested date query params", %{conn: conn} do
+      conn = get(conn, event_path(conn, :index, date: [month: 7, year: 2023]))
+
+      assert conn.status == 200
+      assert %{year: 2023, month: 7} = conn.assigns
+    end
+
     test "renders a list of events", %{conn: conn} do
       conn = get(conn, event_path(conn, :index))
       assert conn.assigns.year == 2019

--- a/test/util/util_test.exs
+++ b/test/util/util_test.exs
@@ -599,6 +599,16 @@ defmodule UtilTest do
       assert {:error, :invalid_date} == Util.parse_valid_date("2020-02-31")
     end
 
+    test "parses valid year and month parameters" do
+      assert {:ok, ~D[2023-07-01]} ==
+               Util.parse_valid_date(%{"month" => "7", "year" => "2023"})
+    end
+
+    test "returns an error for invalid year and month parameters" do
+      assert {:error, :invalid_date} ==
+               Util.parse_valid_date(%{"month" => "13", "year" => "2023"})
+    end
+
     test "returns an error for a argument of the wrong type" do
       assert {:error, :invalid_date} == Util.parse_valid_date(%{foo: "bar"})
     end


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📆🐞 Events page can no longer navigate to other years/months](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217383179374243?focus=true)

## Implementation

> [!NOTE]
> I used Copilot for this! It ended up finding a simpler solution than I would have conjured.

Now parsing URL parameters for valid dates supports maps in addition to strings. So `date=2026-09-01` works, but constructs like `date[month]=9&date[year]=2026` work now too!

## How to test

From `/events`, change the year (upper right dropdown) and/or the month (by clicking the month on the left) and find that now you can successfully navigate to that timeframe and actually see events from that time!
