### PR TITLE
chore: Add `@moduledoc` to `DotcomWeb.Router`, and `@doc` to `handle_error/2`

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -1,12 +1,31 @@
 defmodule DotcomWeb.Router do
-  @moduledoc false
-  # remove this comment, it is here to try and fix github (don't ask)
+  @moduledoc """
+  Dotcom's router. A normal Phoenix router with a fairly large
+  number of routes, which exist in order to support a large number
+  of historical pages.
+
+  One quirk worth noting is that we have an all-purpose fallback. If
+  a path doesn't resolve to any of our hard-coded routes, then it
+  falls back to the `DotcomWeb.CMSController`. This means that the
+  URL sigil `~p` won't provide a warning if you get a path wrong,
+  because in theory, that path could resolve to something in the
+  CMS.
+  """
+
   use DotcomWeb, :router
   use Plug.ErrorHandler
 
   alias DotcomWeb.ControllerHelpers
 
   @impl Plug.ErrorHandler
+
+  @doc """
+  A custom error handling function that renders the appropriate
+  error page.
+
+  For most (unexpected) errors, we render a 500 page. When we see a
+  `DotcomWeb.NotFoundError`, we render the 404 page instead.
+  """
   def handle_errors(conn, %{reason: reason}) do
     case reason do
       %{plug_status: 404} ->


### PR DESCRIPTION
## Scope

No ticket, and not terribly important either. I just added this because I noticed when working on https://github.com/mbta/dotcom/pull/3478 that [the docs for the new `AssignRoute` hook](https://mbta.github.io/dotcom/DotcomWeb.Hooks.AssignRoute.html) didn't link to `handle_error/1`, and that's because there's nothing to link to, due to `@moduledoc false`.

## Screenshots

<img width="1806" height="586" alt="Screenshot 2026-09-08 at 6 23 02 PM" src="https://github.com/user-attachments/assets/a575da9b-91ff-41d2-b978-10a9e753d9f0" />

Look! Now there's a link!

# How to test

Run `mix docs`, and then look at the docs at `<path>/<to>/<dotcom>/doc/DotcomWeb.Hooks.AssignRoute.html#on_mount/4` and `<path>/<to>/<dotcom>/doc/DotcomWeb.Router.html`