### PR TITLE
dev: Have webpack clean output directory on startup

### DIFF
--- a/assets/webpack.config.dev.js
+++ b/assets/webpack.config.dev.js
@@ -13,7 +13,8 @@ module.exports = env =>
 
     output: {
       publicPath: `http://localhost:${port}/`,
-      path: path.resolve(__dirname, "../priv/static/css")
+      path: path.resolve(__dirname, "../priv/static/css"),
+      clean: true
     },
 
     devServer: {


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->
Resolves `Error: EMFILE: too many open files, watch 'dotcom/priv/static/css/stop.c6f8a32fa3a07730bd2d.hot-update.js.map'`

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** 

No ticket, but discussed in [Slack](https://mbta.slack.com/archives/C06TP48CJ9W/p1788382746672769?thread_ts=1788380327.595099&cid=C06TP48CJ9W)

## Implementation
Keeps local webpack output folder clean so it doesn't get overwhelmed by hot reload artifacts. Not sure what this incurs in startup costs, if at all (since I assume server rebuilds the initial chunks anyway, emptying out the folder beforehand surely wouldn't add too much time? But if it's building off old chunks, then maybe it's more expensive? Unsure.), but it's probably not a noticeable amount. 

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

<!--
> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots
N/A

## How to test
Observe that `priv/static/css` has many hotreload files. With setting on, observe that starting server cleans out the directory and starts with fresh chunks.
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
