### PR TITLE
Line Diagram | Guide Links

### DIFF
--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -8,6 +8,65 @@ defmodule DotcomWeb.LineDiagramLive do
   @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
+  @guides [
+    %{
+      title: ~t(Subway Beginner's Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2018-12/Subway-Wordless-for-homepage-revised-2018-12-11.png",
+      link: "/guides/subway-guide",
+      modes: [0, 1]
+    },
+    %{
+      title: ~t(Bus Beginner's Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2018-12/Guides-Bus-Singleword-revised-2018-12-11.png",
+      link: "/guides/bus-guide",
+      modes: [3]
+    },
+    %{
+      title: ~t(Commuter Rail Beginner's Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2018-11/Guides-Commuter-HomepageWordless.png",
+      link: "/guides/commuter-rail-guide",
+      modes: [2]
+    },
+    %{
+      title: ~t(Ferry Beginner's Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2019-09/ferry-v2-wordless-for-homepage.png",
+      link: "/guides/ferry-guide",
+      modes: [4]
+    },
+    %{
+      title: ~t(Subway Access Guide),
+      image:
+        "sites/default/files/styles/max_2600x2600/public/Accessibility/govt-center-press-access-button.jpg",
+      link: "/accessibility/subway-guide",
+      modes: [0, 1]
+    },
+    %{
+      title: ~t(Bus Access Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/projects/betterbus/bus-pulling-up-route-43.jpg",
+      link: "/accessibility/bus-guide",
+      modes: [3]
+    },
+    %{
+      title: ~t(Commuter Rail Access Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2018-07/cr-level-boarding-platform.jpg",
+      link: "/accessibility/commuter-rail-guide",
+      modes: [2]
+    },
+    %{
+      title: ~t(Ferry Access Guide),
+      image:
+        "/sites/default/files/styles/max_2600x2600/public/media/2018-07/mbta-ferry-boarding-with-wmd.jpg",
+      link: "/accessibility/ferry-guide",
+      modes: [4]
+    }
+  ]
+
   alias DotcomWeb.PartialView.{HeaderTab, HeaderTabs}
 
   import DotcomWeb.Components.ScheduleHeaderComponents, only: [route_header: 1]
@@ -41,7 +100,8 @@ defmodule DotcomWeb.LineDiagramLive do
      |> assign(:route_id, route_id)
      |> assign(:route, route)
      |> assign(:tab, "new_line")
-     |> assign(:tab_params, tab_params)}
+     |> assign(:tab_params, tab_params)
+     |> assign(:guides, @guides)}
   end
 
   def make_link(assigns, page, add_params? \\ false) do
@@ -122,7 +182,7 @@ defmodule DotcomWeb.LineDiagramLive do
           🚧 Under Construction 🚧
         </marquee>
       </div>
-      <div class="col-md-5">
+      <div class="col-md-5 gap-[32px] flex flex-col">
         <marquee
           style="font-size:1cm;filter: drop-shadow(2px 4px 6px orange);"
           scrollamount="16"
@@ -130,8 +190,22 @@ defmodule DotcomWeb.LineDiagramLive do
         >
           ⚠️ Watch Your Step ⚠️
         </marquee>
+        <.guides route={@route} guides={@guides} />
       </div>
     </div>
+    """
+  end
+
+  def guides(assigns) do
+    ~H"""
+    <a
+      :for={guide <- @guides |> Enum.filter(fn guide -> assigns.route.type in guide.modes end)}
+      href={guide.link}
+      class="text-black text-lg font-bold"
+    >
+      <img src={guide.image} class="w-[380px] rounded-sm mb-[8px]" />
+      <div>{guide.title}</div>
+    </a>
     """
   end
 end

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -40,7 +40,7 @@ defmodule DotcomWeb.LineDiagramLive do
     %{
       title: ~t(Subway Access Guide),
       image:
-        "sites/default/files/styles/max_2600x2600/public/Accessibility/govt-center-press-access-button.jpg",
+        "/sites/default/files/styles/max_2600x2600/public/Accessibility/govt-center-press-access-button.jpg",
       link: "/accessibility/subway-guide",
       modes: [0, 1]
     },

--- a/lib/dotcom_web/live/line_diagram_live.ex
+++ b/lib/dotcom_web/live/line_diagram_live.ex
@@ -93,6 +93,9 @@ defmodule DotcomWeb.LineDiagramLive do
 
     tab_params = %{"schedule_direction[direction_id]": direction_id}
 
+    guides_for_this_route =
+      @guides |> Enum.filter(fn guide -> route.type in guide.modes end)
+
     {:ok,
      socket
      |> assign(:direction_id, direction_id)
@@ -101,7 +104,7 @@ defmodule DotcomWeb.LineDiagramLive do
      |> assign(:route, route)
      |> assign(:tab, "new_line")
      |> assign(:tab_params, tab_params)
-     |> assign(:guides, @guides)}
+     |> assign(:guides, guides_for_this_route)}
   end
 
   def make_link(assigns, page, add_params? \\ false) do
@@ -199,11 +202,11 @@ defmodule DotcomWeb.LineDiagramLive do
   def guides(assigns) do
     ~H"""
     <a
-      :for={guide <- @guides |> Enum.filter(fn guide -> assigns.route.type in guide.modes end)}
+      :for={guide <- @guides}
       href={guide.link}
       class="text-black text-lg font-bold"
     >
-      <img src={guide.image} class="w-[380px] rounded-sm mb-[8px]" />
+      <img src={guide.image} class="w-[380px] rounded-sm mb-[8px]" alt="" />
       <div>{guide.title}</div>
     </a>
     """

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -701,6 +701,7 @@ msgstr ""
 msgid "Bus %{trip_name}"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4000,6 +4001,7 @@ msgstr ""
 msgid "Subway"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5401,4 +5403,34 @@ msgstr ""
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/en/LC_MESSAGES/dotcom.po
@@ -701,6 +701,7 @@ msgstr ""
 msgid "Bus %{trip_name}"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4000,6 +4001,7 @@ msgstr ""
 msgid "Subway"
 msgstr ""
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5401,4 +5403,34 @@ msgstr ""
 #: lib/dotcom_web/templates/schedule/_timetable.html.heex
 #, elixir-autogen, elixir-format
 msgid "Morning"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -703,6 +703,7 @@ msgstr "autobús"
 msgid "Bus %{trip_name}"
 msgstr "Colectivo %{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4017,6 +4018,7 @@ msgstr "Presentar una solicitud de acceso a registros públicos a la MBTA"
 msgid "Subway"
 msgstr "Subterráneo"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5425,3 +5427,33 @@ msgstr "Noche"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "Buenos días"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/fr-FR/LC_MESSAGES/dotcom.po
@@ -703,6 +703,7 @@ msgstr "bus"
 msgid "Bus %{trip_name}"
 msgstr "bus %{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4018,6 +4019,7 @@ msgstr "Soumettez une demande de documents publics auprès de la MBTA"
 msgid "Subway"
 msgstr "métro"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5425,3 +5427,33 @@ msgstr "Soirée"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "Bonjour"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/ht/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/ht/LC_MESSAGES/dotcom.po
@@ -703,6 +703,7 @@ msgstr "bis"
 msgid "Bus %{trip_name}"
 msgstr "bis %{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4007,6 +4008,7 @@ msgstr "Soumèt yon demann pou dosye piblik bay MBTA a"
 msgid "Subway"
 msgstr "subway"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5412,3 +5414,33 @@ msgstr "Aswè"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "Maten"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/dotcom.po
@@ -703,6 +703,7 @@ msgstr "ônibus"
 msgid "Bus %{trip_name}"
 msgstr "ônibus %{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4014,6 +4015,7 @@ msgstr "Envie um pedido de acesso a registros públicos para o MBTA."
 msgid "Subway"
 msgstr "metrô"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5421,3 +5423,33 @@ msgstr "Noite"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "Manhã"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/vi/LC_MESSAGES/dotcom.po
@@ -697,6 +697,7 @@ msgstr "xe buýt"
 msgid "Bus %{trip_name}"
 msgstr "xe buýt %{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -4009,6 +4010,7 @@ msgstr "Gửi yêu cầu cung cấp hồ sơ công khai đến MBTA."
 msgid "Subway"
 msgstr "tàu điện ngầm"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5416,3 +5418,33 @@ msgstr "Buổi tối"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "Buổi sáng"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-CN/LC_MESSAGES/dotcom.po
@@ -695,6 +695,7 @@ msgstr "巴士"
 msgid "Bus %{trip_name}"
 msgstr "巴士%{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -3994,6 +3995,7 @@ msgstr "向MBTA提交公共记录申请。"
 msgid "Subway"
 msgstr "地铁"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5396,3 +5398,33 @@ msgstr "晚上"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "早晨"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""

--- a/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/zh-TW/LC_MESSAGES/dotcom.po
@@ -695,6 +695,7 @@ msgstr "巴士"
 msgid "Bus %{trip_name}"
 msgstr "巴士%{trip_name}"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Bus Beginner's Guide"
@@ -3994,6 +3995,7 @@ msgstr "向MBTA提交公共記錄申請。"
 msgid "Subway"
 msgstr "地鐵"
 
+#: lib/dotcom_web/live/line_diagram_live.ex
 #: lib/dotcom_web/templates/page/_user_guides.html.heex
 #, elixir-autogen, elixir-format
 msgid "Subway Beginner's Guide"
@@ -5396,3 +5398,33 @@ msgstr "晚上"
 #, elixir-autogen, elixir-format
 msgid "Morning"
 msgstr "早晨"
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Bus Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Commuter Rail Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Access Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Ferry Beginner's Guide"
+msgstr ""
+
+#: lib/dotcom_web/live/line_diagram_live.ex
+#, elixir-autogen, elixir-format
+msgid "Subway Access Guide"
+msgstr ""


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [💈 Guide links](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216638931645036?focus=true)

## Implementation

Created a look-up-table of access and beginner guides.  
Created a component that renders the correct guides given a route.

We could update this in the future with vanity URLs for these images, but considering the URLs imply they haven't changed since 2018 I don't think it's a pressing matter.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

<!--
> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots

### Commuter Rail Guides
<img width="787" height="697" alt="Screenshot 2026-09-09 at 2 31 56 PM" src="https://github.com/user-attachments/assets/1c95d0a5-637b-47be-bc14-58b68575c632" />

### Subway Guides
<img width="788" height="690" alt="Screenshot 2026-09-09 at 2 32 44 PM" src="https://github.com/user-attachments/assets/405152c5-959b-4a9c-a843-81d3c9f5a2b6" />

### Bus Guides
<img width="789" height="679" alt="Screenshot 2026-09-09 at 2 32 56 PM" src="https://github.com/user-attachments/assets/97206401-1ef7-45d1-9216-7b520a3f6237" />

### Silver Line Guides == Bus Guides
<img width="792" height="691" alt="Screenshot 2026-09-09 at 2 34 53 PM" src="https://github.com/user-attachments/assets/21487a5d-5592-4a25-9065-58df59301630" />

### Ferry Guides
<img width="791" height="724" alt="Screenshot 2026-09-09 at 2 33 16 PM" src="https://github.com/user-attachments/assets/babab63b-2ca2-4592-b33c-2ae1a34b9ad3" />



## How to test

[Silver Line 1](http://localhost:4001/schedules/751/line_new)
[71 Bus](http://localhost:4001/schedules/71/line_new)
[Red Line](http://localhost:4001/schedules/Red/line_new)
[Fall River/New Bedford CR](http://localhost:4001/schedules/CR-NewBedford/line_new)
[Loop Ferry](http://localhost:4001/schedules/Boat-F10/line_new)

Confirm that the correct guides show up, have the correct images, and link to the correct pages.






<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
