### PR TITLE
feat: Style tweaks for the route schedule page headers

### DIFF
--- a/assets/css/_schedule.scss
+++ b/assets/css/_schedule.scss
@@ -5,9 +5,9 @@
 
 .schedule__route-name {
   display: inline-block;
-  margin-bottom: calc(#{$base-spacing} / 2);
-  margin-top: 1.75rem;
-  text-transform: uppercase;
+  font-size: var(--font-size-2xl);
+  margin-bottom: 1rem;
+  margin-top: 1.5rem;
 }
 
 .schedule-date-picker {
@@ -308,6 +308,7 @@
 
 .schedule__description {
   display: inline-block;
+  font-size: 2rem;
   margin-bottom: $base-spacing * 1.5;
   margin-top: 0;
 }
@@ -352,15 +353,6 @@
   color: $white;
   display: inline-block;
   font-weight: bold;
-  min-width: $base-spacing * 4;
-  padding: calc(#{$base-spacing} / 4) $base-spacing;
+  padding: calc(#{$base-spacing} / 8) calc(3 * $base-spacing / 4);
   text-align: center;
-
-  @include media-breakpoint-down(xs) {
-    min-width: $base-spacing * 3;
-  }
-
-  @include media-breakpoint-up(lg) {
-    min-width: $base-spacing * 5;
-  }
 }

--- a/assets/css/_schedule.scss
+++ b/assets/css/_schedule.scss
@@ -5,7 +5,6 @@
 
 .schedule__route-name {
   display: inline-block;
-  font-size: var(--font-size-2xl);
   margin-bottom: 1rem;
   margin-top: 1.5rem;
 }

--- a/assets/css/_schedule.scss
+++ b/assets/css/_schedule.scss
@@ -352,6 +352,11 @@
   color: $white;
   display: inline-block;
   font-weight: bold;
+  min-width: 3rem;
   padding: calc(#{$base-spacing} / 8) calc(3 * $base-spacing / 4);
   text-align: center;
+
+  @include media-breakpoint-up(sm) {
+    min-width: 3.5rem;
+  }
 }

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -1,0 +1,15 @@
+defmodule DotcomWeb.Components.ScheduleHeaderComponents do
+  @moduledoc """
+  Components for the shared header for the schedule pages (line, timetable, and route-level alerts pages).
+  """
+
+  use DotcomWeb, :component
+
+  import DotcomWeb.ScheduleView, only: [route_header_text: 1]
+
+  def route_header(assigns) do
+    ~H"""
+    <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
+    """
+  end
+end

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -7,9 +7,60 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   import DotcomWeb.ScheduleView, only: [route_header_text: 1]
 
+  alias Routes.Route
+
   def route_header(assigns) do
     ~H"""
-    <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
+    <h1 class="schedule__route-name notranslate">
+      <div class="flex gap-1 items-center">
+        <.route_header_icon route={@route} /> <span>{route_header_text(@route)}</span>
+      </div>
+    </h1>
+    """
+  end
+
+  defp route_header_icon(%{route: %Route{type: route_type}} = assigns)
+       when route_type in [0, 1] do
+    ~H"""
+    <.header_icon name="icon-subway-default" />
+    """
+  end
+
+  defp route_header_icon(%{route: %Route{type: 2}} = assigns) do
+    ~H"""
+    <.header_icon name="icon-commuter-rail-default" />
+    """
+  end
+
+  defp route_header_icon(%{route: %Route{type: 3} = route} = assigns) do
+    if Route.silver_line?(route) do
+      ~H"""
+      <.header_icon class="mr-1" name="icon-bus-default" />
+      """
+    else
+      ~H""
+    end
+  end
+
+  defp route_header_icon(%{route: %Route{type: 4}} = assigns) do
+    ~H"""
+    <.header_icon class="mr-1" name="icon-ferry-default" />
+    """
+  end
+
+  defp route_header_icon(assigns), do: ~H""
+
+  attr :class, :string, default: ""
+  attr :name, :string, required: true
+
+  defp header_icon(assigns) do
+    ~H"""
+    <.icon
+      aria-hidden
+      class={"fill-current size-8 shrink-0 #{@class}"}
+      type="icon-svg"
+      name={@name}
+    />
     """
   end
 end

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -5,19 +5,38 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   use DotcomWeb, :component
 
-  import DotcomWeb.ScheduleView, only: [route_header_text: 1]
+  import DotcomWeb.ViewHelpers, only: [clean_route_name: 1]
 
   alias Routes.Route
 
   def route_header(assigns) do
     ~H"""
     <h1 class="schedule__route-name notranslate">
-      <div class="flex gap-1 items-center">
+      <div class="flex flex-wrap gap-1 items-center">
         <.route_header_icon route={@route} /> <span>{route_header_text(@route)}</span>
       </div>
     </h1>
     """
   end
+
+  defp route_header_text(%Route{type: 3, name: name} = route) do
+    if Route.silver_line?(route) do
+      if route.id == "746" do
+        "Silver Line Waterfront"
+      else
+        "Silver Line #{name}"
+      end
+    else
+      if route.long_name == "" do
+        ~t"Bus Route"
+      else
+        route.long_name
+      end
+    end
+  end
+
+  defp route_header_text(%Route{type: 2, name: name}), do: clean_route_name(name)
+  defp route_header_text(%Route{name: name}), do: name
 
   defp route_header_icon(%{route: %Route{type: route_type}} = assigns)
        when route_type in [0, 1] do
@@ -56,7 +75,7 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   defp bus_route_sign(assigns) do
     ~H"""
-    <div class="bus-route-sign">
+    <div class="bus-route-sign mr-1.5">
       {@route_name}
     </div>
     """

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -11,10 +11,10 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   def route_header(assigns) do
     ~H"""
-    <h1 class="schedule__route-name text-2xl sm:text-[2.5rem] notranslate">
+    <h1 class={["schedule__route-name notranslate", route_header_font_size(@route)]}>
       <div class="flex flex-wrap gap-1 items-center">
         <.route_header_icon route={@route} />
-        <span class={[route_header_font_size(@route), "leading-tight"]}>
+        <span class="leading-tight">
           {@route |> route_header_text() |> break_text_at_slash()}
         </span>
       </div>
@@ -42,13 +42,13 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   defp route_header_font_size(%Route{type: 3} = route) do
     if Route.silver_line?(route) do
-      ""
+      "text-2xl sm:text-[2.5rem]"
     else
       "text-xl sm:text-[1.75rem]"
     end
   end
 
-  defp route_header_font_size(_), do: ""
+  defp route_header_font_size(_), do: "text-2xl sm:text-[2.5rem]"
 
   defp route_header_icon(%{route: %Route{type: route_type}} = assigns)
        when route_type in [0, 1] do
@@ -87,7 +87,7 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   defp bus_route_sign(assigns) do
     ~H"""
-    <div class="bus-route-sign mr-1.5">
+    <div class="bus-route-sign mr-1 sm:mr-1.5">
       {@route_name}
     </div>
     """

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -23,6 +23,12 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     """
   end
 
+  # The text that shows up visibly on the schedule header as the
+  # route's title. For subway, commuter rail, and ferry, this will be
+  # the route's name. For non-silver-line bus, it'll be the route long
+  # name (e.g. "Harvard Square - Nubian Station"), or "Bus Route" if
+  # there isn't one. Silver Line buses get a more descriptive "Silver
+  # Line"-flavored name.
   defp route_header_text(%Route{id: "746", type: 3}), do: "Silver Line Waterfront"
 
   defp route_header_text(%Route{type: 3, name: name} = route) when is_silver_line?(route),
@@ -33,11 +39,22 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   defp route_header_text(%Route{name: name}), do: name
 
+  # Non-silver-line bus routes tend to have longer names, so we use a
+  # smaller font size for those.
   defp route_header_font_size(%Route{type: 3} = route) when not is_silver_line?(route),
     do: "text-xl sm:text-[1.75rem]"
 
   defp route_header_font_size(_), do: "text-2xl sm:text-[2.5rem]"
 
+  # The icon that goes to the left of the title. For non-silver-line
+  # bus, that icon is a route pill with the route number in it. For
+  # everything else, it's a mode icon.
+  #
+  # NOTE: For subway, commuter rail, ferry, and silver line bus, the
+  # icon is purely decorative, and is thus `aria-hidden`. For
+  # non-silver-line bus, the icon has the bus route number in it,
+  # which is useful information, and is thus *not* aria-hidden; it
+  # *should* be included in screen reader readout.
   defp route_header_icon(%{route: %Route{type: route_type}} = assigns)
        when route_type in [0, 1] do
     ~H"""

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -38,7 +38,9 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
       <.header_icon class="mr-1" name="icon-bus-default" />
       """
     else
-      ~H""
+      ~H"""
+      <.bus_route_sign route_name={@route.name} />
+      """
     end
   end
 
@@ -49,6 +51,16 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
   end
 
   defp route_header_icon(assigns), do: ~H""
+
+  attr :route_name, :string, required: true
+
+  defp bus_route_sign(assigns) do
+    ~H"""
+    <div class="bus-route-sign">
+      {@route_name}
+    </div>
+    """
+  end
 
   attr :class, :string, default: ""
   attr :name, :string, required: true

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -11,10 +11,12 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   def route_header(assigns) do
     ~H"""
-    <h1 class="schedule__route-name notranslate">
+    <h1 class="schedule__route-name text-2xl sm:text-[2.5rem] notranslate">
       <div class="flex flex-wrap gap-1 items-center">
         <.route_header_icon route={@route} />
-        <span>{@route |> route_header_text() |> break_text_at_slash()}</span>
+        <span class={[route_header_font_size(@route), "leading-tight"]}>
+          {@route |> route_header_text() |> break_text_at_slash()}
+        </span>
       </div>
     </h1>
     """
@@ -37,6 +39,16 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
   end
 
   defp route_header_text(%Route{name: name}), do: name
+
+  defp route_header_font_size(%Route{type: 3} = route) do
+    if Route.silver_line?(route) do
+      ""
+    else
+      "text-xl sm:text-[1.75rem]"
+    end
+  end
+
+  defp route_header_font_size(_), do: ""
 
   defp route_header_icon(%{route: %Route{type: route_type}} = assigns)
        when route_type in [0, 1] do
@@ -88,7 +100,7 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     ~H"""
     <.icon
       aria-hidden
-      class={"fill-current size-8 shrink-0 #{@class}"}
+      class={"fill-current size-8 sm:size-10 shrink-0 #{@class}"}
       type="icon-svg"
       name={@name}
     />

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -6,6 +6,7 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
   use DotcomWeb, :component
 
   import DotcomWeb.ViewHelpers, only: [break_text_at_slash: 1]
+  import Routes.Route, only: [is_silver_line?: 1]
 
   alias Routes.Route
 
@@ -22,31 +23,18 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     """
   end
 
-  defp route_header_text(%Route{type: 3, name: name} = route) do
-    if Route.silver_line?(route) do
-      if route.id == "746" do
-        "Silver Line Waterfront"
-      else
-        "Silver Line #{name}"
-      end
-    else
-      if route.long_name == "" do
-        ~t"Bus Route"
-      else
-        route.long_name
-      end
-    end
-  end
+  defp route_header_text(%Route{id: "746", type: 3}), do: "Silver Line Waterfront"
+
+  defp route_header_text(%Route{type: 3, name: name} = route) when is_silver_line?(route),
+    do: "Silver Line #{name}"
+
+  defp route_header_text(%Route{type: 3, long_name: ""}), do: ~t"Bus Route"
+  defp route_header_text(%Route{type: 3, long_name: long_name}), do: long_name
 
   defp route_header_text(%Route{name: name}), do: name
 
-  defp route_header_font_size(%Route{type: 3} = route) do
-    if Route.silver_line?(route) do
-      "text-2xl sm:text-[2.5rem]"
-    else
-      "text-xl sm:text-[1.75rem]"
-    end
-  end
+  defp route_header_font_size(%Route{type: 3} = route) when not is_silver_line?(route),
+    do: "text-xl sm:text-[1.75rem]"
 
   defp route_header_font_size(_), do: "text-2xl sm:text-[2.5rem]"
 
@@ -63,16 +51,17 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     """
   end
 
-  defp route_header_icon(%{route: %Route{type: 3} = route} = assigns) do
-    if Route.silver_line?(route) do
-      ~H"""
-      <.header_icon class="mr-1" name="icon-bus-default" />
-      """
-    else
-      ~H"""
-      <.bus_route_sign route_name={@route.name} />
-      """
-    end
+  defp route_header_icon(%{route: %Route{type: 3} = route} = assigns)
+       when is_silver_line?(route) do
+    ~H"""
+    <.header_icon class="mr-1" name="icon-bus-default" />
+    """
+  end
+
+  defp route_header_icon(%{route: %Route{type: 3}} = assigns) do
+    ~H"""
+    <.bus_route_sign route_name={@route.name} />
+    """
   end
 
   defp route_header_icon(%{route: %Route{type: 4}} = assigns) do

--- a/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
+++ b/lib/dotcom_web/components/schedule_page/schedule_header_components.ex
@@ -5,7 +5,7 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
 
   use DotcomWeb, :component
 
-  import DotcomWeb.ViewHelpers, only: [clean_route_name: 1]
+  import DotcomWeb.ViewHelpers, only: [break_text_at_slash: 1]
 
   alias Routes.Route
 
@@ -13,7 +13,8 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     ~H"""
     <h1 class="schedule__route-name notranslate">
       <div class="flex flex-wrap gap-1 items-center">
-        <.route_header_icon route={@route} /> <span>{route_header_text(@route)}</span>
+        <.route_header_icon route={@route} />
+        <span>{@route |> route_header_text() |> break_text_at_slash()}</span>
       </div>
     </h1>
     """
@@ -35,7 +36,6 @@ defmodule DotcomWeb.Components.ScheduleHeaderComponents do
     end
   end
 
-  defp route_header_text(%Route{type: 2, name: name}), do: clean_route_name(name)
   defp route_header_text(%Route{name: name}), do: name
 
   defp route_header_icon(%{route: %Route{type: route_type}} = assigns)

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -11,10 +11,11 @@ defmodule DotcomWeb.LineDiagramLive do
 
   alias DotcomWeb.PartialView.{HeaderTab, HeaderTabs}
 
+  import DotcomWeb.Components.ScheduleHeaderComponents, only: [route_header: 1]
+
   import DotcomWeb.ScheduleView,
     only: [
       header_class: 1,
-      route_header_text: 1,
       route_header_description: 1,
       route_feature_badge: 1,
       route_tab_class: 1
@@ -105,7 +106,7 @@ defmodule DotcomWeb.LineDiagramLive do
     ~H"""
     <div class={"schedule__header #{ header_class(@route) }"}>
       <div class="schedule__header-container">
-        <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
+        <.route_header route={@route} />
         {route_header_description(@route)}
         {route_feature_badge(@route)}
         <div class="schedule__header-tabs">{header_tabs(assigns)}</div>

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -16,7 +16,6 @@ defmodule DotcomWeb.LineDiagramLive do
   import DotcomWeb.ScheduleView,
     only: [
       header_class: 1,
-      route_header_description: 1,
       route_feature_badge: 1,
       route_tab_class: 1
     ]
@@ -107,7 +106,6 @@ defmodule DotcomWeb.LineDiagramLive do
     <div class={"schedule__header #{ header_class(@route) }"}>
       <div class="schedule__header-container">
         <.route_header route={@route} />
-        {route_header_description(@route)}
         {route_feature_badge(@route)}
         <div class="schedule__header-tabs">{header_tabs(assigns)}</div>
       </div>

--- a/lib/dotcom_web/templates/schedule/_line_header.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line_header.html.heex
@@ -1,6 +1,6 @@
 <div class={"schedule__header #{ header_class(@route) }"}>
   <div class="schedule__header-container">
-    <h1 class="schedule__route-name notranslate">{route_header_text(@route)}</h1>
+    <DotcomWeb.Components.ScheduleHeaderComponents.route_header route={@route} />
     {route_header_description(@route)}
     {route_feature_badge(@route)}
     <div class="schedule__header-tabs">

--- a/lib/dotcom_web/templates/schedule/_line_header.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line_header.html.heex
@@ -1,7 +1,6 @@
 <div class={"schedule__header #{ header_class(@route) }"}>
   <div class="schedule__header-container">
     <DotcomWeb.Components.ScheduleHeaderComponents.route_header route={@route} />
-    {route_header_description(@route)}
     {route_feature_badge(@route)}
     <div class="schedule__header-tabs">
       {route_header_tabs(@conn)}

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -239,6 +239,10 @@ defmodule DotcomWeb.ScheduleView do
       else
         ["Silver Line ", name]
       end
+    else
+      content_tag :div, class: "bus-route-sign" do
+        route.name
+      end
     end
   end
 

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -239,10 +239,6 @@ defmodule DotcomWeb.ScheduleView do
       else
         ["Silver Line ", name]
       end
-    else
-      content_tag :div, class: "bus-route-sign" do
-        route.name
-      end
     end
   end
 

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -99,6 +99,9 @@ defmodule Routes.Route do
            when route.type == 3 and route.description == :rail_replacement_bus and
                   not is_external?(route)
 
+  defguard is_silver_line?(route)
+           when route.id in @silver_line and not is_external?(route)
+
   @spec type_atom(t | type_int | String.t()) :: route_type
   def type_atom(%__MODULE__{external_agency_name: "Massport"}), do: :massport_shuttle
   def type_atom(%__MODULE__{external_agency_name: "Logan Express"}), do: :logan_express

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -728,6 +728,7 @@ msgstr ""
 msgid "Bus Other"
 msgstr ""
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -728,6 +728,7 @@ msgstr ""
 msgid "Bus Other"
 msgstr ""
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -730,6 +730,7 @@ msgstr "Mapa de colectivos"
 msgid "Bus Other"
 msgstr "colectivo Otros"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -730,6 +730,7 @@ msgstr "Carte des bus"
 msgid "Bus Other"
 msgstr "bus Autres"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -730,6 +730,7 @@ msgstr "Kat jeyografik bis"
 msgid "Bus Other"
 msgstr "bis Lòt"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -730,6 +730,7 @@ msgstr "Mapa de ônibus"
 msgid "Bus Other"
 msgstr "ônibus Outro"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -724,6 +724,7 @@ msgstr "Bản đồ xe buýt"
 msgid "Bus Other"
 msgstr "xe buýt Khác"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -722,6 +722,7 @@ msgstr "巴士地图"
 msgid "Bus Other"
 msgstr "巴士其他"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -722,6 +722,7 @@ msgstr "巴士地圖"
 msgid "Bus Other"
 msgstr "巴士其他"
 
+#: lib/dotcom_web/components/schedule_page/schedule_header_components.ex
 #: lib/dotcom_web/views/schedule_view.ex
 #, elixir-autogen, elixir-format
 msgid "Bus Route"


### PR DESCRIPTION
## Scope

**Asana Ticket:** [💈 Visual styling tweaks](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1216638931645026?focus=true)

> [!NOTE]
> There was a tiny bit of scope-shifting, due to some tokens that are desired for this not being available in the design system, and thus not available in Figma.
> 
> - For non-silver-line bus, the route pill and long-name text should all be in the `h1`, and should be 1.75rem (28px) on Desktop, and 1.5rem (24px) on Mobile. For all other modes, those font sizes should be the same as they currently are in prod, which is 2.5rem (40px) on Desktop, and 2rem (32px) on Mobile.
> - In prod, we currently remove the `" Line"` suffix for commuter rail routes, but we decided not to do that anymore.
> 
> I added these notes to the ticket as well.

## Implementation

I did this in ~three~ _five_+ commits:
1. Just the plain old CSS stuff - the font size and padding changes.
2. Refactor to create a HEEx component file, currently just for the `<h1>{route_header_text}</h1>`, but I imagine that we may want to eventually use it for the whole schedule route header.
3. Add the mode icon to the appropriate routes/modes. 
4. Refactor to make the bus route sign (the black-background-white-text pill with the bus route number) be the route header icon instead of the route header text. (This preserves the readout, however, since that is important)
5. Move the bus route long-name (e.g. ["Hull Ferry - Hingham Depot"](http://localhost:4001/schedules/714/line)) into the `<h1>` title, and remove the `<h2>` description (this improves line-wrapping... see below, and aligns with the designs, which have both the route number and the long-name as `<h1>`'s).

... plus a few additional commits to fix tests, address design feedback, etc.

<!--
In case you're looking at the HTML view of this PR, wondering what happened to the :robot: note, this PR was all human-generated, so I left the note commented.

> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots

[Subway](http://localhost:4001/schedules/Red/line)
<img width="2004" height="678" alt="Screenshot 2026-09-04 at 5 46 49 PM" src="https://github.com/user-attachments/assets/71a3ab84-02f0-461c-ac5b-f3f18f086176" />

[Commuter Rail](http://localhost:4001/schedules/CR-Greenbush/timetable)
<img width="2000" height="630" alt="Screenshot 2026-09-08 at 1 25 30 PM" src="https://github.com/user-attachments/assets/c358ef20-679c-44f2-b9a0-c7663dac47bb" />

[Silver Line Bus](http://localhost:4001/schedules/741/line)
<img width="2000" height="628" alt="Screenshot 2026-09-04 at 5 48 15 PM" src="https://github.com/user-attachments/assets/cf4f9739-4aad-4f26-ae03-cd7558f508f4" />

[Non-Silver Line Bus](http://localhost:4001/schedules/714/line)
<img width="1998" height="782" alt="Screenshot 2026-09-08 at 4 07 31 PM" src="https://github.com/user-attachments/assets/9228112c-8d79-4dc2-b72a-233f8d84e35f" />

[Ferry](http://localhost:4001/schedules/Boat-F7/timetable)
<img width="1998" height="738" alt="Screenshot 2026-09-04 at 5 52 36 PM" src="https://github.com/user-attachments/assets/cb3098a4-02ee-41cf-9965-c162cc33f110" />


## How to test

Look at the various route pages linked above, as well as any other route pages you can think of. Check [bus routes with short route numbers](http://localhost:4001/schedules/1/line), [commuter rail routes with long names](http://localhost:4001/schedules/CR-NewBedford/timetable), [bus routes with long long-names](http://localhost:4001/schedules/23/line), etc. See how things look at different browser widths.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->

## Note

👇  is the current line-wrapping behavior, compared to prod. Unlike below, I _am_ happy with this.
<img width="2000" height="808" alt="Screenshot 2026-09-08 at 4 11 01 PM" src="https://github.com/user-attachments/assets/bfbeed82-9999-4304-8f7c-6b75d8dd126c" />


Below is what it looked like before I added [this change](https://github.com/mbta/dotcom/pull/3477/commits/09f823ea266d3ee144c7670d57819ff18723cc9d).

---

~I'm not sure I love the wrapping behavior for bus routes with long names. It's not new, but the combination of the bottom-padding change and the fact that the bus route ID and the route description are the same font size now make the wrapping look more _wrong_ (IMO). I'm interested in ideas for how to make that look better, and will likely explore those before merging.~

<img width="2006" height="856" alt="Screenshot 2026-09-04 at 5 51 33 PM" src="https://github.com/user-attachments/assets/a315eeeb-2d2a-4bf2-b01d-02b4e1b64c06" />

