### PR TITLE
[Line Diagram]: Set up new line page LiveView to use the same header & tabs layout as the existing one

### DIFF
--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -111,10 +111,26 @@ defmodule DotcomWeb.LineDiagramLive do
         <div class="schedule__header-tabs">{header_tabs(assigns)}</div>
       </div>
     </div>
-
-    <marquee style="font-size:2cm" scrollamount="16" scrolldelay="60">
-      🚧 Under Construction 🚧
-    </marquee>
+    <div class="container">
+      <div class="col-md-7">
+        <marquee
+          style="font-size:1cm;filter: drop-shadow(2px 4px 6px orange);"
+          scrollamount="16"
+          scrolldelay="60"
+        >
+          🚧 Under Construction 🚧
+        </marquee>
+      </div>
+      <div class="col-md-5">
+        <marquee
+          style="font-size:1cm;filter: drop-shadow(2px 4px 6px orange);"
+          scrollamount="16"
+          scrolldelay="60"
+        >
+          ⚠️ Watch Your Step ⚠️
+        </marquee>
+      </div>
+    </div>
     """
   end
 end

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -6,6 +6,10 @@ defmodule DotcomWeb.LineDiagramLive do
   use DotcomWeb, :live_view
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
+  @date_time_module Application.compile_env!(:dotcom, :date_time_module)
+
+  alias DotcomWeb.PartialView.{HeaderTab, HeaderTabs}
 
   import DotcomWeb.ScheduleView,
     only: [
@@ -13,22 +17,79 @@ defmodule DotcomWeb.LineDiagramLive do
       route_header_text: 1,
       route_header_description: 1,
       route_feature_badge: 1,
-      route_header_tabs: 1
+      route_tab_class: 1
     ]
+
+  import DotcomWeb.Views.Helpers.AlertHelpers, only: [alert_badge: 1]
 
   def mount(params, _session, socket) do
     route_id = params |> Map.get("route_id")
     direction_id = params |> Map.get("direction_id", "1")
     route_patterns = @route_patterns_repo.by_route_id(route_id)
     route = @routes_repo.get(route_id)
-    dbg(socket, limit: :infinity)
 
     {:ok,
      socket
      |> assign(:direction_id, direction_id)
      |> assign(:route_patterns, route_patterns)
      |> assign(:route_id, route_id)
-     |> assign(:route, route)}
+     |> assign(:route, route)
+     |> assign(:tab, "new_line")
+     |> assign(:params, params)}
+  end
+
+  def make_link(assigns, page) do
+    path = "/schedules/#{assigns.route.id}/#{page}"
+    params = URI.encode_query(assigns.params)
+    "#{path}?#{params}"
+  end
+
+  def header_tabs(%{route: route} = assigns) do
+    route = route
+    info_link = make_link(assigns, "line")
+    line_path = make_link(assigns, "line_new")
+    timetable_link = make_link(assigns, "timetable")
+    alerts_link = make_link(assigns, "alerts")
+    alert_count = @alerts_repo.by_route_ids([route.id], @date_time_module.now()) |> Enum.count()
+
+    tabs = [
+      %HeaderTab{
+        id: "alerts",
+        name: ~t"Alerts",
+        href: alerts_link,
+        badge: alert_count |> alert_badge()
+      }
+    ]
+
+    tabs =
+      if assigns |> Map.get(:line_diagram, false) do
+        [
+          %HeaderTab{
+            id: "new_line",
+            name: ~t"Schedules & Maps (new)",
+            href: line_path
+          }
+          | tabs
+        ]
+      else
+        tabs
+      end
+
+    tabs =
+      case route.type do
+        n when n in [2, 4] ->
+          [
+            %HeaderTab{id: "timetable", name: ~t"Timetable", href: timetable_link},
+            %HeaderTab{id: "line", name: ~t"Schedule & Maps", href: info_link} | tabs
+          ]
+
+        _ ->
+          [
+            %HeaderTab{id: "line", name: ~t"Schedules & Maps", href: info_link} | tabs
+          ]
+      end
+
+    HeaderTabs.render_tabs(tabs, selected: assigns.tab, tab_class: route_tab_class(route))
   end
 
   def render(assigns) do
@@ -38,7 +99,7 @@ defmodule DotcomWeb.LineDiagramLive do
         <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
         {route_header_description(@route)}
         {route_feature_badge(@route)}
-        <div class="schedule__header-tabs">{}</div>
+        <div class="schedule__header-tabs">{header_tabs(assigns)}</div>
       </div>
     </div>
 

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -24,9 +24,13 @@ defmodule DotcomWeb.LineDiagramLive do
 
   def mount(params, _session, socket) do
     route_id = params |> Map.get("route_id")
-    direction_id = params |> Map.get("direction_id", "1")
-    route_patterns = @route_patterns_repo.by_route_id(route_id)
     route = @routes_repo.get(route_id)
+    route_patterns = @route_patterns_repo.by_route_id(route_id)
+
+    direction_id =
+      params |> Map.get("schedule_direction", %{direction_id: 0}) |> Map.get("direction_id")
+
+    tab_params = %{"schedule_direction[direction_id]": direction_id}
 
     {:ok,
      socket
@@ -35,20 +39,25 @@ defmodule DotcomWeb.LineDiagramLive do
      |> assign(:route_id, route_id)
      |> assign(:route, route)
      |> assign(:tab, "new_line")
-     |> assign(:params, params)}
+     |> assign(:tab_params, tab_params)}
   end
 
-  def make_link(assigns, page) do
+  def make_link(assigns, page, add_params? \\ false) do
     path = "/schedules/#{assigns.route.id}/#{page}"
-    params = URI.encode_query(assigns.params)
-    "#{path}?#{params}"
+    params = URI.encode_query(assigns.tab_params)
+
+    if add_params? do
+      "#{path}?#{params}"
+    else
+      path
+    end
   end
 
   def header_tabs(%{route: route} = assigns) do
     route = route
     info_link = make_link(assigns, "line")
     line_path = make_link(assigns, "line_new")
-    timetable_link = make_link(assigns, "timetable")
+    timetable_link = make_link(assigns, "timetable", true)
     alerts_link = make_link(assigns, "alerts")
     alert_count = @alerts_repo.by_route_ids([route.id], @date_time_module.now()) |> Enum.count()
 

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -5,21 +5,43 @@ defmodule DotcomWeb.LineDiagramLive do
 
   use DotcomWeb, :live_view
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+
+  import DotcomWeb.ScheduleView,
+    only: [
+      header_class: 1,
+      route_header_text: 1,
+      route_header_description: 1,
+      route_feature_badge: 1,
+      route_header_tabs: 1
+    ]
 
   def mount(params, _session, socket) do
     route_id = params |> Map.get("route_id")
     direction_id = params |> Map.get("direction_id", "1")
     route_patterns = @route_patterns_repo.by_route_id(route_id)
+    route = @routes_repo.get(route_id)
+    dbg(socket, limit: :infinity)
 
     {:ok,
      socket
      |> assign(:direction_id, direction_id)
      |> assign(:route_patterns, route_patterns)
-     |> assign(:route_id, route_id)}
+     |> assign(:route_id, route_id)
+     |> assign(:route, route)}
   end
 
   def render(assigns) do
     ~H"""
+    <div class={"schedule__header #{ header_class(@route) }"}>
+      <div class="schedule__header-container">
+        <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
+        {route_header_description(@route)}
+        {route_feature_badge(@route)}
+        <div class="schedule__header-tabs">{}</div>
+      </div>
+    </div>
+
     <marquee style="font-size:2cm" scrollamount="16" scrolldelay="60">
       🚧 Under Construction 🚧
     </marquee>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -332,7 +332,10 @@ defmodule DotcomWeb.ScheduleView do
           ]
       end
 
-    HeaderTabs.render_tabs(tabs, selected: conn.assigns.tab, tab_class: route_tab_class(route))
+    HeaderTabs.render_tabs(tabs,
+      selected: conn.assigns.tab,
+      tab_class: route_tab_class(route)
+    )
   end
 
   @spec alert_count(Conn.t()) :: integer
@@ -340,7 +343,7 @@ defmodule DotcomWeb.ScheduleView do
   defp alert_count(_), do: 0
 
   @spec route_tab_class(Route.t()) :: String.t()
-  defp route_tab_class(%Route{type: 3} = route) do
+  def route_tab_class(%Route{type: 3} = route) do
     if Route.silver_line?(route) do
       ""
     else
@@ -348,7 +351,7 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
-  defp route_tab_class(_), do: ""
+  def route_tab_class(_), do: ""
 
   @spec route_fare_link(Route.t()) :: String.t()
   def route_fare_link(route) do

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -449,6 +449,7 @@ msgstr ""
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3457,6 +3458,7 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3526,6 +3528,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4331,6 +4334,7 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5377,6 +5381,7 @@ msgstr ""
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -449,6 +449,7 @@ msgstr ""
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3457,6 +3458,7 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3526,6 +3528,7 @@ msgstr ""
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4331,6 +4334,7 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5377,6 +5381,7 @@ msgstr ""
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -449,6 +449,7 @@ msgstr "alerta"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3471,6 +3472,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "Sábado"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3543,6 +3545,7 @@ msgstr "horario"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4349,6 +4352,7 @@ msgstr "Este tren suele tener<br /><strong>%{seats} asientos disponibles</strong
 msgid "Thursday"
 msgstr "Jueves"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5400,6 +5404,7 @@ msgstr "Trenes"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendario para %{route_name}, %{formatted_date}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -449,6 +449,7 @@ msgstr "alerte"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3473,6 +3474,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "Samedi"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3544,6 +3546,7 @@ msgstr "horaire"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4350,6 +4353,7 @@ msgstr "Ce train a généralement<br /><strong>%{seats} places disponibles</stro
 msgid "Thursday"
 msgstr "Jeudi"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5400,6 +5404,7 @@ msgstr "Trains"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} calendrier pour %{route_name}, %{formatted_date}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -449,6 +449,7 @@ msgstr "avètisman"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3464,6 +3465,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "Samdi"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3533,6 +3535,7 @@ msgstr "orè"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4339,6 +4342,7 @@ msgstr "Tren sa a anjeneral gen<br /><strong>%{seats} plas disponib.</strong>"
 msgid "Thursday"
 msgstr "Jedi"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5387,6 +5391,7 @@ msgstr "Tren yo"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Orè %{direction_name} pou %{route_name}, %{formatted_date}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -449,6 +449,7 @@ msgstr "alerta"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3469,6 +3470,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "Sábado"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3540,6 +3542,7 @@ msgstr "horário"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4346,6 +4349,7 @@ msgstr "Este trem normalmente tem<br /><strong>%{seats} assentos disponíveis</s
 msgid "Thursday"
 msgstr "Quinta-feira"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5396,6 +5400,7 @@ msgstr "Trens"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "Horário %{direction_name} para %{route_name}, %{formatted_date}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -443,6 +443,7 @@ msgstr "cảnh báo"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3465,6 +3466,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "Thứ bảy"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3535,6 +3537,7 @@ msgstr "lịch trình"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4341,6 +4344,7 @@ msgstr "Chuyến tàu này thường có<br /><strong>%{seats} chỗ ngồi còn
 msgid "Thursday"
 msgstr "Thứ Năm"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5391,6 +5395,7 @@ msgstr "Tàu hỏa"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} thời khóa biểu cho %{route_name}, %{formatted_date}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -443,6 +443,7 @@ msgstr "警报"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3451,6 +3452,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "周六"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3520,6 +3522,7 @@ msgstr "时刻表"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4325,6 +4328,7 @@ msgstr "这趟列车通常有<br /> <strong>%{seats}座位可用</strong>"
 msgid "Thursday"
 msgstr "星期四"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5371,6 +5375,7 @@ msgstr "火车"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的时间表"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -443,6 +443,7 @@ msgstr "警報"
 #: lib/dotcom_web/components/layouts/alerts_layout.html.heex
 #: lib/dotcom_web/controllers/alert_controller.ex
 #: lib/dotcom_web/live/commuter_rail_alerts_live.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/live/subway_alerts_live.ex
 #: lib/dotcom_web/templates/page/_tab_list.html.heex
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -3451,6 +3452,7 @@ msgstr "Samsung Pay"
 msgid "Saturday"
 msgstr "週六"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedule & Maps"
@@ -3520,6 +3522,7 @@ msgstr "時刻表"
 #: lib/dotcom_web/controllers/mode/hub.ex
 #: lib/dotcom_web/controllers/mode_controller.ex
 #: lib/dotcom_web/controllers/schedule/route_breadcrumbs.ex
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps"
@@ -4325,6 +4328,7 @@ msgstr "這列列車通常有<br /> <strong>%{seats}座位可用</strong>"
 msgid "Thursday"
 msgstr "星期四"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Timetable"
@@ -5371,6 +5375,7 @@ msgstr "火車"
 msgid "%{direction_name} timetable for %{route_name}, %{formatted_date}"
 msgstr "%{direction_name} %{route_name}、%{formatted_date} 的時間表"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Schedules & Maps (new)"


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [💈Set up new line page LiveView to use the same header & tabs layout as the existing one](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217398531030287?focus=true)

## Implementation

Copied over the header from the existing line diagram.
The tab code depended on `conn` when we're already on to `socket` so I had to reimplement some parts of that.
Added in a basic layout skeleton to separate main and right-rail content

TODO:  Make the URL generating code smarter, we don't technically need it, but for general web usability it would be nice

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

<!--
> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots


<img width="1169" height="249" alt="Screenshot 2026-09-03 at 2 02 33 PM" src="https://github.com/user-attachments/assets/dbc41597-799f-4b4f-952e-78ff0f587d05" />

We need some actual content soon, otherwise I'm might just add a view counter, web ring links, and 
Best Viewed in: <img width="88" height="31" alt="netscape_now" src="https://github.com/user-attachments/assets/38b22396-c5e3-4c38-a9fb-d0460e0bdf18" />


## How to test

http://localhost:4001/schedules/Red/line_new - Confirm the header and tabs look right and behave appropriately.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
