### PR TITLE
fix: Weird non-deterministic border on visited link grid items in Firefox

### DIFF
--- a/lib/dotcom_web/templates/mode/_grid_button.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.heex
@@ -1,5 +1,5 @@
 <%= link [to: @link_path, class: "c-grid-button c-grid-button--#{grid_button_class_modifier(@route)}", id: grid_button_id(assigns)] do %>
-  <div class="c-grid-button__content">
+  <div class="c-grid-button__content border-gray-lightest">
     <%= if show_icon?(@route, @show_icon?) do %>
       <span class="c-grid-button__icon" aria-hidden="true">
         {line_icon(@route, :default)}

--- a/lib/dotcom_web/templates/mode/_grid_button_condensed.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button_condensed.html.heex
@@ -1,5 +1,5 @@
 <%= link [to: @link_path, class: "c-grid-button__condensed", id: grid_button_id(assigns)] do %>
-  <div class="c-grid-button__content">
+  <div class="c-grid-button__content border-gray-lightest">
     <span class="c-grid-button__icon c-grid-button__icon--condensed" aria-hidden="true">
       {line_icon(@route, :default)}
       <span class="c-grid-button__alert--condensed">


### PR DESCRIPTION
## Scope

No ticket. [Flagged in Slack](https://mbta.slack.com/archives/C076FBBC21K/p1789070726675369).

## Implementation

It seems like Firefox's latest update changed how it handles ambiguity in CSS precedence, so grid items that correspond to visited links seem to randomly get a dark blue or light gray border.

`border-gray-lightest` gets higher precedence than anything else. Hooray.

<!--
> [!NOTE]
> :robot: If you used AI to write some or all of this PR, please
> uncomment this block and use it to explain how AI was used.
>
> Remember that you are responsible for all work that you PR, whether
> it's hand-written or AI-generated.
-->

## Screenshots

The bug, including showing how hovering and unhovering can non-deterministically change the border color.

https://github.com/user-attachments/assets/db8a9edf-4e95-48f2-9654-bbf48ad5f8b9

Side-by-side this-branch versus prod.
<img width="1464" height="729" alt="Screenshot 2026-09-10 at 5 21 09 PM" src="https://github.com/user-attachments/assets/5594041c-4cdd-4e6a-b2f3-2559aa614c63" />

## How to test

Visit the [schedules](http://localhost:4001/schedules) and [bus schedules](http://localhost:4001/schedules/bus) pages in Firefox (make sure you're on the latest version, 155.0.1). If you look at those pages in prod, you'll see that _some_ (not all) of the links corresponding to pages you've visited have that weird outline.