### PR TITLE
feat(Schedules.Trip): parse the next trip

### DIFF
--- a/lib/json_api.ex
+++ b/lib/json_api.ex
@@ -28,10 +28,7 @@ defmodule JsonApi do
 
   @spec empty() :: JsonApi.t()
   def empty do
-    %JsonApi{
-      links: %{},
-      data: []
-    }
+    %JsonApi{links: %{}, data: []}
   end
 
   @spec merge(JsonApi.t(), JsonApi.t()) :: JsonApi.t()
@@ -80,12 +77,19 @@ defmodule JsonApi do
   @spec parse_data(term()) :: {:ok, [JsonApi.Item.t()]} | {:error, any}
   defp parse_data(%{"data" => data} = parsed) when is_list(data) do
     included = parse_included(parsed)
-    {:ok, Enum.map(data, &parse_data_item(&1, included))}
+    # cache is a mutable-ish accumulator: {type, id} => %JsonApi.Item{}
+    {items, _cache} =
+      Enum.map_reduce(data, %{}, fn item, cache ->
+        parse_data_item(item, included, cache, MapSet.new())
+      end)
+
+    {:ok, items}
   end
 
   defp parse_data(%{"data" => data} = parsed) do
     included = parse_included(parsed)
-    {:ok, [parse_data_item(data, included)]}
+    {item, _cache} = parse_data_item(data, included, %{}, MapSet.new())
+    {:ok, [item]}
   end
 
   defp parse_data(%{"errors" => errors}) do
@@ -106,56 +110,115 @@ defmodule JsonApi do
     {:error, :invalid}
   end
 
-  def parse_data_item(%{"type" => type, "id" => id, "attributes" => attributes} = item, included) do
-    %JsonApi.Item{
-      type: type,
-      id: id,
-      attributes: attributes,
-      relationships: load_relationships(item["relationships"], included)
-    }
+  # parse_data_item/2 kept as a public, cache-free convenience wrapper for
+  # anywhere else in the codebase that calls it directly (e.g. tests).
+  @spec parse_data_item(map(), map()) :: JsonApi.Item.t()
+  def parse_data_item(item, included) do
+    {parsed, _cache} = parse_data_item(item, included, %{}, MapSet.new())
+    parsed
   end
 
-  def parse_data_item(%{"type" => type, "id" => id}, _) do
-    %JsonApi.Item{
-      type: type,
-      id: id
-    }
-  end
+  # The real implementation. `cache` maps {type, id} => already-built Item,
+  # so a resource referenced from multiple places in the graph is only ever
+  # parsed once. `visiting` is the set of {type, id} pairs currently being
+  # expanded on the *current path* - if we hit one of those again, it means
+  # the included graph is cyclic (e.g. stop <-> transfer <-> stop), and we
+  # stop descending instead of recursing forever.
+  @spec parse_data_item(map(), map(), map(), MapSet.t()) :: {JsonApi.Item.t(), map()}
+  defp parse_data_item(
+         %{"type" => type, "id" => id, "attributes" => attributes} = item,
+         included,
+         cache,
+         visiting
+       ) do
+    key = {type, id}
 
-  defp load_relationships(nil, _) do
-    %{}
-  end
+    cond do
+      Map.has_key?(cache, key) ->
+        {Map.fetch!(cache, key), cache}
 
-  defp load_relationships(%{} = relationships, included) do
-    relationships
-    |> map_values(&load_single_relationship(&1, included))
-  end
+      MapSet.member?(visiting, key) ->
+        # Cycle detected: return a stub without relationships rather than
+        # recursing further. This breaks the loop; the caller already has
+        # (or will have) the fully-expanded version in the cache once its
+        # own parse completes.
+        stub = %JsonApi.Item{
+          type: type,
+          id: id,
+          attributes: attributes,
+          relationships: %{}
+        }
 
-  defp map_values(map, f) do
-    map
-    |> Map.new(fn {key, value} -> {key, f.(value)} end)
-  end
+        {stub, cache}
 
-  defp load_single_relationship(relationship, _) when relationship == %{} do
-    []
-  end
+      true ->
+        visiting = MapSet.put(visiting, key)
 
-  defp load_single_relationship(%{"data" => data}, included) when is_list(data) do
-    data
-    |> Enum.map(&match_included(&1, included))
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map(&parse_data_item(&1, included))
-  end
+        {relationships, cache} =
+          load_relationships(item["relationships"], included, cache, visiting)
 
-  defp load_single_relationship(%{"data" => %{} = data}, included) do
-    case data |> match_included(included) do
-      nil -> []
-      item -> [parse_data_item(item, included)]
+        parsed = %JsonApi.Item{
+          type: type,
+          id: id,
+          attributes: attributes,
+          relationships: relationships
+        }
+
+        {parsed, Map.put(cache, key, parsed)}
     end
   end
 
-  defp load_single_relationship(_, _) do
-    []
+  # Bare resource identifier: no "attributes" key, so this is a
+  # relationship-linkage object rather than a fully-loaded resource.
+  # attributes/relationships are left at their struct defaults (nil/nil).
+  defp parse_data_item(%{"type" => type, "id" => id}, _included, cache, _visiting) do
+    item = %JsonApi.Item{type: type, id: id}
+    {item, Map.put(cache, {type, id}, item)}
+  end
+
+  defp load_relationships(nil, _included, cache, _visiting) do
+    {%{}, cache}
+  end
+
+  defp load_relationships(%{} = relationships, included, cache, visiting) do
+    Enum.map_reduce(relationships, cache, fn {name, relationship}, cache ->
+      {items, cache} = load_single_relationship(relationship, included, cache, visiting)
+      {{name, items}, cache}
+    end)
+    |> then(fn {pairs, cache} -> {Map.new(pairs), cache} end)
+  end
+
+  defp load_single_relationship(relationship, _included, cache, _visiting)
+       when relationship == %{} do
+    {[], cache}
+  end
+
+  defp load_single_relationship(%{"data" => data}, included, cache, visiting)
+       when is_list(data) do
+    {items, cache} =
+      data
+      |> Enum.map(&match_included(&1, included))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map_reduce(cache, fn item, cache ->
+        parse_data_item(item, included, cache, visiting)
+      end)
+
+    {items, cache}
+  end
+
+  defp load_single_relationship(%{"data" => %{} = data}, included, cache, visiting) do
+    case match_included(data, included) do
+      nil ->
+        {[], cache}
+
+      item ->
+        {parsed, cache} = parse_data_item(item, included, cache, visiting)
+        {[parsed], cache}
+    end
+  end
+
+  defp load_single_relationship(_, _included, cache, _visiting) do
+    {[], cache}
   end
 
   defp match_included(nil, _) do

--- a/lib/schedules/parser.ex
+++ b/lib/schedules/parser.ex
@@ -87,7 +87,8 @@ defmodule Schedules.Parser do
       shape_id: shape_id(relationships),
       route_pattern_id: route_pattern_id(relationships),
       bikes_allowed?: bikes_allowed?(attributes),
-      occupancy: occupancy(relationships)
+      occupancy: occupancy(relationships),
+      next_trip_id: next_trip_id(relationships)
     }
   end
 
@@ -192,4 +193,18 @@ defmodule Schedules.Parser do
   end
 
   defp occupancy(_), do: nil
+
+  # 4 is in-seat transfer
+  defp next_trip_id(%{
+         "from_trip_transfers" => [
+           %JsonApi.Item{
+             attributes: %{"transfer_type" => 4},
+             relationships: %{"to_trip" => [%{id: to_trip_id}]}
+           }
+         ]
+       }) do
+    to_trip_id
+  end
+
+  defp next_trip_id(_), do: nil
 end

--- a/lib/schedules/parser.ex
+++ b/lib/schedules/parser.ex
@@ -56,42 +56,28 @@ defmodule Schedules.Parser do
   def trip(%JsonApi.Item{
         relationships: %{
           "trip" => [
-            %JsonApi.Item{
-              id: id,
-              attributes:
-                %{"name" => name, "headsign" => headsign, "direction_id" => direction_id} =
-                  attributes,
-              relationships: relationships
-            }
+            %JsonApi.Item{} = trip
             | _
           ]
         }
       }) do
-    %Schedules.Trip{
-      id: id,
-      headsign: headsign,
-      name: name,
-      direction_id: direction_id,
-      bikes_allowed?: bikes_allowed?(attributes),
-      route_pattern_id: route_pattern_id(relationships),
-      shape_id: shape_id(relationships),
-      occupancy: occupancy(relationships)
-    }
+    trip(trip)
   end
 
-  def trip(%JsonApi{
-        data: [
-          %JsonApi.Item{
-            id: id,
-            attributes:
-              %{
-                "headsign" => headsign,
-                "name" => name,
-                "direction_id" => direction_id
-              } = attributes,
-            relationships: relationships
-          }
-        ]
+  def trip(%JsonApi{data: [%JsonApi.Item{type: "trip"} = trip]}) do
+    trip(trip)
+  end
+
+  def trip(%JsonApi.Item{
+        type: "trip",
+        id: id,
+        attributes:
+          %{
+            "headsign" => headsign,
+            "name" => name,
+            "direction_id" => direction_id
+          } = attributes,
+        relationships: relationships
       }) do
     %Schedules.Trip{
       id: id,
@@ -105,11 +91,7 @@ defmodule Schedules.Parser do
     }
   end
 
-  def trip(%JsonApi.Item{relationships: %{"trip" => _}}) do
-    nil
-  end
-
-  def trip(%JsonApi{data: []}), do: nil
+  def trip(_), do: nil
 
   def stop_id(%JsonApi.Item{
         relationships: %{

--- a/lib/schedules/repo.ex
+++ b/lib/schedules/repo.ex
@@ -25,7 +25,7 @@ defmodule Schedules.Repo do
   @type schedule_pair :: {Schedule.t(), Schedule.t()}
 
   @default_params [
-    include: "trip,trip.occupancies",
+    include: "trip,trip.occupancies,trip.from_trip_transfers",
     "fields[schedule]":
       "departure_time,arrival_time,drop_off_type,pickup_type,stop_sequence,stop_headsign,timepoint",
     "fields[trip]": "name,headsign,direction_id,bikes_allowed"
@@ -155,8 +155,8 @@ defmodule Schedules.Repo do
   defp fetch_trip(trip_id, trip_by_id_fn) do
     trip_opts =
       case Util.config(:dotcom, :enable_experimental_features) do
-        "true" -> [include: "occupancies"]
-        _ -> []
+        "true" -> [include: "occupancies,from_trip_transfers"]
+        _ -> [include: "from_trip_transfers"]
       end
 
     case trip_by_id_fn.(trip_id, trip_opts) do

--- a/lib/schedules/schedule.ex
+++ b/lib/schedules/schedule.ex
@@ -89,6 +89,7 @@ defmodule Schedules.Trip do
     :shape_id,
     :route_pattern_id,
     :occupancy,
+    :next_trip_id,
     bikes_allowed?: false
   ]
 
@@ -103,6 +104,7 @@ defmodule Schedules.Trip do
           shape_id: Shape.id_t() | nil,
           route_pattern_id: RoutePattern.id_t() | nil,
           bikes_allowed?: boolean,
-          occupancy: crowding() | nil
+          occupancy: crowding() | nil,
+          next_trip_id: id_t | nil
         }
 end

--- a/test/schedules/parser_test.exs
+++ b/test/schedules/parser_test.exs
@@ -1,6 +1,9 @@
 defmodule Schedules.ParserTest do
   use ExUnit.Case, async: true
+
   import Schedules.Parser
+  import Test.Support.Factories.MBTA.Api
+
   alias Routes.Route
 
   @arrival_time ~U[2023-06-13 10:00:00Z]
@@ -261,6 +264,52 @@ defmodule Schedules.ParserTest do
       }
 
       assert trip(api_item) == nil
+    end
+
+    test "parses the from_trip_transfer relationship to populate next_trip_id" do
+      next_trip_id = Test.Support.FactoryHelpers.build(:id)
+
+      transfer_item =
+        build(:item, %{
+          attributes: %{"transfer_type" => 4},
+          relationships: %{"to_trip" => [build(:trip_item, id: next_trip_id)]},
+          type: "transfer"
+        })
+
+      api_item =
+        build(:trip_item, %{
+          id: "trip-1",
+          relationships: %{
+            "from_trip_transfers" => [transfer_item]
+          }
+        })
+
+      assert %Schedules.Trip{
+               next_trip_id: ^next_trip_id
+             } = trip(api_item)
+    end
+
+    test "does not use transfers other than in-seat" do
+      next_trip_id = Test.Support.FactoryHelpers.build(:id)
+      other_transfer_type = Faker.Util.pick(0..3)
+
+      transfer_item =
+        build(:item, %{
+          attributes: %{"transfer_type" => other_transfer_type},
+          relationships: %{"to_trip" => [build(:trip_item, id: next_trip_id)]},
+          type: "transfer"
+        })
+
+      api_item =
+        build(:trip_item, %{
+          id: "trip-1",
+          relationships: %{
+            "from_trip_transfers" => [transfer_item]
+          }
+        })
+
+      trip = trip(api_item)
+      refute trip.next_trip_id == next_trip_id
     end
   end
 

--- a/test/schedules/repo_test.exs
+++ b/test/schedules/repo_test.exs
@@ -195,6 +195,7 @@ defmodule Schedules.RepoTest do
             "trip" => [
               %JsonApi.Item{
                 id: trip_id,
+                type: "trip",
                 attributes: %{
                   "headsign" => "North Station",
                   "name" => "300",


### PR DESCRIPTION
## Scope

**Asana Ticket:** part of [Follow up on "🛜 🐞 Daily Schedules sometimes doesn't show school trips "](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217929539836227?focus=true)

## Implementation

- https://github.com/mbta/api/pull/1074

Following this V3 API PR, we can now get information about in-seat transfers. In-seat transfers specifically use `transfer_type=4`.

[More about transfers](https://api-v3.mbta.com/docs/swagger/index.html#/Transfer/ApiWeb_TransferController_index) and [example API response](https://api-dev.mbtace.com/trips/76303138_2?include=from_trip_transfers.to_trip).

This PR lets us get transfers from a trip (via its `from_trip_transfers` relationship), and for in-seat transfers, get the transfer's related `to_trip` ID, and save this value in `%Schedules.Trip{}`'s new `next_trip_id` field.

> [!NOTE]
> I did use Copilot for the third commit, which slightly refactors our parsing module. Our current code infinitely recurses when there are nested relations with repeated types (like a trip's related transfer's related trip) :( 
