### PR TITLE
fix(CustomerSupportForm): move privacy checkbox

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -73,6 +73,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         edge.fullstory.com
         https://www.google.com/recaptcha/api.js
         https://www.google.com/recaptcha/api/fallback
+        https://www.gstatic.com
         https://www.googletagmanager.com/gtm.js
         snap.licdn.com
         translate.google.com/translate_a/element.js

--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -130,20 +130,6 @@
         <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
         <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-input support-form-input--small form-control", "aria-describedby": "phoneHelp", autocomplete: "tel", id: "phone" %>
       </div>
-      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %> u-mb-0 u-mt-1">
-        <%= support_error_tag @errors, "privacy" %>
-        <%= DotcomWeb.PartialView.render("_checkbox.html", %{
-          form: f,
-          field: :privacy,
-          id: "privacy",
-          required: "required",
-          label_text: ["I have read and agree to the ", link("Privacy Policy", target: "_blank", to: cms_static_page_path(@conn, "/policies/privacy-policy"))]
-        })
-        %>
-        <div class="error-indicator hidden" id="privacy-error-indicator">
-          <span aria-hidden="true" class="fa fa-exclamation-circle error-icon"></span> Required
-        </div>
-      </div>
       <div class="form-group">
         <%= DotcomWeb.PartialView.render("_checkbox.html", %{
           form: f,
@@ -155,6 +141,20 @@
         %>
       </div>
     </div> <!-- End contact info section -->
+    <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %> u-mb-0 u-mt-1">
+      <%= support_error_tag @errors, "privacy" %>
+      <%= DotcomWeb.PartialView.render("_checkbox.html", %{
+        form: f,
+        field: :privacy,
+        id: "privacy",
+        required: "required",
+        label_text: ["I have read and agree to the ", link("Privacy Policy", target: "_blank", to: cms_static_page_path(@conn, "/policies/privacy-policy"))]
+      })
+      %>
+      <div class="error-indicator hidden" id="privacy-error-indicator">
+        <span aria-hidden="true" class="fa fa-exclamation-circle error-icon"></span> Required
+      </div>
+    </div>
     <div class="form-group <%= class_for_error("recaptcha", @errors, "has-danger", "has-success") %>">
       <%= support_error_tag @errors, "recaptcha" %>
       <%= raw Recaptcha.Template.display(noscript: true) %>


### PR DESCRIPTION
- Before, it was impossible to submit without contact info, as the required privacy checkbox was hidden in the collapsed contact info form
- After, can now complete the form
- I also have another commit which adds another Google URL to the Content Security Policy because when I was working on this yesterday the recaptcha widget was blocked. But I can't reproduce that now 😵 But I figure leaving that change in here won't hurt

## Screenshots

| Before | After |
|--------|--------|
| <img width="516" height="233" alt="image" src="https://github.com/user-attachments/assets/44e0913f-4871-4b62-b3e1-635e089fd69a" /> | <img width="527" height="385" alt="image" src="https://github.com/user-attachments/assets/af30b7a6-7425-4d84-8aaf-923006dc798b" /> | 