### PR TITLE
dev(DotcomWeb.Router): show Phoenix's debugger

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -13,26 +13,30 @@ defmodule DotcomWeb.Router do
   """
 
   use DotcomWeb, :router
-  use Plug.ErrorHandler
 
-  alias DotcomWeb.ControllerHelpers
+  if Mix.env() == :dev do
+    use Plug.Debugger, otp_app: :dotcom
+  else
+    use Plug.ErrorHandler
 
-  @impl Plug.ErrorHandler
+    alias DotcomWeb.ControllerHelpers
 
-  @doc """
-  A custom error handling function that renders the appropriate
-  error page.
+    @impl Plug.ErrorHandler
+    @doc """
+    A custom error handling function that renders the appropriate
+    error page.
 
-  For most (unexpected) errors, we render a 500 page. When we see a
-  `DotcomWeb.NotFoundError`, we render the 404 page instead.
-  """
-  def handle_errors(conn, %{reason: reason}) do
-    case reason do
-      %{plug_status: 404} ->
-        ControllerHelpers.render_404(conn)
+    For most (unexpected) errors, we render a 500 page. When we see a
+    `DotcomWeb.NotFoundError`, we render the 404 page instead.
+    """
+    def handle_errors(conn, %{reason: reason}) do
+      case reason do
+        %{plug_status: 404} ->
+          ControllerHelpers.render_404(conn)
 
-      _ ->
-        ControllerHelpers.render_500(conn)
+        _ ->
+          ControllerHelpers.render_500(conn)
+      end
     end
   end
 


### PR DESCRIPTION
Phoenix ships with a default debugger view for local development, which we enabled by setting `debug_errors: true` in the Endpoint configuration.

We also have custom error handling set up in `DotcomWeb.Router`, using the `Plug.ErrorHandler` behavior. This is what turns many errors into 500 responses.

However, it turns out that overrides the debugger view. From its docs:

> Note: If this module is used with [Plug.ErrorHandler](https://plug.hexdocs.pm/Plug.ErrorHandler.html), only one of them will effectively handle errors. For this reason, it is recommended that [Plug.Debugger](https://plug.hexdocs.pm/Plug.Debugger.html) is used before [Plug.ErrorHandler](https://plug.hexdocs.pm/Plug.ErrorHandler.html) and only in particular environments, like :dev.

This PR changes our setup a bit to use the debugger on dev, and the current setup elsewhere.

## Screenshots

<img width="1187" height="806" alt="image" src="https://github.com/user-attachments/assets/ff76d4ec-7b5b-4b70-9248-3e0e37973a96" />

## How to test

Feel free to `raise` whatever errors you want in Elixir to try it out on your own pages locally
