### PR TITLE
feat: Breadcrumbs for new line diagram page

### DIFF
--- a/lib/dotcom_web/hooks/assign_route.ex
+++ b/lib/dotcom_web/hooks/assign_route.ex
@@ -1,0 +1,14 @@
+defmodule DotcomWeb.Hooks.AssignRoute do
+  @moduledoc """
+  Assign the route, before both disconnected and connected mounts.
+  """
+  import Phoenix.Component, only: [assign: 3]
+
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+
+  def on_mount(:default, %{"route_id" => route_id}, _session, socket) do
+    route = @routes_repo.get(route_id)
+
+    {:cont, assign(socket, :route, route)}
+  end
+end

--- a/lib/dotcom_web/hooks/assign_route.ex
+++ b/lib/dotcom_web/hooks/assign_route.ex
@@ -6,14 +6,18 @@ defmodule DotcomWeb.Hooks.AssignRoute do
 
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
+  @doc """
+  Uses the route ID in the params to look up the corresponding
+  route, and assigns that route to the socket as `:route`.
+
+  If the route doesn't exist, then raises a
+  `DotcomWeb.NotFoundError` in order to get
+  `DotcomWeb.Router.handle_errors/2` to render the 404 page.
+  """
   def on_mount(:default, %{"route_id" => route_id}, _session, socket) do
     case @routes_repo.get(route_id) do
-      nil ->
-        # Raising this error will render the 404 page
-        raise DotcomWeb.NotFoundError
-
-      route ->
-        {:cont, assign(socket, :route, route)}
+      nil -> raise DotcomWeb.NotFoundError
+      route -> {:cont, assign(socket, :route, route)}
     end
   end
 end

--- a/lib/dotcom_web/hooks/assign_route.ex
+++ b/lib/dotcom_web/hooks/assign_route.ex
@@ -7,8 +7,13 @@ defmodule DotcomWeb.Hooks.AssignRoute do
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
   def on_mount(:default, %{"route_id" => route_id}, _session, socket) do
-    route = @routes_repo.get(route_id)
+    case @routes_repo.get(route_id) do
+      nil ->
+        # Raising this error will render the 404 page
+        raise DotcomWeb.NotFoundError
 
-    {:cont, assign(socket, :route, route)}
+      route ->
+        {:cont, assign(socket, :route, route)}
+    end
   end
 end

--- a/lib/dotcom_web/hooks/breadcrumbs.ex
+++ b/lib/dotcom_web/hooks/breadcrumbs.ex
@@ -2,6 +2,7 @@ defmodule DotcomWeb.Hooks.Breadcrumbs do
   @moduledoc """
   Assign the breadcrumbs, before both disconnected and connected mounts.
   """
+  alias DotcomWeb.Schedule.RouteBreadcrumbs
 
   use Dotcom.Gettext.Sigils
   use DotcomWeb, :verified_routes
@@ -15,6 +16,10 @@ defmodule DotcomWeb.Hooks.Breadcrumbs do
 
   def on_mount(:trip_planner, _params, _session, socket) do
     {:cont, assign(socket, :breadcrumbs, [build(~t"Trip Planner")])}
+  end
+
+  def on_mount(:schedule_page, _params, _session, %{assigns: %{route: route}} = socket) do
+    {:cont, assign(socket, :breadcrumbs, RouteBreadcrumbs.breadcrumbs(route))}
   end
 
   # catch-all case

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -22,6 +22,7 @@ defmodule DotcomWeb.LineDiagramLive do
   import DotcomWeb.Views.Helpers.AlertHelpers, only: [alert_badge: 1]
 
   on_mount DotcomWeb.Hooks.AssignRoute
+  on_mount {DotcomWeb.Hooks.Breadcrumbs, :schedule_page}
 
   def mount(params, _session, socket) do
     route = socket.assigns.route

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -5,7 +5,6 @@ defmodule DotcomWeb.LineDiagramLive do
 
   use DotcomWeb, :live_view
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
-  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
@@ -22,9 +21,11 @@ defmodule DotcomWeb.LineDiagramLive do
 
   import DotcomWeb.Views.Helpers.AlertHelpers, only: [alert_badge: 1]
 
+  on_mount DotcomWeb.Hooks.AssignRoute
+
   def mount(params, _session, socket) do
-    route_id = params |> Map.get("route_id")
-    route = @routes_repo.get(route_id)
+    route = socket.assigns.route
+    route_id = route.id
     route_patterns = @route_patterns_repo.by_route_id(route_id)
 
     direction_id =


### PR DESCRIPTION
## Scope

**Asana Ticket:** [💈 Add breadcrumbs to new line diagram page](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1218191070934369?focus=true)

## Implementation

I chose to add an `AssignRoute` hook, rather than just querying for the route in the `Breadcrumbs` hook, because I didn't want to create a world where we were re-querying the same route ID over and over again. So the state of the world now is that we have an `AssignRoute` hook that assigns the route to the socket, and the `Breadcrumbs` hook (if called in the context of the `:schedule_page`) assumes that `:route` is already assigned.

> [!NOTE]
> :robot: This was mostly human-written, but [the commit that adds proper not-found handling](https://github.com/mbta/dotcom/pull/3478/commits/6cba70d003582a49416842399824af134b6b1184) was written by Copilot (and then [refined with a human touch](https://github.com/mbta/dotcom/pull/3478/commits/9d6fd82bcce9519009650d21c0d4b91e23ad8129))

## Screenshots

<img width="2008" height="1046" alt="Screenshot 2026-09-04 at 6 02 36 PM" src="https://github.com/user-attachments/assets/c9e1623c-1d08-4d41-9cc6-af4eb31cee70" />

Why yes, I did make sure to get a screenshot where the "Watch Your Step" message had a visible step in it.

## How to test

Look at the [new line diagram page](http://localhost:4001/schedules/Boat-F7/line_new) and see that the breadcrumbs are the same as they are on any of the other tabs.